### PR TITLE
feat: group transitive deps by parent composite action

### DIFF
--- a/cmd/gh-actions-pin/upgrade.go
+++ b/cmd/gh-actions-pin/upgrade.go
@@ -259,7 +259,22 @@ func upgradeOneFile(f *pinFactory, opts *upgradeOptions, workflowPath string, r 
 		return nil, fmt.Errorf("%d action ref(s) have SHA-like names that point to different commits", len(mismatches))
 	}
 
+	// Snapshot dep keys before PreserveRefs so we can rekey the parent map.
+	preKeys := make([]string, len(deps))
+	for i, d := range deps {
+		preKeys[i] = d.Key()
+	}
+
 	deps = lockfile.PreserveRefs(existingDeps, deps)
+
+	// Rekey parent map for any refs that PreserveRefs restored.
+	parentRewrites := make(map[string]string)
+	for i, d := range deps {
+		if newKey := d.Key(); newKey != preKeys[i] {
+			parentRewrites[preKeys[i]] = newKey
+		}
+	}
+	r.RekeyParentMap(parentRewrites)
 
 	diff := lockfile.DiffDeps(existingDeps, deps)
 	var changes []jsonUpgradeChange

--- a/cmd/gh-actions-pin/upgrade.go
+++ b/cmd/gh-actions-pin/upgrade.go
@@ -285,7 +285,7 @@ func upgradeOneFile(f *pinFactory, opts *upgradeOptions, workflowPath string, r 
 		return changes, nil
 	}
 
-	written, err := upgradedWF.WriteDependencies(deps)
+	written, err := upgradedWF.WriteDependencies(deps, r.ParentMap())
 	if err != nil {
 		return nil, fmt.Errorf("writing dependencies: %w", err)
 	}

