### PR TITLE
fix(check): gracefully skip workflows without pinned dependencies

### DIFF
--- a/root.go
+++ b/root.go
@@ -15,6 +15,8 @@ import (
 )
 
 var errSilent = errors.New("silent error")
+var errNoDeps = errors.New("no dependencies: section found")
+var errNoActions = errors.New("no action references found")
 var newResolver = resolver.New
 
 type pinOptions struct {
@@ -360,6 +362,19 @@ func runCheck(opts *checkOptions) error {
 		}
 		result, err := validateOneFile(workflowPath, r)
 		if err != nil {
+			if errors.Is(err, errNoActions) {
+				// Workflow has only run: steps, no actions to pin — skip silently.
+				continue
+			}
+			if errors.Is(err, errNoDeps) {
+				if opts.JSONFields != "" {
+					aggregate.Warnings = append(aggregate.Warnings,
+						fmt.Sprintf("%s: not yet pinned (run `gh actions-pin --write` first)", workflowPath))
+				} else {
+					fmt.Fprintf(os.Stderr, "skipping %s: not yet pinned (run `gh actions-pin --write` first)\n", workflowPath)
+				}
+				continue
+			}
 			aggregate.Valid = false
 			aggregate.Errors = append(aggregate.Errors, validationError{
 				Type:       "ERROR",
@@ -389,6 +404,18 @@ func runCheck(opts *checkOptions) error {
 			fmt.Fprintf(os.Stderr, "All %d workflow(s) valid\n", len(opts.WorkflowPaths))
 		}
 		return nil
+	}
+
+	// Print errors and warnings in human-readable mode.
+	// Skip ERROR entries — those were already printed inline when validateOneFile returned an error.
+	for _, e := range aggregate.Errors {
+		if e.Type == "ERROR" {
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "error: [%s] %s: %s\n", e.Type, e.Dependency, e.Details)
+	}
+	for _, w := range aggregate.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
 
 	return errSilent
@@ -684,7 +711,13 @@ func validateOneFile(workflowPath string, r *resolver.Resolver) (*validationResu
 		return nil, err
 	}
 	if len(existingDeps) == 0 {
-		return nil, fmt.Errorf("no dependencies: section found -- run `gh actions-pin --write` first")
+		// Check if the workflow even has action references.
+		// Run-only workflows (no uses: directives) need no pinning.
+		refs, _, _ := wf.ExtractActionRefs()
+		if len(refs) == 0 {
+			return nil, errNoActions
+		}
+		return nil, errNoDeps
 	}
 
 	refs, _, parseWarnings := wf.ExtractActionRefs()


### PR DESCRIPTION
## What

Gracefully handle workflow files that have no pinned dependencies during `check`, instead of spamming `[ERROR]` for each one.

## Why

When running `gh actions-pin check` in a repo with many workflows, files without a `dependencies:` section produce noisy error output:
```
error: [ERROR] .github/workflows/vendor-firmware.yml: no dependencies: section found -- run `gh actions-pin --write` first
error: [ERROR] .github/workflows/vendor-xcode-release.yml: no dependencies: section found -- run `gh actions-pin --write` first
```

These aren't errors — they're either not-yet-pinned files (actionable) or run-only workflows (nothing to do). Treating them as errors fails the check and obscures real validation failures.

## How

Three-tier handling based on workflow content:

| Scenario | Behavior |
|----------|----------|
| No `uses:` directives (run-only) | Skip silently — nothing to pin |
| Has `uses:` but no `dependencies:` section | Skip with guidance: *"not yet pinned (run \`gh actions-pin --write\` first)"* |
| Has `dependencies:` section | Validate normally |

Also fixes duplicate error printing: `validateOneFile` errors were printed inline AND again in the aggregate error loop. Now the aggregate loop skips `ERROR`-type entries that were already printed.

Skipped files surface as warnings in JSON output so CI consumers can see what was skipped without failing the check.

## Risk

| Aspect | Assessment |
|--------|------------|
| Blast radius | `--check` behavior change: previously-failing repos may now pass |
| Reversibility | 🟢 Easy revert |
| Rollback plan | Revert commit |
| Dependencies | None |

## Testing

- All existing unit and command tests pass
- Validated manually that run-only workflows skip silently