### PR TITLE
fix: point release build at cmd/gh-actions-pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           generate_attestations: true
           go_version_file: go.mod
+          go_build_options: ./cmd/gh-actions-pin
 
 # Automatically generated and managed by: `gh actions-pin --write <workflow-path>`
 dependencies:


### PR DESCRIPTION
The `gh-extension-precompile` action builds from repo root by default, but `main.go` was moved to `cmd/gh-actions-pin/` during the refactor.

Adds `go_build_options: ./cmd/gh-actions-pin` to point the build at the correct package.

Fixes the release failure: https://github.com/github/gh-actions-pin/actions/runs/25118224137/job/73611284063

```
no Go files in /home/runner/work/gh-actions-pin/gh-actions-pin
```