--- a/demo/try-it.sh
+++ b/demo/try-it.sh
@@ -21,14 +21,16 @@ comment() { echo -e "${DIM}# $1${RESET_COLOR}"; }
 run() { echo -e "${GREEN}\$ $*${RESET_COLOR}"; "$@"; echo; }
 show_workflow_summary() {
   awk '
-    /uses:/ || /^# Automatically generated/ || /^dependencies:/ || /^  # / || /^  - / {
+    /^# Automatically generated/ { in_deps=1 }
+    /uses:/ || (in_deps && (/^# / || /^dependencies:/ || /^  # / || /^  - / || /^$/)) {
       print
     }
   ' "$1"
 }
 show_lockfile() {
   awk '
-    /^# Automatically generated/ || /^dependencies:/ || /^  # / || /^  - / {
+    /^# Automatically generated/ { in_deps=1 }
+    in_deps && (/^# / || /^dependencies:/ || /^  # / || /^  - / || /^$/) {
       print
     }
   ' "$1"
@@ -75,11 +77,11 @@ usage() {
 scenario_check_autofix() {
   banner "Auto-fix (non-interactive)"
   bash "$RESET"
-  comment "Unpinned workflow — 4 actions using mutable tags, including a nested composite"
+  comment "Unpinned workflow — 4 actions including a nested composite with transitive deps"
   run grep uses: demo/workflows-check/ci.yml
   comment "Pin all actions (non-interactive auto-fix)"
   run gh actions-pin check --no-interactive demo/workflows-check/ci.yml
-  comment "Lockfile written — check the result"
+  comment "Lockfile groups transitive deps by parent composite action"
   run show_lockfile demo/workflows-check/ci.yml
   comment "Subsequent check passes"
   run gh actions-pin check demo/workflows-check/ci.yml

--- a/demo/vhs/check-autofix.tape
+++ b/demo/vhs/check-autofix.tape
@@ -10,7 +10,7 @@ Set PlaybackSpeed 1.5
 Set TypingSpeed 50ms
 Set Theme "GitHub Dark"
 
-Type "echo '# Unpinned workflow — 4 actions using mutable tags, including a nested composite'"
+Type "echo '# Unpinned workflow — 4 actions including a nested composite with transitive deps'"
 Enter
 Sleep 1s
 
@@ -26,7 +26,7 @@ Type "gh actions-pin check --no-interactive demo/workflows-check/ci.yml"
 Enter
 Sleep 12s
 
-Type "echo '# Lockfile written — check the result'"
+Type "echo '# Lockfile groups transitive deps by parent composite action'"
 Enter
 Sleep 1s
 

--- a/demo/vhs/check-autofix.tape
+++ b/demo/vhs/check-autofix.tape
@@ -30,6 +30,6 @@ Type "echo '# Lockfile groups transitive deps by parent composite action'"
 Enter
 Sleep 1s
 
-Type "awk '/^# Automatically generated/ || /^dependencies:/ || /^  # / || /^  - / { print }' demo/workflows-check/ci.yml"
+Type "awk '/^# Automatically generated/{d=1} d&&(/^#/||/^dep/||/^  /||/^$/)' demo/workflows-check/ci.yml"
 Enter
 Sleep 3s

--- a/demo/workflows-check/ci.yml
+++ b/demo/workflows-check/ci.yml
@@ -8,8 +8,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.3.1
-      - uses: actions/setup-go@v5.6.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go test ./...
@@ -17,20 +17,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.3.1
+      - uses: actions/checkout@v4
       - uses: nodeselector/actions-test-fixtures/nested-composite@updated
-      - uses: golangci/golangci-lint-action@v6.5.2
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-
-# Automatically generated and managed by gh-actions-pin
-dependencies:
-  - github.com/actions/checkout@v4.3.1:sha1-34e114876b0b11c390a56381ad16ebd13914f8d5
-  - github.com/actions/setup-go@v5.6.0:sha1-40f1582b2485089dde7abd97c1529aa768e1baff
-  - github.com/golangci/golangci-lint-action@v6.5.2:sha1-55c2c1448f86e01eaae002a5a3a9624417608d84
-  - github.com/nodeselector/actions-test-fixtures/nested-composite@updated:sha1-ea53476fdc172d8552df5af9658a45a367e4f41d
-
-  # Transitive dependencies
-  - github.com/nodeselector/actions-test-fixtures-b/simple-echo@main:sha1-92b7b0058bc223c6e9dd4e19ef9247c934ba7637
-  - github.com/nodeselector/actions-test-fixtures/simple-composite@main:sha1-fbe04216bcc00ebe76c49276d4b8ee066a21ef22
-  - github.com/nodeselector/actions-test-fixtures/simple-node@main:sha1-fbe04216bcc00ebe76c49276d4b8ee066a21ef22

--- a/internal/doctor/apply.go
+++ b/internal/doctor/apply.go
@@ -79,7 +79,7 @@ func (rem *Remediator) applyPin(wr WorkflowReport) error {
 		}
 	}
 
-	written, err := wf.WriteDependencies(deps)
+	written, err := wf.WriteDependencies(deps, rem.resolver.ParentMap())
 	if err != nil {
 		return fmt.Errorf("writing dependencies: %w", err)
 	}
@@ -128,7 +128,7 @@ func (rem *Remediator) applySHAToTag(wr WorkflowReport, dep *lockfile.Dependency
 	if err != nil {
 		return fmt.Errorf("re-resolving after ref change: %w", err)
 	}
-	written, err := wf2.WriteDependencies(deps)
+	written, err := wf2.WriteDependencies(deps, rem.resolver.ParentMap())
 	if err != nil {
 		return fmt.Errorf("writing dependencies: %w", err)
 	}
@@ -154,7 +154,7 @@ func (rem *Remediator) applyReResolve(wr WorkflowReport, dep *lockfile.Dependenc
 		return fmt.Errorf("resolving actions: %w", err)
 	}
 
-	written, err := wf.WriteDependencies(deps)
+	written, err := wf.WriteDependencies(deps, rem.resolver.ParentMap())
 	if err != nil {
 		return fmt.Errorf("writing dependencies: %w", err)
 	}

--- a/internal/doctor/apply.go
+++ b/internal/doctor/apply.go
@@ -37,6 +37,7 @@ func (rem *Remediator) applyPin(wr WorkflowReport) error {
 	// Skip narrowing for same-owner internal repos — broad tags are fine
 	// within your own org's private actions. Public repos always narrow.
 	rewrites := make(map[string]string)
+	parentRewrites := make(map[string]string)
 	for i := range deps {
 		dep := &deps[i]
 		if !IsMutableVersionTag(dep.Ref) {
@@ -59,9 +60,13 @@ func (rem *Remediator) applyPin(wr WorkflowReport) error {
 		oldUses := dep.NWO + "@" + dep.Ref
 		newUses := dep.NWO + "@" + patchTag
 		rewrites[oldUses] = newUses
+		parentRewrites[dep.Key()] = dep.NWO + "@" + patchTag
 		rem.output.Detail("  %s → %s (pinning to patch version)", dep.Ref, patchTag)
 		dep.Ref = patchTag
 	}
+
+	// Update parent map keys to reflect narrowed refs.
+	rem.resolver.RekeyParentMap(parentRewrites)
 
 	// If we have rewrites, update the uses: lines in the workflow first.
 	if len(rewrites) > 0 {

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -228,7 +228,10 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 			isTransitive := !directNWOs[rr.Owner+"/"+rr.Repo]
 			parentNWO := ""
 			if isTransitive {
-				parentNWO = r.ParentMap()[rr.Owner+"/"+rr.Repo]
+				depKey := rr.Owner + "/" + rr.Repo + "@" + rr.Ref
+				if parents := r.ParentMap()[depKey]; len(parents) > 0 {
+					parentNWO = parents[0]
+				}
 			}
 			wr.Findings = append(wr.Findings, Finding{
 				WorkflowPath: path,

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -228,8 +228,7 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 			isTransitive := !directNWOs[rr.Owner+"/"+rr.Repo]
 			parentNWO := ""
 			if isTransitive {
-				depKey := rr.Owner + "/" + rr.Repo + "@" + rr.Ref
-				if parents := r.ParentMap()[depKey]; len(parents) > 0 {
+				if parents := r.ParentMap()[rr.DepKey]; len(parents) > 0 {
 					parentNWO = parents[0]
 				}
 			}

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -395,9 +395,11 @@ func (f *File) ExtractActionRefs() ([]ActionRef, []string, []string) {
 }
 
 // ReadDependencies extracts the current dependencies: section from the workflow.
+// Exact duplicate entries (same key and SHA) are silently deduped.
+// Conflicting duplicates (same key, different SHA) produce an error.
 func (f *File) ReadDependencies() ([]Dependency, error) {
 	var deps []Dependency
-	seen := make(map[string]bool)
+	seen := make(map[string]Dependency)
 
 	doc := docNode(&f.root)
 	if doc == nil {
@@ -420,10 +422,14 @@ func (f *File) ReadDependencies() ([]Dependency, error) {
 			if err != nil {
 				return nil, fmt.Errorf("parsing dependency entry: %w", err)
 			}
-			if seen[dep.Key()] {
-				return nil, fmt.Errorf("duplicate dependency entry for %s", dep.Key())
+			if prev, exists := seen[dep.Key()]; exists {
+				if !strings.EqualFold(prev.SHA, dep.SHA) || prev.HashAlgo != dep.HashAlgo {
+					return nil, fmt.Errorf("conflicting dependency entries for %s", dep.Key())
+				}
+				// Exact duplicate — skip silently.
+				continue
 			}
-			seen[dep.Key()] = true
+			seen[dep.Key()] = dep
 			deps = append(deps, dep)
 		}
 		return deps, nil
@@ -433,7 +439,10 @@ func (f *File) ReadDependencies() ([]Dependency, error) {
 }
 
 // WriteDependencies returns the workflow content with an updated dependencies: section.
-func (f *File) WriteDependencies(deps []Dependency) ([]byte, error) {
+// When parentMap is non-nil, transitive dependencies are grouped by the parent
+// composite action that brings them in — the same dep may appear under multiple
+// parents. The parser silently deduplicates exact duplicate entries.
+func (f *File) WriteDependencies(deps []Dependency, parentMap map[string][]string) ([]byte, error) {
 	content := string(f.Content)
 	directRefs, _, _ := f.ExtractActionRefs()
 	directKeys := make(map[string]bool, len(directRefs))
@@ -442,36 +451,37 @@ func (f *File) WriteDependencies(deps []Dependency) ([]byte, error) {
 	}
 
 	directDepsByKey := make(map[string]Dependency)
-	transitiveDepsByKey := make(map[string]Dependency)
+	var transitiveDeps []Dependency
 	for _, dep := range deps {
 		key := dep.Key()
 		if directKeys[key] {
 			directDepsByKey[key] = dep
-			delete(transitiveDepsByKey, key)
 			continue
 		}
 		if _, exists := directDepsByKey[key]; exists {
 			continue
 		}
-		if _, exists := transitiveDepsByKey[key]; !exists {
-			transitiveDepsByKey[key] = dep
+		transitiveDeps = append(transitiveDeps, dep)
+	}
+
+	// Dedup transitive deps list.
+	seenTransitive := make(map[string]bool)
+	var dedupedTransitive []Dependency
+	for _, dep := range transitiveDeps {
+		if !seenTransitive[dep.Key()] {
+			seenTransitive[dep.Key()] = true
+			dedupedTransitive = append(dedupedTransitive, dep)
 		}
 	}
+	transitiveDeps = dedupedTransitive
 
 	directDeps := make([]Dependency, 0, len(directDepsByKey))
 	for _, dep := range directDepsByKey {
 		directDeps = append(directDeps, dep)
 	}
-	transitiveDeps := make([]Dependency, 0, len(transitiveDepsByKey))
-	for _, dep := range transitiveDepsByKey {
-		transitiveDeps = append(transitiveDeps, dep)
-	}
 
 	sort.Slice(directDeps, func(i, j int) bool {
 		return directDeps[i].String() < directDeps[j].String()
-	})
-	sort.Slice(transitiveDeps, func(i, j int) bool {
-		return transitiveDeps[i].String() < transitiveDeps[j].String()
 	})
 
 	var sb strings.Builder
@@ -480,14 +490,9 @@ func (f *File) WriteDependencies(deps []Dependency) ([]byte, error) {
 	for _, dep := range directDeps {
 		sb.WriteString("  - " + dep.String() + "\n")
 	}
+
 	if len(transitiveDeps) > 0 {
-		if len(directDeps) > 0 {
-			sb.WriteString("\n")
-		}
-		sb.WriteString("  # Transitive dependencies\n")
-		for _, dep := range transitiveDeps {
-			sb.WriteString("  - " + dep.String() + "\n")
-		}
+		writeTransitiveDeps(&sb, transitiveDeps, directDeps, parentMap)
 	}
 
 	content = removeDependenciesSection(content)
@@ -495,6 +500,81 @@ func (f *File) WriteDependencies(deps []Dependency) ([]byte, error) {
 	content += sb.String()
 
 	return []byte(content), nil
+}
+
+// writeTransitiveDeps writes the transitive dependencies section, grouped by
+// parent composite action when parentMap is available.
+func writeTransitiveDeps(sb *strings.Builder, transitiveDeps []Dependency, directDeps []Dependency, parentMap map[string][]string) {
+	if len(directDeps) > 0 {
+		sb.WriteString("\n")
+	}
+
+	// If no parent map or all transitive deps are unmapped, use flat format.
+	if len(parentMap) == 0 {
+		sb.WriteString("  # Transitive dependencies\n")
+		sort.Slice(transitiveDeps, func(i, j int) bool {
+			return transitiveDeps[i].String() < transitiveDeps[j].String()
+		})
+		for _, dep := range transitiveDeps {
+			sb.WriteString("  - " + dep.String() + "\n")
+		}
+		return
+	}
+
+	// Group transitive deps by parent. A dep can appear under multiple parents.
+	type parentGroup struct {
+		parentKey string
+		deps      []Dependency
+	}
+	groupMap := make(map[string]*parentGroup)
+	var groupOrder []string
+	var orphans []Dependency
+
+	for _, dep := range transitiveDeps {
+		parents, ok := parentMap[dep.Key()]
+		if !ok || len(parents) == 0 {
+			orphans = append(orphans, dep)
+			continue
+		}
+		for _, pKey := range parents {
+			g, exists := groupMap[pKey]
+			if !exists {
+				g = &parentGroup{parentKey: pKey}
+				groupMap[pKey] = g
+				groupOrder = append(groupOrder, pKey)
+			}
+			g.deps = append(g.deps, dep)
+		}
+	}
+
+	sort.Strings(groupOrder)
+
+	for i, pKey := range groupOrder {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		g := groupMap[pKey]
+		sort.Slice(g.deps, func(a, b int) bool {
+			return g.deps[a].String() < g.deps[b].String()
+		})
+		sb.WriteString("  # Transitive dependencies (via " + pKey + ")\n")
+		for _, dep := range g.deps {
+			sb.WriteString("  - " + dep.String() + "\n")
+		}
+	}
+
+	if len(orphans) > 0 {
+		if len(groupOrder) > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("  # Transitive dependencies\n")
+		sort.Slice(orphans, func(i, j int) bool {
+			return orphans[i].String() < orphans[j].String()
+		})
+		for _, dep := range orphans {
+			sb.WriteString("  - " + dep.String() + "\n")
+		}
+	}
 }
 
 // RewriteActionRefs rewrites targeted uses: refs in the original workflow

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -493,8 +493,11 @@ jobs:
 		{NWO: "unknown/dep", Ref: "v1", SHA: "cccc0000cccc0000cccc0000cccc0000cccc0000", HashAlgo: "sha1"},
 	}
 
-	// parentMap exists but doesn't cover unknown/dep
-	parentMap := map[string][]string{}
+	// parentMap has an entry for a different dep so the orphan-handling branch
+	// (non-empty map, but unknown/dep not mapped) is exercised.
+	parentMap := map[string][]string{
+		"some/other@v1": {"actions/checkout@v4"},
+	}
 
 	output, err := f.WriteDependencies(deps, parentMap)
 	require.NoError(t, err)

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -183,7 +183,7 @@ func TestWriteDependencies(t *testing.T) {
 		{NWO: "actions/setup-go", Ref: "v5", SHA: "d35c59abb061a4a6fb18e82ac0862c26744d6ab5", HashAlgo: "sha1"},
 	}
 
-	output, err := f.WriteDependencies(deps)
+	output, err := f.WriteDependencies(deps, nil)
 	require.NoError(t, err)
 
 	s := string(output)
@@ -204,7 +204,7 @@ func TestWriteDependenciesAddsTransitiveSection(t *testing.T) {
 		{NWO: "actions/cache/save", Ref: "v4", SHA: "5a3ec84eff668545956fd18022155c47e93e2684", HashAlgo: "sha1"},
 	}
 
-	output, err := f.WriteDependencies(deps)
+	output, err := f.WriteDependencies(deps, nil)
 	require.NoError(t, err)
 
 	s := string(output)
@@ -226,7 +226,7 @@ func TestWriteDependenciesDeduplicatesDirectAndTransitive(t *testing.T) {
 		{NWO: "actions/cache/save", Ref: "v4", SHA: "5a3ec84eff668545956fd18022155c47e93e2684", HashAlgo: "sha1"},
 	}
 
-	output, err := f.WriteDependencies(deps)
+	output, err := f.WriteDependencies(deps, nil)
 	require.NoError(t, err)
 
 	s := string(output)
@@ -245,7 +245,7 @@ func TestWriteDependenciesRoundTrip(t *testing.T) {
 		{NWO: "actions/checkout", Ref: "v4", SHA: "abc123abc123abc123abc123abc123abc123abc1", HashAlgo: "sha1"},
 	}
 
-	output, err := f.WriteDependencies(deps)
+	output, err := f.WriteDependencies(deps, nil)
 	require.NoError(t, err)
 
 	s := string(output)
@@ -263,7 +263,7 @@ func TestWriteDependenciesReplacesExisting(t *testing.T) {
 		{NWO: "actions/checkout", Ref: "v4", SHA: "0000000000000000000000000000000000000001", HashAlgo: "sha1"},
 	}
 
-	output, err := f.WriteDependencies(deps)
+	output, err := f.WriteDependencies(deps, nil)
 	require.NoError(t, err)
 
 	s := string(output)
@@ -362,7 +362,7 @@ func TestWriteDependenciesTrailingNewlineEdgeCases(t *testing.T) {
 		{NWO: "actions/checkout", Ref: "v4", SHA: "abc123abc123abc123abc123abc123abc123abc1", HashAlgo: "sha1"},
 	}
 
-	output, err := f.WriteDependencies(deps)
+	output, err := f.WriteDependencies(deps, nil)
 	require.NoError(t, err)
 
 	s := string(output)
@@ -379,7 +379,7 @@ func TestDependencySorted(t *testing.T) {
 		{NWO: "aaa/first", Ref: "v1", SHA: "bbbb0000bbbb0000bbbb0000bbbb0000bbbb0000", HashAlgo: "sha1"},
 	}
 
-	output, err := f.WriteDependencies(deps)
+	output, err := f.WriteDependencies(deps, nil)
 	require.NoError(t, err)
 
 	s := string(output)
@@ -406,13 +406,152 @@ jobs:
 
 	deps := []Dependency{{NWO: "actions/cache/save", Ref: "v4", SHA: "5a3ec84eff668545956fd18022155c47e93e2684", HashAlgo: "sha1"}}
 
-	output, err := f.WriteDependencies(deps)
+	output, err := f.WriteDependencies(deps, nil)
 	require.NoError(t, err)
 
 	s := string(output)
 	assert.NotContains(t, s, "# Direct dependencies")
 	assert.Contains(t, s, "# Transitive dependencies")
 	assert.Contains(t, s, "github.com/actions/cache/save@v4:sha1-5a3ec84eff668545956fd18022155c47e93e2684")
+}
+
+func TestWriteDependenciesGroupedByParent(t *testing.T) {
+	f, err := Load("testdata/simple.yml")
+	require.NoError(t, err)
+
+	deps := []Dependency{
+		{NWO: "actions/checkout", Ref: "v4", SHA: "11bd71901bbe5b1630ceea73d27597364c9af683", HashAlgo: "sha1"},
+		{NWO: "actions/setup-go", Ref: "v5", SHA: "d35c59abb061a4a6fb18e82ac0862c26744d6ab5", HashAlgo: "sha1"},
+		{NWO: "actions/cache/save", Ref: "v4", SHA: "5a3ec84eff668545956fd18022155c47e93e2684", HashAlgo: "sha1"},
+		{NWO: "other/dep", Ref: "v1", SHA: "aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000", HashAlgo: "sha1"},
+	}
+
+	parentMap := map[string][]string{
+		"actions/cache/save@v4": {"actions/setup-go@v5"},
+		"other/dep@v1":         {"actions/checkout@v4"},
+	}
+
+	output, err := f.WriteDependencies(deps, parentMap)
+	require.NoError(t, err)
+
+	s := string(output)
+	// Direct deps should be present
+	assert.Contains(t, s, "github.com/actions/checkout@v4:sha1-11bd71901bbe5b1630ceea73d27597364c9af683")
+	assert.Contains(t, s, "github.com/actions/setup-go@v5:sha1-d35c59abb061a4a6fb18e82ac0862c26744d6ab5")
+
+	// Transitive deps should be grouped by parent
+	assert.Contains(t, s, "# Transitive dependencies (via actions/checkout@v4)")
+	assert.Contains(t, s, "# Transitive dependencies (via actions/setup-go@v5)")
+	assert.Contains(t, s, "github.com/actions/cache/save@v4:sha1-5a3ec84eff668545956fd18022155c47e93e2684")
+	assert.Contains(t, s, "github.com/other/dep@v1:sha1-aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000")
+}
+
+func TestWriteDependenciesTransitiveUnderMultipleParents(t *testing.T) {
+	f, err := Load("testdata/simple.yml")
+	require.NoError(t, err)
+
+	deps := []Dependency{
+		{NWO: "actions/checkout", Ref: "v4", SHA: "11bd71901bbe5b1630ceea73d27597364c9af683", HashAlgo: "sha1"},
+		{NWO: "actions/setup-go", Ref: "v5", SHA: "d35c59abb061a4a6fb18e82ac0862c26744d6ab5", HashAlgo: "sha1"},
+		{NWO: "shared/dep", Ref: "v1", SHA: "bbbb0000bbbb0000bbbb0000bbbb0000bbbb0000", HashAlgo: "sha1"},
+	}
+
+	// shared/dep is pulled in by both direct actions
+	parentMap := map[string][]string{
+		"shared/dep@v1": {"actions/checkout@v4", "actions/setup-go@v5"},
+	}
+
+	output, err := f.WriteDependencies(deps, parentMap)
+	require.NoError(t, err)
+
+	s := string(output)
+	// The shared dep should appear under BOTH parent sections
+	assert.Contains(t, s, "# Transitive dependencies (via actions/checkout@v4)")
+	assert.Contains(t, s, "# Transitive dependencies (via actions/setup-go@v5)")
+	assert.Equal(t, 2, strings.Count(s, "github.com/shared/dep@v1:sha1-bbbb0000bbbb0000bbbb0000bbbb0000bbbb0000"),
+		"shared dep should appear once under each parent")
+}
+
+func TestWriteDependenciesOrphanTransitiveWithParentMap(t *testing.T) {
+	content := []byte(`name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`)
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "orphan.yml")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	f, err := Load(path)
+	require.NoError(t, err)
+
+	deps := []Dependency{
+		{NWO: "actions/checkout", Ref: "v4", SHA: "11bd71901bbe5b1630ceea73d27597364c9af683", HashAlgo: "sha1"},
+		{NWO: "unknown/dep", Ref: "v1", SHA: "cccc0000cccc0000cccc0000cccc0000cccc0000", HashAlgo: "sha1"},
+	}
+
+	// parentMap exists but doesn't cover unknown/dep
+	parentMap := map[string][]string{}
+
+	output, err := f.WriteDependencies(deps, parentMap)
+	require.NoError(t, err)
+
+	s := string(output)
+	// Orphan transitive dep should fall into generic section
+	assert.Contains(t, s, "# Transitive dependencies\n")
+	assert.Contains(t, s, "github.com/unknown/dep@v1:sha1-cccc0000cccc0000cccc0000cccc0000cccc0000")
+}
+
+func TestReadDependenciesExactDuplicateDeduped(t *testing.T) {
+	content := []byte(`name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+dependencies:
+  - github.com/actions/checkout@v4:sha1-11bd71901bbe5b1630ceea73d27597364c9af683
+  - github.com/actions/checkout@v4:sha1-11bd71901bbe5b1630ceea73d27597364c9af683
+`)
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "dup.yml")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	f, err := Load(path)
+	require.NoError(t, err)
+
+	deps, err := f.ReadDependencies()
+	require.NoError(t, err)
+	assert.Len(t, deps, 1)
+	assert.Equal(t, "actions/checkout", deps[0].NWO)
+}
+
+func TestReadDependenciesConflictingDuplicateErrors(t *testing.T) {
+	content := []byte(`name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+dependencies:
+  - github.com/actions/checkout@v4:sha1-11bd71901bbe5b1630ceea73d27597364c9af683
+  - github.com/actions/checkout@v4:sha1-aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000
+`)
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "conflict.yml")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	f, err := Load(path)
+	require.NoError(t, err)
+
+	_, err = f.ReadDependencies()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting dependency entries")
 }
 
 func TestParseActionMeta(t *testing.T) {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -73,6 +73,32 @@ func (r *Resolver) ParentMap() map[string][]string {
 	return r.parentMap
 }
 
+// RekeyParentMap updates parentMap keys and values after dependency refs have
+// been rewritten (e.g. tag narrowing v4 → v4.3.1, or PreserveRefs restoring
+// a previous tag). Both child keys and parent values are remapped.
+func (r *Resolver) RekeyParentMap(rewrites map[string]string) {
+	if len(rewrites) == 0 || len(r.parentMap) == 0 {
+		return
+	}
+	updated := make(map[string][]string, len(r.parentMap))
+	for childKey, parents := range r.parentMap {
+		newChild := childKey
+		if rk, ok := rewrites[childKey]; ok {
+			newChild = rk
+		}
+		newParents := make([]string, len(parents))
+		for i, p := range parents {
+			if rk, ok := rewrites[p]; ok {
+				newParents[i] = rk
+			} else {
+				newParents[i] = p
+			}
+		}
+		updated[newChild] = newParents
+	}
+	r.parentMap = updated
+}
+
 // New creates a resolver using the authenticated gh context.
 func New(hostname string) (*Resolver, error) {
 	return NewWithOptions(api.ClientOptions{Host: hostname})

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -59,16 +59,16 @@ type Resolver struct {
 	cache             map[string]resolvedEntry
 	latestRefCache    map[string]string
 	reachCache        map[string]ReachabilityStatus
-	// parentMap tracks child NWO → parent dep key from last ResolveAllRecursive call.
-	parentMap map[string]string
+	// parentMap tracks child dep key → parent dep keys from last ResolveAllRecursive call.
+	parentMap map[string][]string
 	// checkReachFn overrides the default REST-based reachability check (for tests).
 	checkReachFn func(owner, repo, sha, ref string) (ReachabilityStatus, string)
 }
 
-// ParentMap returns the child NWO → parent dep key mapping from the last ResolveAllRecursive call.
-func (r *Resolver) ParentMap() map[string]string {
+// ParentMap returns the child dep key → parent dep keys mapping from the last ResolveAllRecursive call.
+func (r *Resolver) ParentMap() map[string][]string {
 	if r.parentMap == nil {
-		return map[string]string{}
+		return map[string][]string{}
 	}
 	return r.parentMap
 }
@@ -329,7 +329,7 @@ func cacheKey(ref lockfile.ActionRef) string {
 func (r *Resolver) ResolveAllRecursive(refs []lockfile.ActionRef) ([]lockfile.Dependency, error) {
 	seen := make(map[string]bool)
 	var allDeps []lockfile.Dependency
-	r.parentMap = make(map[string]string)
+	r.parentMap = make(map[string][]string)
 
 	pending := refs
 	depth := 0
@@ -373,9 +373,18 @@ func (r *Resolver) ResolveAllRecursive(refs []lockfile.ActionRef) ([]lockfile.De
 			parentKey := deps[i].Key()
 			for _, use := range meta.NestedUses {
 				if actionRef := lockfile.ParseActionRef(use); actionRef != nil {
-					childNWO := actionRef.FullName()
-					if _, exists := r.parentMap[childNWO]; !exists {
-						r.parentMap[childNWO] = parentKey
+					childKey := actionRef.FullName() + "@" + actionRef.Ref
+					// Track all parents, deduplicating.
+					parents := r.parentMap[childKey]
+					found := false
+					for _, p := range parents {
+						if p == parentKey {
+							found = true
+							break
+						}
+					}
+					if !found {
+						r.parentMap[childKey] = append(parents, parentKey)
 					}
 					nextPending = append(nextPending, *actionRef)
 				}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -158,6 +158,69 @@ func TestResolveAllRecursiveWithCacheAndCompositeExpansion(t *testing.T) {
 	if len(deps) != 3 {
 		t.Fatalf("expected three unique deps, got %d: %+v", len(deps), deps)
 	}
+
+	// Verify parentMap tracks the child dep key → parent dep key.
+	pm := r.ParentMap()
+	parents, ok := pm["actions/setup-go@v6"]
+	if !ok || len(parents) != 1 || parents[0] != "owner/composite@v1" {
+		t.Fatalf("expected parentMap to map actions/setup-go@v6 → [owner/composite@v1], got %v", pm)
+	}
+}
+
+func TestResolveAllRecursiveMultipleParents(t *testing.T) {
+	r := &Resolver{
+		MaxRecursionDepth: DefaultMaxRecursionDepth,
+		cache: map[string]resolvedEntry{
+			"owner/compositeA@v1": {
+				dep:       lockfile.Dependency{NWO: "owner/compositeA", Ref: "v1", SHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				actionYML: "name: A\nruns:\n  using: composite\n  steps:\n    - uses: shared/dep@v1\n",
+			},
+			"owner/compositeB@v1": {
+				dep:       lockfile.Dependency{NWO: "owner/compositeB", Ref: "v1", SHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+				actionYML: "name: B\nruns:\n  using: composite\n  steps:\n    - uses: shared/dep@v1\n",
+			},
+			"shared/dep@v1": {
+				dep:       lockfile.Dependency{NWO: "shared/dep", Ref: "v1", SHA: "cccccccccccccccccccccccccccccccccccccccc"},
+				actionYML: "name: Shared\nruns:\n  using: node20\n",
+			},
+		},
+		latestRefCache: map[string]string{},
+		reachCache:     map[string]ReachabilityStatus{},
+	}
+
+	deps, err := r.ResolveAllRecursive([]lockfile.ActionRef{
+		{Owner: "owner", Repo: "compositeA", Ref: "v1"},
+		{Owner: "owner", Repo: "compositeB", Ref: "v1"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveAllRecursive returned error: %v", err)
+	}
+
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 unique deps, got %d: %+v", len(deps), deps)
+	}
+
+	pm := r.ParentMap()
+	parents, ok := pm["shared/dep@v1"]
+	if !ok {
+		t.Fatal("expected parentMap to contain shared/dep@v1")
+	}
+	if len(parents) != 2 {
+		t.Fatalf("expected 2 parents for shared/dep@v1, got %d: %v", len(parents), parents)
+	}
+	// Both composites should be parents (order may vary).
+	hasA, hasB := false, false
+	for _, p := range parents {
+		if p == "owner/compositeA@v1" {
+			hasA = true
+		}
+		if p == "owner/compositeB@v1" {
+			hasB = true
+		}
+	}
+	if !hasA || !hasB {
+		t.Fatalf("expected both compositeA and compositeB as parents, got %v", parents)
+	}
 }
 
 func TestResolveAllRecursiveRespectsMaxDepth(t *testing.T) {


### PR DESCRIPTION
## Summary

Group transitive lockfile dependencies under their parent composite action instead of listing them in a flat section. This makes it clear which transitive deps belong to which composite, improving auditability.

Builds on #9 which separated transitive deps from direct ones.

## What changed

- `resolver.go`: track parent→child relationships via `ParentMap()` so lockfile writer knows which composite pulled in each transitive dep
- `lockfile.go`: `WriteDependencies()` accepts a parent map and groups transitive entries under `# Transitive dependencies (via <parent>)` comment headers
- `lockfile_test.go`: updated tests for grouped output format
- `diagnose.go` / `apply.go`: thread `ParentMap()` through to `WriteDependencies()` call sites
- `upgrade.go`: same — pass `ParentMap()` when rewriting lockfile during upgrade
- demo fixtures and VHS tapes updated to show the new grouping

## New lockfile format

```yaml
# Automatically generated and managed by gh-actions-pin
dependencies:
  - github.com/actions/checkout@v4.3.1:sha1-34e114876b0b11c390a56381ad16ebd13914f8d5
  - github.com/actions/setup-go@v5.6.0:sha1-40f1582b2485089dde7abd97c1529aa768e1baff
  - github.com/golangci/golangci-lint-action@v6.5.2:sha1-55c2c1448f86e01eaae002a5a3a9624417608d84
  - github.com/nodeselector/actions-test-fixtures/nested-composite@updated:sha1-ea53476fdc17...

  # Transitive dependencies (via nodeselector/actions-test-fixtures/nested-composite@updated)
  - github.com/nodeselector/actions-test-fixtures/simple-composite@main:sha1-33a384c001ed...

  # Transitive dependencies (via nodeselector/actions-test-fixtures/simple-composite@main)
  - github.com/nodeselector/actions-test-fixtures-b/simple-echo@main:sha1-92b7b0058bc2...
  - github.com/nodeselector/actions-test-fixtures/simple-node@main:sha1-33a384c001ed...
```

## Demo

![Transitive deps grouped by parent](https://vhs.charm.sh/vhs-6trCiixLmitc6BsBZqBAKc.gif)

## Verification

- `go test ./...`
- `demo/try-it.sh check-autofix`
