### PR TITLE
fix: robust imposter commit checks

### DIFF
--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -531,6 +531,12 @@ func presentCheckResults(out *ui.UI, report *doctor.Report, valid bool, willReme
 			wg := warnMap[key]
 			f := wg.finding
 			out.Detail("  ↳ %s: %s", key, f.Detail)
+			if f.Dependency != nil && f.LiveSHA != "" {
+				owner, repo := f.Dependency.OwnerRepo()
+				if owner != "" {
+					out.Detail("    %s", out.Dim(fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s", owner, repo, f.Dependency.SHA[:12], f.LiveSHA[:12])))
+				}
+			}
 		}
 	}
 	for _, key := range otherDetailWarnings {

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -386,28 +386,6 @@ func presentCheckResults(out *ui.UI, report *doctor.Report, valid bool, willReme
 		for _, dep := range depOrder {
 			dg := depMap[dep]
 
-			// Merge REF_MOVED+IMPOSTER_COMMIT for same dep.
-			hasTampered := false
-			var unreachableDetail string
-			for _, f := range dg.findings {
-				if f.Category == doctor.CategoryRefMoved {
-					hasTampered = true
-				}
-				if f.Category == doctor.CategoryImposterCommit {
-					unreachableDetail = f.Detail
-				}
-			}
-			if hasTampered && unreachableDetail != "" {
-				var merged []doctor.Finding
-				for _, f := range dg.findings {
-					if f.Category == doctor.CategoryImposterCommit {
-						continue
-					}
-					merged = append(merged, f)
-				}
-				dg.findings = merged
-			}
-
 			// Tally and check if this dep is NOT_PINNED only.
 			allNotPinned := true
 			for _, f := range dg.findings {
@@ -428,28 +406,12 @@ func presentCheckResults(out *ui.UI, report *doctor.Report, valid bool, willReme
 				label := strings.ToUpper(string(f.Category))
 				out.Detail("! %s %s", out.Dim(label), dep)
 				out.Detail("  %s", f.Detail)
-				if hasTampered && unreachableDetail != "" && f.Category == doctor.CategoryRefMoved {
-					out.Detail("  %s", unreachableDetail)
-				}
-				if f.Dependency != nil && f.Category == doctor.CategoryRefMoved {
-					owner, repo := f.Dependency.OwnerRepo()
-					if hasTampered && unreachableDetail != "" {
-						out.Detail("  %s", out.Bold("⚠ The new commit has no shared history with your pinned SHA."))
-						out.Detail("  %s", "Do NOT accept without reviewing the diff for malicious changes.")
-					} else {
-						out.Detail("  %s", "Validate the change is a legitimate update before accepting.")
-					}
-					if owner != "" {
-						out.Detail("  → %s", out.Dim(fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s", owner, repo, f.Dependency.SHA, f.Dependency.Ref)))
-						out.Detail("  → %s", out.Dim(fmt.Sprintf("https://github.com/%s/%s/releases", owner, repo)))
-					}
-				}
 			}
 		}
 
 		parts := []string{}
 		for _, cat := range []doctor.Category{
-			doctor.CategoryRefMoved, doctor.CategoryRefChanged, doctor.CategoryNotPinned,
+			doctor.CategoryRefChanged, doctor.CategoryNotPinned,
 			doctor.CategoryStale, doctor.CategoryMisleadingSHA, doctor.CategoryImposterCommit,
 		} {
 			if n, ok := catCounts[cat]; ok {
@@ -521,7 +483,9 @@ func presentCheckResults(out *ui.UI, report *doctor.Report, valid bool, willReme
 	// don't use dependency pinning — warning on every transitive dep is noisy
 	// and not actionable by the consumer. Revisit when we have a story for
 	// composite action authors to adopt pinning.
+	// Collect REF_MOVED warnings for compact display.
 	var bareSHADeps []string
+	var refMovedWarnings []string
 	var otherDetailWarnings []string
 	for _, key := range otherWarnings {
 		wg := warnMap[key]
@@ -532,6 +496,8 @@ func presentCheckResults(out *ui.UI, report *doctor.Report, valid bool, willReme
 				bareSHADeps = append(bareSHADeps, key)
 			}
 			// transitive SHA_AS_REF: silently swallowed (see TODO above)
+		} else if f.Category == doctor.CategoryRefMoved {
+			refMovedWarnings = append(refMovedWarnings, key)
 		} else if f.Category == doctor.CategoryValid && f.Severity == doctor.SeverityWarning &&
 			strings.Contains(f.Remediation, "transitive dependency") {
 			// transitive reachability unknown: silently swallowed (see TODO above)
@@ -547,6 +513,16 @@ func presentCheckResults(out *ui.UI, report *doctor.Report, valid bool, willReme
 			out.Detail("  ↳ resolving below")
 		} else {
 			out.Detail("  ↳ run `gh actions-pin upgrade` to pin to tagged releases")
+		}
+	}
+	if len(refMovedWarnings) > 0 {
+		out.Warning("%d %s moved upstream — run `gh actions-pin upgrade` to update",
+			len(refMovedWarnings),
+			ui.Pluralize(len(refMovedWarnings), "ref has", "refs have"))
+		for _, key := range refMovedWarnings {
+			wg := warnMap[key]
+			f := wg.finding
+			out.Detail("  ↳ %s: %s", key, f.Detail)
 		}
 	}
 	for _, key := range otherDetailWarnings {

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -154,7 +154,7 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 	// Remediation.
 	actionable := report.WorkflowsNeedingAttention()
 	var fixedCount, skippedCount, alertedCount int
-	var skippedDeps []string
+	var skippedDeps, alertedDeps []string
 
 	if willRemediate && len(actionable) > 0 {
 		hostname := resolveHostname(opts.Hostname)
@@ -204,6 +204,7 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 		skippedCount = uniqueSkipped
 		alertedCount = rem.Alerted
 		skippedDeps = rem.SkippedDeps
+		alertedDeps = rem.AlertedDeps
 	}
 
 	if !valid || skippedCount > 0 || alertedCount > 0 {
@@ -211,11 +212,18 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 		if fixedCount > 0 && skippedCount == 0 && alertedCount == 0 {
 			return nil
 		}
-		remaining := skippedCount + alertedCount
-		if remaining > 0 {
+		if alertedCount > 0 {
+			f.UI.Blank()
+			f.UI.Error("%d %s %s investigation — do not auto-fix:",
+				alertedCount, ui.Pluralize(alertedCount, "action", "actions"), ui.Pluralize(alertedCount, "requires", "require"))
+			for _, dep := range alertedDeps {
+				f.UI.Detail("  %s", dep)
+			}
+		}
+		if skippedCount > 0 {
 			f.UI.Blank()
 			f.UI.Error("%d %s %s interactive resolution — run `gh actions-pin` locally:",
-				remaining, ui.Pluralize(remaining, "action", "actions"), ui.Pluralize(remaining, "requires", "require"))
+				skippedCount, ui.Pluralize(skippedCount, "action", "actions"), ui.Pluralize(skippedCount, "requires", "require"))
 			for _, dep := range skippedDeps {
 				f.UI.Detail("  %s", dep)
 			}

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -348,7 +348,13 @@ func writeCheckJSON(w io.Writer, report *doctor.Report, valid bool, fieldsCSV st
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(payload)
+	if err := enc.Encode(payload); err != nil {
+		return err
+	}
+	if !valid {
+		return errSilent
+	}
+	return nil
 }
 
 // presentCheckResults renders human-readable output from a doctor report.

--- a/cmd/gh-actions-pin/command_test.go
+++ b/cmd/gh-actions-pin/command_test.go
@@ -272,7 +272,7 @@ dependencies:
 	stdout, _, err := runCommandWithHTTPAndReach(t, reg, unreachableFunc(),
 		"check", "--json=valid,findings", workflowPath,
 	)
-	require.NoError(t, err, "JSON mode communicates errors in payload")
+	require.ErrorIs(t, err, errSilent, "JSON mode should exit non-zero when findings are invalid")
 
 	var payload struct {
 		Valid    bool           `json:"valid"`
@@ -323,7 +323,7 @@ dependencies:
 	stdout, _, err := runCommandWithHTTPAndReach(t, reg, unreachableFunc(),
 		"check", "--json=valid,findings", workflowPath,
 	)
-	require.NoError(t, err, "JSON mode communicates errors in payload")
+	require.ErrorIs(t, err, errSilent, "JSON mode should exit non-zero when findings are invalid")
 
 	var payload struct {
 		Valid    bool           `json:"valid"`

--- a/demo/try-it.sh
+++ b/demo/try-it.sh
@@ -67,7 +67,7 @@ usage() {
   echo ""
   echo "  Change detection"
   echo "    ref-moved          Tag moved forward (routine release)"
-  echo "    imposter-commit    Tag hijacked to orphan commit (fork injection)"
+  echo "    imposter-commit    Tag hijacked to fork-network commit (fork injection)"
   echo "    json-output        JSON output for CI integration"
   echo ""
   echo "  all                  Run all scenarios sequentially"
@@ -170,7 +170,7 @@ scenario_imposter_commit() {
   bash "$RESET"
   comment "Workflow pinned BEFORE the tag was hijacked"
   run show_workflow_summary demo/workflows-pwned/1-pinned-before-hijack.yml
-  comment "Check detects the tag moved to an orphan commit"
+  comment "Check detects the tag moved to a fork-network commit"
   run gh actions-pin check demo/workflows-pwned/1-pinned-before-hijack.yml
 }
 

--- a/demo/vhs/imposter-commit.tape
+++ b/demo/vhs/imposter-commit.tape
@@ -10,7 +10,7 @@ Set PlaybackSpeed 1.5
 Set TypingSpeed 50ms
 Set Theme "GitHub Dark"
 
-Type "echo '# Workflow was pinned to a legitimate SHA'"
+Type "echo '# Workflow pinned to a legitimate SHA — attacker moved tag to a fork-network commit'"
 Enter
 Sleep 1s
 
@@ -18,7 +18,7 @@ Type "grep -E 'uses:|  -' demo/workflows-pwned/1-pinned-before-hijack.yml"
 Enter
 Sleep 2s
 
-Type "echo '# Attacker moved the tag to a fork-network commit (fork injection)'"
+Type "echo '# branch_commits detects the fork injection — IMPOSTER_COMMIT fires'"
 Enter
 Sleep 1s
 

--- a/demo/vhs/imposter-commit.tape
+++ b/demo/vhs/imposter-commit.tape
@@ -18,7 +18,7 @@ Type "grep -E 'uses:|  -' demo/workflows-pwned/1-pinned-before-hijack.yml"
 Enter
 Sleep 2s
 
-Type "echo '# Attacker moved the tag to an orphan commit (fork injection)'"
+Type "echo '# Attacker moved the tag to a fork-network commit (fork injection)'"
 Enter
 Sleep 1s
 

--- a/demo/vhs/ref-moved.tape
+++ b/demo/vhs/ref-moved.tape
@@ -10,7 +10,7 @@ Set PlaybackSpeed 1.5
 Set TypingSpeed 50ms
 Set Theme "GitHub Dark"
 
-Type "echo '# Tag moved forward — routine upstream release'"
+Type "echo '# Tag moved forward — routine upstream release (REF_MOVED is a warning, not an error)'"
 Enter
 Sleep 1s
 
@@ -18,7 +18,7 @@ Type "grep -E 'uses:|  -' demo/workflows-pwned/5-pinned-before-update.yml"
 Enter
 Sleep 2s
 
-Type "echo '# Check detects the tag now points to a newer commit'"
+Type "echo '# Check detects the tag now points to a newer commit — warning only'"
 Enter
 Sleep 1s
 

--- a/demo/vhs/tamper-warning.tape
+++ b/demo/vhs/tamper-warning.tape
@@ -18,7 +18,7 @@ Type "grep -E 'uses:|  -' demo/workflows-pwned/1-pinned-before-hijack.yml"
 Enter
 Sleep 2s
 
-Type "echo '# Attacker moved the tag to an orphan commit'"
+Type "echo '# Attacker moved the tag to a fork-network commit'"
 Enter
 Sleep 1s
 

--- a/demo/vhs/tamper-warning.tape
+++ b/demo/vhs/tamper-warning.tape
@@ -10,19 +10,19 @@ Set PlaybackSpeed 1.5
 Set TypingSpeed 50ms
 Set Theme "GitHub Dark"
 
-Type "echo '# Workflow was pinned to a legitimate SHA'"
+Type "echo '# Tag moved BACKWARD to an older commit — same-repo rollback'"
 Enter
 Sleep 1s
 
-Type "grep -E 'uses:|  -' demo/workflows-pwned/1-pinned-before-hijack.yml"
+Type "grep -E 'uses:|  -' demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml"
 Enter
 Sleep 2s
 
-Type "echo '# Attacker moved the tag to a fork-network commit'"
+Type "echo '# REF_MOVED warning fires — commit is real (on a branch), not a fork injection'"
 Enter
 Sleep 1s
 
-Type "gh actions-pin check --no-interactive demo/workflows-pwned/1-pinned-before-hijack.yml"
+Type "gh actions-pin check --no-interactive demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml"
 Enter
 Sleep 10s
 

--- a/demo/workflows-pwned/1-pinned-before-hijack.yml
+++ b/demo/workflows-pwned/1-pinned-before-hijack.yml
@@ -1,4 +1,4 @@
-name: "1: Pinned before attack — fork-network injection (lineage preserved)"
+name: "1: Pinned before attack — fork-network injection (caught by branch_commits)"
 
 # =============================================================================
 # ATTACKER CAPABILITY: Fork repo + write access to move tags
@@ -11,22 +11,32 @@ name: "1: Pinned before attack — fork-network injection (lineage preserved)"
 #      the malicious commit has legitimate git ancestry.
 #   4. Attacker moves @tampered tag to 7b403c9 — a fork-network commit
 #      that exists in GitHub's shared object store
-#   5. You run `gh actions-pin check` → CAUGHT (ref_moved)
+#   5. You run `gh actions-pin check` → FULLY CAUGHT
 #
 # This is the tj-actions/changed-files scenario. The attacker builds on
-# top of real history, so git lineage is preserved — but the SHA mismatch
-# between pinned and live is enough to catch it.
+# top of real history, so git lineage is preserved — but the fork commit
+# is NOT on any branch of the upstream repo.
 #
-# RESULT:  CAUGHT ✗
-#          ✗ REF_MOVED   — live SHA (7b403c9) ≠ pinned SHA (ea53476)
-#          ✓ REACHABLE   — pinned SHA is an ancestor of the fork commit
-#                          (the attacker built on top of real history)
+# RESULT:  FULLY CAUGHT ✗✗
+#          ⚠ REF_MOVED       — live SHA (7b403c9) ≠ pinned SHA (ea53476)
+#          ✗ IMPOSTER_COMMIT — 7b403c9 is not on any branch in
+#                              nodeselector/actions-test-fixtures
+#                              (fork-network injection detected via
+#                              branch_commits endpoint)
 #
-# The lockfile's known-good SHA acts as a tripwire. Even though the fork
-# commit has legitimate ancestry, the SHA mismatch fires ref_moved.
-# Reachability passes because the attacker preserved lineage — making
-# this indistinguishable from a legitimate update if the victim re-pins
-# (see scenario 3 for that failure mode).
+# Detection: branch_commits checks whether the tag's current target
+# exists on any branch of the UPSTREAM repo. Fork-network commits
+# live in GitHub's shared object store but have no branches in the
+# upstream repo — branch_commits returns empty → impostor.
+#
+# REF_MOVED is a warning (tag movement is expected for routine
+# releases). IMPOSTER_COMMIT is the error — the commit doesn't
+# belong to this repo.
+#
+# CONTRAST WITH SCENARIO 5:
+#   Both show REF_MOVED. Scenario 5 is a genuine release where the
+#   new SHA is on a branch — reachability passes. Here the SHA is a
+#   fork commit with no branches — impostor detected.
 #
 # FORK:    https://github.com/choam-io/actions-test-fixtures-fork
 # PAYLOAD: https://github.com/choam-io/actions-test-fixtures-fork/commit/7b403c9

--- a/demo/workflows-pwned/1-pinned-before-hijack.yml
+++ b/demo/workflows-pwned/1-pinned-before-hijack.yml
@@ -1,34 +1,37 @@
-name: "1: Pinned before attack — tag hijacked to fork-network commit"
+name: "1: Pinned before attack — fork-network injection (lineage preserved)"
 
 # =============================================================================
-# ATTACKER CAPABILITY: Write access to move tags (fork-network injection)
+# ATTACKER CAPABILITY: Fork repo + write access to move tags
 # TIMELINE:
-#   1. Maintainer releases @tampered → ea53476 (legitimate)
+#   1. Maintainer releases @tampered → ea53476 (legitimate, HEAD of main)
 #   2. You pin: lockfile records ea53476 ✓
 #   3. Attacker forks the repo (choam-io/actions-test-fixtures-fork), pushes
-#      a malicious commit (7b403c9) to their fork's attacker-payload branch
-#   4. Attacker moves @tampered tag to 7b403c9 — a commit that exists in
-#      the fork network's shared object store but NOT in the upstream lineage
-#   5. You run `gh actions-pin check` → CAUGHT
+#      a malicious commit (7b403c9) to their fork's attacker-payload branch.
+#      The commit's parent (fbe0421) is a real descendant of ea53476, so
+#      the malicious commit has legitimate git ancestry.
+#   4. Attacker moves @tampered tag to 7b403c9 — a fork-network commit
+#      that exists in GitHub's shared object store
+#   5. You run `gh actions-pin check` → CAUGHT (ref_moved)
 #
-# This is the tj-actions/changed-files scenario. The attacker moves a tag
-# to point at a commit from a fork — GitHub shares object stores across
-# fork networks, so the SHA resolves, but it has no lineage in the
-# upstream repo's history.
+# This is the tj-actions/changed-files scenario. The attacker builds on
+# top of real history, so git lineage is preserved — but the SHA mismatch
+# between pinned and live is enough to catch it.
 #
 # RESULT:  CAUGHT ✗
-#          ✗ REF_MOVED   — live SHA ≠ pinned SHA (tag was moved)
-#          The reachability check runs on the PINNED SHA (ea53476), which
-#          IS reachable — it's the real commit. The tripwire is the SHA
-#          mismatch, not the lineage check.
+#          ✗ REF_MOVED   — live SHA (7b403c9) ≠ pinned SHA (ea53476)
+#          ✓ REACHABLE   — pinned SHA is an ancestor of the fork commit
+#                          (the attacker built on top of real history)
 #
-# The lockfile's known-good SHA acts as a tripwire. The moment the tag
-# moves, check detects both the SHA mismatch and the broken lineage.
+# The lockfile's known-good SHA acts as a tripwire. Even though the fork
+# commit has legitimate ancestry, the SHA mismatch fires ref_moved.
+# Reachability passes because the attacker preserved lineage — making
+# this indistinguishable from a legitimate update if the victim re-pins
+# (see scenario 3 for that failure mode).
 #
 # FORK:    https://github.com/choam-io/actions-test-fixtures-fork
 # PAYLOAD: https://github.com/choam-io/actions-test-fixtures-fork/commit/7b403c9
 #
-# Run:     gh actions-pin check .github/workflows/1-pinned-before-hijack.yml
+# Run:     gh actions-pin check demo/workflows-pwned/1-pinned-before-hijack.yml
 # =============================================================================
 
 on:

--- a/demo/workflows-pwned/1-pinned-before-hijack.yml
+++ b/demo/workflows-pwned/1-pinned-before-hijack.yml
@@ -1,25 +1,32 @@
-name: "1: Pinned before attack — tag hijacked to unrelated code"
+name: "1: Pinned before attack — tag hijacked to fork-network commit"
 
 # =============================================================================
-# ATTACKER CAPABILITY: Write access to move tags
+# ATTACKER CAPABILITY: Write access to move tags (fork-network injection)
 # TIMELINE:
 #   1. Maintainer releases @tampered → ea53476 (legitimate)
 #   2. You pin: lockfile records ea53476 ✓
-#   3. Attacker moves tag to orphan commit 614a37a (no shared history)
-#   4. You run `gh actions-pin check` → CAUGHT
+#   3. Attacker forks the repo (choam-io/actions-test-fixtures-fork), pushes
+#      a malicious commit (7b403c9) to their fork's attacker-payload branch
+#   4. Attacker moves @tampered tag to 7b403c9 — a commit that exists in
+#      the fork network's shared object store but NOT in the upstream lineage
+#   5. You run `gh actions-pin check` → CAUGHT
 #
 # This is the tj-actions/changed-files scenario. The attacker moves a tag
-# to point at completely unrelated code — an orphan commit, a fork-network
-# SHA, anything outside the real release lineage.
+# to point at a commit from a fork — GitHub shares object stores across
+# fork networks, so the SHA resolves, but it has no lineage in the
+# upstream repo's history.
 #
 # RESULT:  CAUGHT ✗
-#          ✗ TAMPERED    — live SHA ≠ pinned SHA (tag was moved)
-#          ✗ UNREACHABLE — new SHA has no shared history with the pinned SHA
+#          ✗ REF_MOVED   — live SHA ≠ pinned SHA (tag was moved)
+#          The reachability check runs on the PINNED SHA (ea53476), which
+#          IS reachable — it's the real commit. The tripwire is the SHA
+#          mismatch, not the lineage check.
 #
 # The lockfile's known-good SHA acts as a tripwire. The moment the tag
 # moves, check detects both the SHA mismatch and the broken lineage.
 #
-# DEMO:    https://github.com/nodeselector/actions-test-fixtures/commit/614a37a
+# FORK:    https://github.com/choam-io/actions-test-fixtures-fork
+# PAYLOAD: https://github.com/choam-io/actions-test-fixtures-fork/commit/7b403c9
 #
 # Run:     gh actions-pin check .github/workflows/1-pinned-before-hijack.yml
 # =============================================================================

--- a/demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml
+++ b/demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml
@@ -1,29 +1,31 @@
-name: "2: Pinned before attack — tag moved to ancestor (lineage preserved)"
+name: "2: Pinned before attack — tag moved backward (lineage broken)"
 
 # =============================================================================
-# ATTACKER CAPABILITY: Write access to push commits AND move tags
+# ATTACKER CAPABILITY: Write access to move tags
 # TIMELINE:
-#   1. Maintainer releases @bypassed → ea53476 (legitimate)
+#   1. Maintainer releases @bypassed → ea53476 (legitimate, HEAD of main)
 #   2. You pin: lockfile records ea53476 ✓
-#   3. Attacker pushes malicious commit extending the real history
-#   4. Attacker moves tag to 38b3412 (a real ancestor — lineage intact)
-#   5. You run `gh actions-pin check` → CAUGHT (TAMPERED fires)
+#   3. Attacker moves tag BACKWARD to 38b3412 (parent of ea53476)
+#   4. You run `gh actions-pin check` → FULLY CAUGHT
 #
-# More sophisticated than scenario 1. The attacker preserves git lineage
-# so the malicious commit is a real ancestor/descendant of the legitimate
-# release. Reachability can't distinguish this from normal history.
+# A clumsy attack: the attacker moves the tag to an older commit. The
+# reachability check catches this because the pinned SHA (ea53476) is
+# a DESCENDANT of the tag's new position (38b3412) — not an ancestor.
+# The direction matters: "is the pinned SHA reachable going backward
+# from the ref?" No, because the ref now points at an older commit.
 #
-# RESULT:  PARTIALLY CAUGHT ⚠
-#          ✗ TAMPERED    — live SHA (38b3412) ≠ pinned SHA (ea53476)
-#          ✓ REACHABLE   — SHA is in the tag's lineage → passes
+# RESULT:  FULLY CAUGHT ✗✗
+#          ✗ REF_MOVED       — live SHA (38b3412) ≠ pinned SHA (ea53476)
+#          ✗ IMPOSTER_COMMIT — pinned SHA is NOT reachable from ref
+#                              (tag points backward, pinned SHA is ahead)
 #
-# The TAMPERED check catches the tag movement. But if the victim sees
-# "tampered" and thinks "oh, just a new release" and re-pins →
-# see scenario 3.
+# Both checks fire. This is the easiest attack to detect — the tag moved
+# in the wrong direction. Compare with scenario 1 where the attacker
+# preserves lineage by building on top of real history.
 #
 # DEMO:    https://github.com/nodeselector/actions-test-fixtures/commit/38b3412
 #
-# Run:     gh actions-pin check .github/workflows/2-pinned-before-lineage-rewrite.yml
+# Run:     gh actions-pin check demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml
 # =============================================================================
 
 on:

--- a/demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml
+++ b/demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml
@@ -1,4 +1,4 @@
-name: "2: Pinned before attack — tag moved backward (lineage broken)"
+name: "2: Pinned before attack — tag moved backward (same-repo rollback)"
 
 # =============================================================================
 # ATTACKER CAPABILITY: Write access to move tags
@@ -6,22 +6,29 @@ name: "2: Pinned before attack — tag moved backward (lineage broken)"
 #   1. Maintainer releases @bypassed → ea53476 (legitimate, HEAD of main)
 #   2. You pin: lockfile records ea53476 ✓
 #   3. Attacker moves tag BACKWARD to 38b3412 (parent of ea53476)
-#   4. You run `gh actions-pin check` → FULLY CAUGHT
+#   4. You run `gh actions-pin check` → REF_MOVED warning
 #
-# A clumsy attack: the attacker moves the tag to an older commit. The
-# reachability check catches this because the pinned SHA (ea53476) is
-# a DESCENDANT of the tag's new position (38b3412) — not an ancestor.
-# The direction matters: "is the pinned SHA reachable going backward
-# from the ref?" No, because the ref now points at an older commit.
+# The attacker moves the tag to an older commit IN THE SAME REPO. Unlike
+# scenario 1 (fork injection), 38b3412 is a real commit that exists on
+# the repo's own branches — branch_commits confirms it's reachable.
 #
-# RESULT:  FULLY CAUGHT ✗✗
-#          ✗ REF_MOVED       — live SHA (38b3412) ≠ pinned SHA (ea53476)
-#          ✗ IMPOSTER_COMMIT — pinned SHA is NOT reachable from ref
-#                              (tag points backward, pinned SHA is ahead)
+# RESULT:  WARNING ONLY ⚠
+#          ⚠ REF_MOVED — live SHA (38b3412) ≠ pinned SHA (ea53476)
+#          ✓ REACHABLE — 38b3412 is on branch(es) in the upstream repo
+#                        (it's a real commit, just older)
 #
-# Both checks fire. This is the easiest attack to detect — the tag moved
-# in the wrong direction. Compare with scenario 1 where the attacker
-# preserves lineage by building on top of real history.
+# Why no IMPOSTER_COMMIT? The branch_commits endpoint checks whether the
+# tag's CURRENT target is on any branch of the repo. Since 38b3412 is a
+# legitimate commit in nodeselector/actions-test-fixtures, it passes.
+# The old compare-API approach detected backward moves by checking if
+# the pinned SHA was an ancestor of the live SHA — but that conflated
+# "tag moved backward" with "fork injection". With branch_commits, we
+# separate the concerns:
+#   • Fork injection (foreign code) → IMPOSTER_COMMIT (error)
+#   • Tag movement (same-repo code) → REF_MOVED (warning)
+#
+# A backward move to same-repo code is suspicious but not code injection.
+# The user is warned and can investigate with `upgrade` or the compare link.
 #
 # DEMO:    https://github.com/nodeselector/actions-test-fixtures/commit/38b3412
 #

--- a/demo/workflows-pwned/3-repinned-bypass.yml
+++ b/demo/workflows-pwned/3-repinned-bypass.yml
@@ -1,27 +1,30 @@
 name: "3: Re-pinned after attack — full bypass"
 
 # =============================================================================
-# ATTACKER CAPABILITY: Same as scenario 2
+# ATTACKER CAPABILITY: Same as scenario 1 (fork injection)
 # TIMELINE:
 #   1. Maintainer releases @bypassed → ea53476 (legitimate)
 #   2. You pin: lockfile records ea53476 ✓
-#   3. Attacker moves tag to 38b3412 (lineage-preserving)
-#   4. You run `gh actions-pin check` → TAMPERED fires (scenario 2)
+#   3. Attacker moves tag to 38b3412 (ancestor — see scenario 2)
+#   4. You run `gh actions-pin check` → REF_MOVED + IMPOSTER_COMMIT fire
 #   5. You think "oh, just a new release" and re-pin with `gh actions-pin`
 #   6. Lockfile now records 38b3412 — the attacker's SHA
 #   7. You run `gh actions-pin check` → ALL CLEAR. Attacker wins.
 #
-# This is the continuation of scenario 2. The victim re-pinned, accepting
-# the attacker's SHA as the new known-good state.
+# This is the continuation of scenario 2. The victim saw the warning,
+# assumed it was a routine update, and re-pinned. The attacker's SHA
+# is now the lockfile's known-good baseline.
 #
 # RESULT:  COMPLETELY INVISIBLE ✓ (false negative)
 #          ✓ NOT TAMPERED — pinned SHA matches live resolution
-#          ✓ REACHABLE    — SHA is in the tag's lineage
+#          ✓ REACHABLE    — tag points directly at the pinned SHA
 #          `check` reports this workflow as clean.
 #
 # The lockfile is a tamper-EVIDENT seal, not tamper-proof. It catches tag
-# movement on first contact (scenario 2). But once the victim re-pins, a
-# history-preserving rewrite is indistinguishable from a legitimate release.
+# movement on first contact (scenario 2). But once the victim re-pins,
+# the attacker's SHA becomes the new baseline. The same applies to
+# scenario 1 (fork injection) — if you re-pin after seeing ref_moved,
+# the fork commit becomes trusted.
 #
 # MITIGATIONS (outside lockfile scope):
 #   • Tag protection rules / rulesets (prevent tag movement at the source)
@@ -31,7 +34,7 @@ name: "3: Re-pinned after attack — full bypass"
 #
 # DEMO:    https://github.com/nodeselector/actions-test-fixtures/commit/38b3412
 #
-# Run:     gh actions-pin check .github/workflows/3-repinned-bypass.yml
+# Run:     gh actions-pin check demo/workflows-pwned/3-repinned-bypass.yml
 # =============================================================================
 
 on:

--- a/demo/workflows-pwned/3-repinned-bypass.yml
+++ b/demo/workflows-pwned/3-repinned-bypass.yml
@@ -1,30 +1,33 @@
-name: "3: Re-pinned after attack — full bypass"
+name: "3: Re-pinned after backward move — false baseline"
 
 # =============================================================================
-# ATTACKER CAPABILITY: Same as scenario 1 (fork injection)
+# ATTACKER CAPABILITY: Write access to move tags (same as scenario 2)
 # TIMELINE:
 #   1. Maintainer releases @bypassed → ea53476 (legitimate)
 #   2. You pin: lockfile records ea53476 ✓
-#   3. Attacker moves tag to 38b3412 (ancestor — see scenario 2)
-#   4. You run `gh actions-pin check` → REF_MOVED + IMPOSTER_COMMIT fire
-#   5. You think "oh, just a new release" and re-pin with `gh actions-pin`
-#   6. Lockfile now records 38b3412 — the attacker's SHA
+#   3. Attacker moves tag backward to 38b3412 (parent of ea53476)
+#   4. You run `gh actions-pin check` → REF_MOVED ⚠
+#   5. You think "oh, just a routine update" and re-pin with `gh actions-pin`
+#   6. Lockfile now records 38b3412 — the attacker's chosen SHA
 #   7. You run `gh actions-pin check` → ALL CLEAR. Attacker wins.
 #
-# This is the continuation of scenario 2. The victim saw the warning,
-# assumed it was a routine update, and re-pinned. The attacker's SHA
-# is now the lockfile's known-good baseline.
+# This is the continuation of scenario 2. The victim saw the REF_MOVED
+# warning, assumed it was a routine update, and re-pinned. The attacker's
+# SHA is now the lockfile's known-good baseline.
 #
 # RESULT:  COMPLETELY INVISIBLE ✓ (false negative)
 #          ✓ NOT TAMPERED — pinned SHA matches live resolution
-#          ✓ REACHABLE    — tag points directly at the pinned SHA
+#          ✓ REACHABLE    — 38b3412 is on branches (real commit)
 #          `check` reports this workflow as clean.
 #
-# The lockfile is a tamper-EVIDENT seal, not tamper-proof. It catches tag
-# movement on first contact (scenario 2). But once the victim re-pins,
-# the attacker's SHA becomes the new baseline. The same applies to
-# scenario 1 (fork injection) — if you re-pin after seeing ref_moved,
-# the fork commit becomes trusted.
+# NOTE: This scenario only works with same-repo tag movement (scenario 2).
+# Fork injection (scenario 1) cannot be re-pinned — `gh actions-pin` now
+# runs reachability checks at pin time and refuses to pin fork-network
+# commits (IMPOSTER_COMMIT blocks the pin operation).
+#
+# The lockfile is a tamper-EVIDENT seal, not tamper-proof. For same-repo
+# backward moves, REF_MOVED is the only signal — and if the victim
+# accepts it, the attacker's SHA becomes the new baseline.
 #
 # MITIGATIONS (outside lockfile scope):
 #   • Tag protection rules / rulesets (prevent tag movement at the source)

--- a/demo/workflows-pwned/4-never-pinned-pwned.yml
+++ b/demo/workflows-pwned/4-never-pinned-pwned.yml
@@ -4,19 +4,21 @@ name: "4: Never pinned — walking into a compromised repo"
 # ATTACKER CAPABILITY: Write access to move tags (attack already happened)
 # TIMELINE:
 #   1. Maintainer released @tampered → ea53476 (legitimate)
-#   2. Attacker moved tag to orphan commit 614a37a
-#   3. You discover the action and run `gh actions-pin` for the first time
-#   4. Lockfile records 614a37a — the ATTACKER's SHA. You never knew ea53476.
-#   5. You run `gh actions-pin check` → ???
+#   2. Attacker forked the repo (choam-io/actions-test-fixtures-fork), pushed
+#      a malicious commit (7b403c9) to their fork's attacker-payload branch
+#   3. Attacker moved tag to 7b403c9 (fork-network commit)
+#   4. You discover the action and run `gh actions-pin` for the first time
+#   5. Lockfile records 7b403c9 — the ATTACKER's SHA. You never knew ea53476.
+#   6. You run `gh actions-pin check` → ???
 #
 # You're pinning for the first time AFTER the attack. There's no prior
 # known-good SHA to compare against. TAMPERED can't fire — there's nothing
 # to tamper relative to.
 #
 # RESULT:  COMPLETELY INVISIBLE ✓ (false negative)
-#          ✓ NOT TAMPERED — pinned SHA matches live resolution (both are 614a37a)
+#          ✓ NOT TAMPERED — pinned SHA matches live resolution (both are 7b403c9)
 #          ✓ REACHABLE    — tag points directly at the pinned SHA ("identical")
-#          Reachability can't help here: the tag IS the orphan commit.
+#          Reachability can't help here: the tag IS the fork commit.
 #          There's no "expected" lineage to compare against.
 #
 # BOTTOM LINE: Pinning is not a security guarantee at the moment of first
@@ -26,7 +28,8 @@ name: "4: Never pinned — walking into a compromised repo"
 # lineage checking can save you — you need out-of-band verification
 # (attestations, code review, trusted release channels).
 #
-# DEMO:    https://github.com/nodeselector/actions-test-fixtures/commit/614a37a
+# FORK:    https://github.com/choam-io/actions-test-fixtures-fork
+# PAYLOAD: https://github.com/choam-io/actions-test-fixtures-fork/commit/7b403c9
 #
 # Run:     gh actions-pin check .github/workflows/4-never-pinned-pwned.yml
 # =============================================================================
@@ -47,5 +50,5 @@ jobs:
 # The lockfile recorded the attacker's SHA because that's what the tag resolved to.
 dependencies:
   - github.com/actions/checkout@v4:sha1-34e114876b0b11c390a56381ad16ebd13914f8d5
-  # Pinned AFTER the attack — attacker's orphan SHA is all you've ever known
-  - github.com/nodeselector/actions-test-fixtures/nested-composite@tampered:sha1-614a37a63d1a75476792a8781b55983a9d9bcb80
+  # Pinned AFTER the attack — attacker's fork-network SHA is all you've ever known
+  - github.com/nodeselector/actions-test-fixtures/nested-composite@tampered:sha1-7b403c9ec14bd3ae0bbf793c2bee8815a7ac920a

--- a/demo/workflows-pwned/4-never-pinned-pwned.yml
+++ b/demo/workflows-pwned/4-never-pinned-pwned.yml
@@ -1,4 +1,4 @@
-name: "4: Never pinned — walking into a compromised repo"
+name: "4: Never pinned — fork injection caught even without prior baseline"
 
 # =============================================================================
 # ATTACKER CAPABILITY: Write access to move tags (attack already happened)
@@ -7,26 +7,37 @@ name: "4: Never pinned — walking into a compromised repo"
 #   2. Attacker forked the repo (choam-io/actions-test-fixtures-fork), pushed
 #      a malicious commit (7b403c9) to their fork's attacker-payload branch
 #   3. Attacker moved @tampered tag to 7b403c9 (fork-network commit)
-#   4. You discover the action and run `gh actions-pin` for the first time
-#   5. Lockfile records 7b403c9 — the ATTACKER's SHA. You never knew ea53476.
-#   6. You run `gh actions-pin check` → ALL CLEAR
+#   4. You discover the action and try `gh actions-pin` for the first time
+#      → BLOCKED: pin-time reachability check detects impostor commit
 #
-# You're pinning for the first time AFTER the attack. There's no prior
-# known-good SHA to compare against.
+# With the branch_commits reachability check, this scenario is now caught
+# at TWO points:
 #
-# RESULT:  COMPLETELY INVISIBLE ✓ (false negative)
-#          ✓ NOT TAMPERED — pinned SHA matches live resolution (both 7b403c9)
-#          ✓ REACHABLE    — tag points directly at the pinned SHA ("identical")
+# PIN TIME:
+#   `gh actions-pin` resolves @tampered → 7b403c9, runs
+#   CheckReachabilityAll before writing the lockfile, discovers
+#   7b403c9 is not on any branch → refuses to pin. You never get a
+#   lockfile with the attacker's SHA.
 #
-# Pinning establishes a BASELINE, not a guarantee of legitimacy. The
-# lockfile can only detect CHANGES from that baseline. If you walk into
-# a compromised repo, the malicious state becomes your known-good state.
-# No amount of SHA comparison or lineage checking can save you — you
-# need out-of-band verification (attestations, code review, trusted
-# release channels).
+# CHECK TIME (if lockfile was created by older version):
+#   This fixture simulates a lockfile that was created before pin-time
+#   checks existed. Even so, `gh actions-pin check` catches it:
+#
+# RESULT:  CAUGHT ✗
+#          ✓ NOT TAMPERED    — pinned SHA matches live resolution (both 7b403c9)
+#          ✗ IMPOSTER_COMMIT — 7b403c9 is not on any branch in
+#                              nodeselector/actions-test-fixtures
+#                              (fork-network commit detected)
+#
+# This is a major improvement over the old compare-API approach. The
+# compare API only detected tag MOVEMENT (SHA mismatch). If there was
+# no prior baseline, there was no mismatch to detect. branch_commits
+# asks a different question: "does this commit belong to this repo?"
+# Fork-network commits don't — regardless of whether you have a
+# prior known-good SHA.
 #
 # FORK:    https://github.com/choam-io/actions-test-fixtures-fork
-# PAYLOAD: https://github.com/choam-io/actions-test-fixtures-fork/commit/7b403c9
+# PAYLOAD: https://github.com/nodeselector/actions-test-fixtures/commit/7b403c9
 #
 # Run:     gh actions-pin check demo/workflows-pwned/4-never-pinned-pwned.yml
 # =============================================================================

--- a/demo/workflows-pwned/4-never-pinned-pwned.yml
+++ b/demo/workflows-pwned/4-never-pinned-pwned.yml
@@ -6,32 +6,29 @@ name: "4: Never pinned — walking into a compromised repo"
 #   1. Maintainer released @tampered → ea53476 (legitimate)
 #   2. Attacker forked the repo (choam-io/actions-test-fixtures-fork), pushed
 #      a malicious commit (7b403c9) to their fork's attacker-payload branch
-#   3. Attacker moved tag to 7b403c9 (fork-network commit)
+#   3. Attacker moved @tampered tag to 7b403c9 (fork-network commit)
 #   4. You discover the action and run `gh actions-pin` for the first time
 #   5. Lockfile records 7b403c9 — the ATTACKER's SHA. You never knew ea53476.
-#   6. You run `gh actions-pin check` → ???
+#   6. You run `gh actions-pin check` → ALL CLEAR
 #
 # You're pinning for the first time AFTER the attack. There's no prior
-# known-good SHA to compare against. TAMPERED can't fire — there's nothing
-# to tamper relative to.
+# known-good SHA to compare against.
 #
 # RESULT:  COMPLETELY INVISIBLE ✓ (false negative)
-#          ✓ NOT TAMPERED — pinned SHA matches live resolution (both are 7b403c9)
+#          ✓ NOT TAMPERED — pinned SHA matches live resolution (both 7b403c9)
 #          ✓ REACHABLE    — tag points directly at the pinned SHA ("identical")
-#          Reachability can't help here: the tag IS the fork commit.
-#          There's no "expected" lineage to compare against.
 #
-# BOTTOM LINE: Pinning is not a security guarantee at the moment of first
-# pin. It establishes a baseline. The lockfile can only detect CHANGES
-# from that baseline. If you walk into a compromised repo, the malicious
-# state becomes your known-good state. No amount of SHA comparison or
-# lineage checking can save you — you need out-of-band verification
-# (attestations, code review, trusted release channels).
+# Pinning establishes a BASELINE, not a guarantee of legitimacy. The
+# lockfile can only detect CHANGES from that baseline. If you walk into
+# a compromised repo, the malicious state becomes your known-good state.
+# No amount of SHA comparison or lineage checking can save you — you
+# need out-of-band verification (attestations, code review, trusted
+# release channels).
 #
 # FORK:    https://github.com/choam-io/actions-test-fixtures-fork
 # PAYLOAD: https://github.com/choam-io/actions-test-fixtures-fork/commit/7b403c9
 #
-# Run:     gh actions-pin check .github/workflows/4-never-pinned-pwned.yml
+# Run:     gh actions-pin check demo/workflows-pwned/4-never-pinned-pwned.yml
 # =============================================================================
 
 on:

--- a/demo/workflows-pwned/5-pinned-before-update.yml
+++ b/demo/workflows-pwned/5-pinned-before-update.yml
@@ -1,25 +1,32 @@
-name: "5: Pinned before routine update — tag moved forward in lineage"
+name: "5: Pinned before routine update — legitimate tag movement"
 
 # =============================================================================
-# SCENARIO: Legitimate upstream release
+# SCENARIO: Legitimate upstream release (not an attack)
 # TIMELINE:
 #   1. Maintainer releases @updated → 38b3412 (legitimate)
 #   2. You pin: lockfile records 38b3412 ✓
 #   3. Maintainer pushes a new commit, moves @updated → ea53476 (descendant)
-#   4. You run `gh actions-pin check` → REF_MOVED detected
+#   4. You run `gh actions-pin check` → REF_MOVED
 #
-# This is the normal case: a maintainer cuts a new release and moves the tag
-# forward. The new SHA is a descendant of the pinned SHA — same lineage,
-# just newer. The compare link lets you review what changed.
+# The normal case: a maintainer cuts a new release and moves the tag
+# forward. The new SHA (ea53476) is a descendant of the pinned SHA
+# (38b3412) — same lineage, just newer.
 #
-# RESULT:  REF_MOVED ⚠ (informational)
+# RESULT:  REF_MOVED ⚠ (informational, not an attack)
 #          ✗ REF_MOVED  — live SHA (ea53476) ≠ pinned SHA (38b3412)
-#          ✓ REACHABLE  — new SHA is a descendant of the pinned SHA
+#          ✓ REACHABLE  — pinned SHA is an ancestor of the new position
+#                         (tag moved forward in the same lineage)
 #
-# The lockfile detects the tag moved but lineage is intact. Review the diff,
-# then `gh actions-pin upgrade` to accept the new version.
+# The compare link lets you review what changed. Use `gh actions-pin
+# upgrade` to accept the new version and update the lockfile.
 #
-# DEMO:    https://github.com/nodeselector/actions-test-fixtures/compare/38b3412adcb7afb4a061c519513e45cbaf4a1cec...ea53476fdc172d8552df5af9658a45a367e4f41d
+# CONTRAST WITH SCENARIO 1:
+#   Both show ref_moved with reachability passing. The difference is
+#   scenario 1 is a fork injection (attacker built on real history)
+#   while this is a genuine release. The lockfile can't distinguish
+#   these — both have valid lineage. You must review the diff.
+#
+# DEMO:    https://github.com/nodeselector/actions-test-fixtures/compare/38b3412...ea53476
 #
 # Run:     gh actions-pin check demo/workflows-pwned/5-pinned-before-update.yml
 # =============================================================================

--- a/demo/workflows-pwned/5-pinned-before-update.yml
+++ b/demo/workflows-pwned/5-pinned-before-update.yml
@@ -6,25 +6,27 @@ name: "5: Pinned before routine update — legitimate tag movement"
 #   1. Maintainer releases @updated → 38b3412 (legitimate)
 #   2. You pin: lockfile records 38b3412 ✓
 #   3. Maintainer pushes a new commit, moves @updated → ea53476 (descendant)
-#   4. You run `gh actions-pin check` → REF_MOVED
+#   4. You run `gh actions-pin check` → REF_MOVED ⚠
 #
 # The normal case: a maintainer cuts a new release and moves the tag
 # forward. The new SHA (ea53476) is a descendant of the pinned SHA
-# (38b3412) — same lineage, just newer.
+# (38b3412) — same lineage, just newer. ea53476 is on branches of the
+# upstream repo, so branch_commits confirms it's reachable.
 #
-# RESULT:  REF_MOVED ⚠ (informational, not an attack)
-#          ✗ REF_MOVED  — live SHA (ea53476) ≠ pinned SHA (38b3412)
-#          ✓ REACHABLE  — pinned SHA is an ancestor of the new position
-#                         (tag moved forward in the same lineage)
+# RESULT:  WARNING ONLY ⚠ (informational, not an attack)
+#          ⚠ REF_MOVED — live SHA (ea53476) ≠ pinned SHA (38b3412)
+#          ✓ REACHABLE — ea53476 is on branch(es) in the upstream repo
 #
-# The compare link lets you review what changed. Use `gh actions-pin
-# upgrade` to accept the new version and update the lockfile.
+# REF_MOVED is a warning, not an error. The check passes — your lockfile
+# is still valid, just behind upstream. Use `gh actions-pin upgrade` to
+# accept the new version and update the lockfile.
 #
 # CONTRAST WITH SCENARIO 1:
-#   Both show ref_moved with reachability passing. The difference is
-#   scenario 1 is a fork injection (attacker built on real history)
-#   while this is a genuine release. The lockfile can't distinguish
-#   these — both have valid lineage. You must review the diff.
+#   Both show REF_MOVED. The difference: scenario 1's new SHA (7b403c9)
+#   is a fork-network commit with no branches in the upstream repo →
+#   IMPOSTER_COMMIT fires. Here, the new SHA is on a real branch →
+#   reachability passes. branch_commits distinguishes the two cases
+#   that the old compare-API approach could not.
 #
 # DEMO:    https://github.com/nodeselector/actions-test-fixtures/compare/38b3412...ea53476
 #

--- a/internal/doctor/apply.go
+++ b/internal/doctor/apply.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/github/gh-actions-pin/internal/lockfile"
+	"github.com/github/gh-actions-pin/internal/resolver"
 )
 
 // isSHARef returns true if ref looks like a full commit SHA (40 or 64 hex chars).
@@ -30,6 +31,24 @@ func (rem *Remediator) applyPin(wr WorkflowReport) error {
 	deps, err := rem.resolver.ResolveAllRecursive(wr.ActionRefs)
 	if err != nil {
 		return fmt.Errorf("resolving actions: %w", err)
+	}
+
+	// Check for impostor commits at pin time — don't let fork-network
+	// commits get pinned in the first place. Fail closed: if we can't
+	// verify reachability (e.g. branch_commits returns 429), refuse to
+	// pin rather than silently accepting a potentially poisoned commit.
+	reachResults := rem.resolver.CheckReachabilityAll(deps)
+	for _, rr := range reachResults {
+		switch rr.Status {
+		case resolver.Unreachable:
+			rem.output.Error("%s/%s@%s: %s", rr.Owner, rr.Repo, rr.Ref, rr.Detail)
+			rem.Alerted++
+			return fmt.Errorf("refusing to pin: impostor commit detected for %s/%s@%s", rr.Owner, rr.Repo, rr.Ref)
+		case resolver.ReachabilityUnknown:
+			rem.output.Error("%s/%s@%s: could not verify commit reachability — %s", rr.Owner, rr.Repo, rr.Ref, rr.Detail)
+			rem.Alerted++
+			return fmt.Errorf("refusing to pin: cannot verify reachability for %s/%s@%s (try again later)", rr.Owner, rr.Repo, rr.Ref)
+		}
 	}
 
 	// Narrow mutable version tags (v4, v4.2) to specific patch tags (v4.2.1)

--- a/internal/doctor/compare.go
+++ b/internal/doctor/compare.go
@@ -37,6 +37,7 @@ func compareSnapshots(path string, existing, live []lockfile.Dependency, directN
 				Dependency:   &pinned,
 				Detail:       fmt.Sprintf("pinned %s but ref now resolves to %s", pinned.SHA[:12], resolvedCopy.SHA[:12]),
 				Remediation:  fmt.Sprintf("update to %s with `gh actions-pin upgrade`", resolvedCopy.SHA[:12]),
+				LiveSHA:      resolvedCopy.SHA,
 			})
 		}
 	}

--- a/internal/doctor/compare.go
+++ b/internal/doctor/compare.go
@@ -33,7 +33,7 @@ func compareSnapshots(path string, existing, live []lockfile.Dependency, directN
 			findings = append(findings, Finding{
 				WorkflowPath: path,
 				Category:     CategoryRefMoved,
-				Severity:     SeverityError,
+				Severity:     SeverityWarning,
 				Dependency:   &pinned,
 				Detail:       fmt.Sprintf("pinned %s but ref now resolves to %s", pinned.SHA[:12], resolvedCopy.SHA[:12]),
 				Remediation:  fmt.Sprintf("update to %s with `gh actions-pin upgrade`", resolvedCopy.SHA[:12]),

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -222,7 +222,7 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 				Category:     CategoryImposterCommit,
 				Severity:     SeverityError,
 				Dependency:   depPtr,
-				Detail:       fmt.Sprintf("SHA %s is NOT reachable from ref — possible fork injection", rr.SHA[:12]),
+				Detail:       rr.Detail,
 			})
 		case resolver.ReachabilityUnknown:
 			isTransitive := !directNWOs[rr.Owner+"/"+rr.Repo]

--- a/internal/doctor/finding.go
+++ b/internal/doctor/finding.go
@@ -104,7 +104,7 @@ func (r *WorkflowReport) CountByCategory(c Category) int {
 // IsValid returns true for findings that don't represent integrity violations.
 func (f *Finding) IsValid() bool {
 	switch f.Category {
-	case CategoryValid, CategoryRunOnly, CategorySHAAsRef:
+	case CategoryValid, CategoryRunOnly, CategorySHAAsRef, CategoryRefMoved:
 		return true
 	case CategoryNotPinned:
 		return f.ActionRef == nil // workflow-level is a warning
@@ -117,6 +117,8 @@ func (f *Finding) IsValid() bool {
 func (f *Finding) IsWarning() bool {
 	switch {
 	case f.Category == CategorySHAAsRef:
+		return true
+	case f.Category == CategoryRefMoved:
 		return true
 	case f.Category == CategoryValid && f.Severity == SeverityWarning:
 		return true

--- a/internal/doctor/finding.go
+++ b/internal/doctor/finding.go
@@ -54,6 +54,8 @@ type Finding struct {
 	Detail string
 	// Remediation describes what doctor can do about it.
 	Remediation string
+	// LiveSHA is the current upstream SHA when it differs from the pinned SHA (e.g. REF_MOVED).
+	LiveSHA string
 }
 
 // InventoryEntry describes a single dependency with context.

--- a/internal/doctor/finding.go
+++ b/internal/doctor/finding.go
@@ -81,7 +81,7 @@ type WorkflowReport struct {
 func (r *WorkflowReport) NeedsAttention() bool {
 	for _, f := range r.Findings {
 		switch f.Category {
-		case CategoryValid, CategoryRunOnly, CategoryMisleadingSHA:
+		case CategoryValid, CategoryRunOnly, CategoryMisleadingSHA, CategoryRefMoved:
 			continue
 		default:
 			return true

--- a/internal/doctor/remediate.go
+++ b/internal/doctor/remediate.go
@@ -37,7 +37,7 @@ type Remediator struct {
 	Skipped     int
 	Alerted     int
 	SkippedDeps []string // unique dep keys that were skipped (for summary)
-	AlertedDeps []string // unique dep keys that were alerted (security issues)
+	AlertedDeps []string // dep keys that triggered security alerts (deduplicated)
 }
 
 // NewRemediator creates a new Remediator.
@@ -105,6 +105,16 @@ func (rem *Remediator) depKey(f Finding) string {
 		return f.ActionRef.FullName() + "@" + f.ActionRef.Ref
 	}
 	return ""
+}
+
+func (rem *Remediator) addAlertedDep(f Finding) {
+	key := rem.depKey(f)
+	for _, k := range rem.AlertedDeps {
+		if k == key {
+			return
+		}
+	}
+	rem.AlertedDeps = append(rem.AlertedDeps, key)
 }
 
 // skipDep records a dependency as skipped (needs interactive resolution).
@@ -208,13 +218,13 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 			rem.output.Error("%s", finding.Detail)
 			rem.output.Hint("This may indicate a fork-network injection attack. Do not auto-fix.")
 			rem.Alerted++
-			rem.AlertedDeps = append(rem.AlertedDeps, rem.depKey(finding))
+			rem.addAlertedDep(finding)
 
 		case CategoryMisleadingSHA:
 			rem.output.Error("MISLEADING_SHA %s: %s", rem.depKey(finding), finding.Detail)
 			rem.output.Hint("This ref may be a deceptive branch or tag name masquerading as a commit hash.")
 			rem.Alerted++
-			rem.AlertedDeps = append(rem.AlertedDeps, rem.depKey(finding))
+			rem.addAlertedDep(finding)
 		}
 	}
 

--- a/internal/doctor/remediate.go
+++ b/internal/doctor/remediate.go
@@ -37,6 +37,7 @@ type Remediator struct {
 	Skipped     int
 	Alerted     int
 	SkippedDeps []string // unique dep keys that were skipped (for summary)
+	AlertedDeps []string // unique dep keys that were alerted (security issues)
 }
 
 // NewRemediator creates a new Remediator.
@@ -207,11 +208,13 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 			rem.output.Error("%s", finding.Detail)
 			rem.output.Hint("This may indicate a fork-network injection attack. Do not auto-fix.")
 			rem.Alerted++
+			rem.AlertedDeps = append(rem.AlertedDeps, rem.depKey(finding))
 
 		case CategoryMisleadingSHA:
 			rem.output.Error("MISLEADING_SHA %s: %s", rem.depKey(finding), finding.Detail)
 			rem.output.Hint("This ref may be a deceptive branch or tag name masquerading as a commit hash.")
 			rem.Alerted++
+			rem.AlertedDeps = append(rem.AlertedDeps, rem.depKey(finding))
 		}
 	}
 

--- a/internal/doctor/remediate.go
+++ b/internal/doctor/remediate.go
@@ -377,9 +377,8 @@ func (rem *Remediator) handleNotPinned(wr WorkflowReport) error {
 }
 
 // offerDefaultBranch checks each action ref for same-owner repos (internal
-// actions) and switches bare SHA or non-semver refs to the default branch.
-// For refs that already look like a version tag, offers a choice.
-// Uses session memory so the user is only asked once per owner/repo.
+// actions) and switches bare SHA refs to the default branch. Named refs
+// (tags, branches, versions) are preserved as-is.
 // Returns a (possibly modified) copy of the WorkflowReport with updated refs.
 func (rem *Remediator) offerDefaultBranch(wr WorkflowReport) WorkflowReport {
 	updated := make([]lockfile.ActionRef, 0, len(wr.ActionRefs))
@@ -388,8 +387,6 @@ func (rem *Remediator) offerDefaultBranch(wr WorkflowReport) WorkflowReport {
 			updated = append(updated, ref)
 			continue
 		}
-
-		nwo := ref.Owner + "/" + ref.Repo
 
 		info, err := rem.tagLister.GetRepoInfo(ref.Owner, ref.Repo)
 		if err != nil {
@@ -403,31 +400,16 @@ func (rem *Remediator) offerDefaultBranch(wr WorkflowReport) WorkflowReport {
 			continue
 		}
 
-		// Session memory: reuse prior choice for this repo, but only for
-		// non-version refs. Version-ish refs must match the workflow uses: line.
-		if !LooksLikeVersion(ref.Ref) {
-			if priorRef, ok := rem.state.internalRefChoices[nwo]; ok {
-				if priorRef != ref.Ref {
-					rem.output.Detail("  ↳ reusing prior choice for %s: %s", ref.FullName(), priorRef)
-					ref.Ref = priorRef
-				}
-				updated = append(updated, ref)
-				continue
-			}
-		}
-
-		// Bare SHA or non-version ref on a same-owner repo → use default branch.
-		if isSHARef(ref.Ref) || !LooksLikeVersion(ref.Ref) {
+		// Bare SHA → swap to default branch. Named refs stay as-is.
+		if isSHARef(ref.Ref) {
 			rem.output.Detail("  %s: using %s (default branch) instead of %s",
 				ref.FullName(), info.DefaultBranch, ref.Ref)
 			ref.Ref = info.DefaultBranch
-			rem.state.internalRefChoices[nwo] = info.DefaultBranch
 			updated = append(updated, ref)
 			continue
 		}
 
-		// Version-ish ref on a same-owner repo — pin as-is. Changing the ref
-		// here without rewriting the workflow uses: line would create a mismatch.
+		// Named ref (tag, branch, version) — preserve what the user wrote.
 		updated = append(updated, ref)
 	}
 

--- a/internal/doctor/remediate.go
+++ b/internal/doctor/remediate.go
@@ -153,7 +153,7 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 
 	first := true
 	for _, finding := range wr.Findings {
-		if finding.Category == CategoryValid || finding.Category == CategoryRunOnly {
+		if finding.Category == CategoryValid || finding.Category == CategoryRunOnly || finding.Category == CategoryRefMoved {
 			continue
 		}
 
@@ -202,11 +202,6 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 			if err := rem.handleRefChanged(wr, finding); err != nil {
 				return err
 			}
-
-		case CategoryRefMoved:
-			rem.output.Error("%s: %s", finding.Dependency.Key(), finding.Detail)
-			rem.output.Hint("Ref has moved — investigate before updating. Use `gh actions-pin upgrade` manually.")
-			rem.Alerted++
 
 		case CategoryImposterCommit:
 			rem.output.Error("%s", finding.Detail)

--- a/internal/resolver/reachability_integration_test.go
+++ b/internal/resolver/reachability_integration_test.go
@@ -108,15 +108,15 @@ func TestIntegration_Unreachable_NonexistentSHA(t *testing.T) {
 }
 
 // TestIntegration_Unreachable_ForkNetworkInjection tests that a fork commit
-// used as a pinned SHA against a clean tag is detected as unreachable. This
-// catches the simple case where merge_base(forkSHA, v1) != forkSHA.
+// used as a pinned SHA against a clean tag is detected as unreachable.
+// branch_commits returns no branches for fork-network commits in the upstream repo.
 func TestIntegration_Unreachable_ForkNetworkInjection(t *testing.T) {
 	skipWithoutAuth(t)
 	r := newLiveResolver(t)
 
 	result := r.CheckReachability(fixtureOwner, fixtureRepo, forkAttackerSHA, "v1")
 	assert.Equal(t, Unreachable, result.Status,
-		"fork-network SHA should NOT be reachable via merge-base identity check: %+v", result)
+		"fork-network SHA should NOT be reachable via branch_commits check: %+v", result)
 }
 
 // TestIntegration_Unreachable_ForkNetworkInjection_PreservedLineage is the
@@ -127,10 +127,8 @@ func TestIntegration_Unreachable_ForkNetworkInjection(t *testing.T) {
 // upstream parent (fbe0421), so it PRESERVES LINEAGE — the old pinned SHA
 // (v1SHA / ea53476) IS an ancestor of the fork commit.
 //
-// The ancestry check alone (compare(v1SHA...tampered)) would pass because
-// merge_base == v1SHA. The containment check (compare(HEAD...tampered)) catches
-// this because the fork commit is "diverged" from the default branch — it's not
-// in this repository's history, only visible through the fork network.
+// The branch_commits endpoint catches this because fork-network commits have
+// no branches in the upstream repo, regardless of their ancestry.
 func TestIntegration_Unreachable_ForkNetworkInjection_PreservedLineage(t *testing.T) {
 	skipWithoutAuth(t)
 	r := newLiveResolver(t)

--- a/internal/resolver/reachability_integration_test.go
+++ b/internal/resolver/reachability_integration_test.go
@@ -22,9 +22,9 @@ const (
 	fixtureOwner = "nodeselector"
 	fixtureRepo  = "actions-test-fixtures"
 
-	// HEAD of main, also where tag v1 points
-	headSHA = "ea53476fdc172d8552df5af9658a45a367e4f41d"
-	// Parent of HEAD — in v1's lineage but not at HEAD (tag-drift scenario)
+	// Where tag v1 points (was HEAD of main at time of fixture creation)
+	v1SHA = "ea53476fdc172d8552df5af9658a45a367e4f41d"
+	// Parent of v1 — in v1's lineage but not at v1 HEAD (tag-drift scenario)
 	parentSHA = "38b3412adcb7afb4a061c519513e45cbaf4a1cec"
 	// Root commit of main (oldest ancestor)
 	rootSHA = "5f13f2a16a43112afcd6e1bcc29c418176894d53"
@@ -32,8 +32,10 @@ const (
 	orphanSHA = "614a37a63d1a75476792a8781b55983a9d9bcb80"
 	// A SHA that doesn't exist anywhere
 	fakeSHA = "0000000000000000000000000000000000000000"
-	// Commit on choam-io/actions-test-fixtures-fork attacker-payload branch
-	// This SHA exists in the fork network but NOT in the upstream repo's lineage
+	// Commit on choam-io/actions-test-fixtures-fork attacker-payload branch.
+	// This SHA exists in the fork network but NOT in the upstream repo's branches.
+	// Tag "tampered" in the upstream repo has been moved to point at this commit,
+	// simulating a fork-network injection attack with preserved lineage.
 	forkAttackerSHA = "7b403c9ec14bd3ae0bbf793c2bee8815a7ac920a"
 )
 
@@ -59,7 +61,7 @@ func TestIntegration_Reachable_HeadSHA(t *testing.T) {
 	skipWithoutAuth(t)
 	r := newLiveResolver(t)
 
-	result := r.CheckReachability(fixtureOwner, fixtureRepo, headSHA, "v1")
+	result := r.CheckReachability(fixtureOwner, fixtureRepo, v1SHA, "v1")
 	assert.Equal(t, Reachable, result.Status, "HEAD SHA should be reachable from v1: %+v", result)
 }
 
@@ -105,14 +107,9 @@ func TestIntegration_Unreachable_NonexistentSHA(t *testing.T) {
 	assert.Equal(t, Unreachable, result.Status, "fake SHA should be unreachable: %+v", result)
 }
 
-// TestIntegration_Unreachable_ForkNetworkInjection is the KEY test proving
-// the Compare API merge-base identity check detects fork-network injection.
-//
-// The Compare API operates on the fork-network-shared object store, so the
-// fork commit IS visible. However, the merge_base_commit for a fork commit
-// will NOT be the fork SHA itself — it will be the actual common ancestor in
-// the upstream history. This mismatch (merge_base != pinnedSHA) is the signal
-// that detects the imposter commit.
+// TestIntegration_Unreachable_ForkNetworkInjection tests that a fork commit
+// used as a pinned SHA against a clean tag is detected as unreachable. This
+// catches the simple case where merge_base(forkSHA, v1) != forkSHA.
 func TestIntegration_Unreachable_ForkNetworkInjection(t *testing.T) {
 	skipWithoutAuth(t)
 	r := newLiveResolver(t)
@@ -122,16 +119,45 @@ func TestIntegration_Unreachable_ForkNetworkInjection(t *testing.T) {
 		"fork-network SHA should NOT be reachable via merge-base identity check: %+v", result)
 }
 
-// TestIntegration_SHAAsRef_ReturnsUnknown verifies that when the ref is itself
-// a raw SHA (the anti-pattern), we return Unknown with guidance to pin to a tag.
-func TestIntegration_SHAAsRef_ReturnsUnknown(t *testing.T) {
+// TestIntegration_Unreachable_ForkNetworkInjection_PreservedLineage is the
+// critical test for tag manipulation attacks with preserved lineage.
+//
+// Scenario: tag "tampered" has been moved to point at forkAttackerSHA (7b403c9),
+// a commit in choam-io/actions-test-fixtures-fork. This fork commit has a real
+// upstream parent (fbe0421), so it PRESERVES LINEAGE — the old pinned SHA
+// (v1SHA / ea53476) IS an ancestor of the fork commit.
+//
+// The ancestry check alone (compare(v1SHA...tampered)) would pass because
+// merge_base == v1SHA. The containment check (compare(HEAD...tampered)) catches
+// this because the fork commit is "diverged" from the default branch — it's not
+// in this repository's history, only visible through the fork network.
+func TestIntegration_Unreachable_ForkNetworkInjection_PreservedLineage(t *testing.T) {
 	skipWithoutAuth(t)
 	r := newLiveResolver(t)
 
-	result := r.CheckReachability(fixtureOwner, fixtureRepo, headSHA, headSHA)
-	assert.Equal(t, ReachabilityUnknown, result.Status,
-		"SHA-as-ref should return Unknown: %+v", result)
-	assert.Contains(t, result.Detail, "pin to a tag")
+	// v1SHA (ea53476) was the original pinned SHA.
+	// Tag "tampered" now points to forkAttackerSHA (7b403c9) which descends
+	// from v1SHA through the fork network. Without the containment check,
+	// this would incorrectly pass as Reachable.
+	result := r.CheckReachability(fixtureOwner, fixtureRepo, v1SHA, "tampered")
+	assert.Equal(t, Unreachable, result.Status,
+		"fork commit via tag manipulation should be detected even with preserved lineage: %+v", result)
+	assert.Contains(t, result.Detail, "fork-network",
+		"detail should mention fork-network injection: %s", result.Detail)
+}
+
+// TestIntegration_SHAAsRef_ReturnsReachableWithWarning verifies that when the
+// ref is itself a raw SHA (the anti-pattern), we return Reachable with guidance
+// to pin to a tag instead, since origin can't be verified at job runtime.
+func TestIntegration_SHAAsRef_ReturnsReachableWithWarning(t *testing.T) {
+	skipWithoutAuth(t)
+	r := newLiveResolver(t)
+
+	result := r.CheckReachability(fixtureOwner, fixtureRepo, v1SHA, v1SHA)
+	assert.Equal(t, Reachable, result.Status,
+		"SHA-as-ref with valid commit should return Reachable: %+v", result)
+	assert.Contains(t, result.Detail, "bare SHA",
+		"detail should warn about bare SHA pinning: %s", result.Detail)
 }
 
 // TestIntegration_CacheConsistency verifies that repeated calls return
@@ -140,8 +166,8 @@ func TestIntegration_CacheConsistency(t *testing.T) {
 	skipWithoutAuth(t)
 	r := newLiveResolver(t)
 
-	r1 := r.CheckReachability(fixtureOwner, fixtureRepo, headSHA, "v1")
-	r2 := r.CheckReachability(fixtureOwner, fixtureRepo, headSHA, "v1")
+	r1 := r.CheckReachability(fixtureOwner, fixtureRepo, v1SHA, "v1")
+	r2 := r.CheckReachability(fixtureOwner, fixtureRepo, v1SHA, "v1")
 	assert.Equal(t, r1.Status, r2.Status)
 	assert.Equal(t, "cached", r2.Detail, "second call should come from cache")
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -54,6 +54,8 @@ type ReachabilityResult struct {
 type Resolver struct {
 	client            *api.GraphQLClient
 	restClient        *api.RESTClient
+	httpTransport     http.RoundTripper // raw transport for non-API requests (branch_commits)
+	authToken         string            // auth token for non-API requests
 	hostname          string
 	MaxRecursionDepth int
 	cache             map[string]resolvedEntry
@@ -104,6 +106,8 @@ func NewWithOptions(opts api.ClientOptions) (*Resolver, error) {
 	return &Resolver{
 		client:            client,
 		restClient:        restClient,
+		httpTransport:     opts.Transport,
+		authToken:         opts.AuthToken,
 		hostname:          hostname,
 		MaxRecursionDepth: DefaultMaxRecursionDepth,
 		cache:             make(map[string]resolvedEntry),
@@ -199,6 +203,27 @@ func (r *Resolver) CheckReachability(owner, repo, sha, ref string) ReachabilityR
 	status, detail := r.apiReachabilityCheck(owner, repo, sha, ref)
 	result.Status = status
 	result.Detail = detail
+
+	// When the ancestry check passes for a named ref, verify the ref's
+	// current target is actually contained in a branch of this repository
+	// — not just reachable through the fork network. The Compare API
+	// transparently spans the fork network, so a fork commit that preserves
+	// lineage (normal git commit with an upstream parent) passes the
+	// ancestry check. We catch this using the undocumented branch_commits
+	// endpoint (same approach as zizmor): if the resolved SHA has no
+	// branches in this repo, it's a fork-network commit.
+	//
+	// See: https://docs.zizmor.sh/audits/#impostor-commit
+	if status == Reachable {
+		containStatus, containDetail := r.branchCommitsCheck(owner, repo, ref)
+		if containStatus == Unreachable {
+			result.Status = Unreachable
+			result.Detail = containDetail
+		}
+		// If containment check is Unknown (rate limit etc), keep the
+		// Reachable result — we don't downgrade on uncertainty.
+	}
+
 	if result.Status != ReachabilityUnknown {
 		r.reachCache[cacheKey] = result.Status
 	}
@@ -245,6 +270,80 @@ func (r *Resolver) apiReachabilityCheck(owner, repo, sha, ref string) (Reachabil
 		return Reachable, "ancestor of " + ref + " (compare: " + resp.Status + ")"
 	}
 	return Unreachable, fmt.Sprintf("merge base is %s, not the pinned SHA — likely a fork-network commit", resp.MergeBaseCommit.SHA[:12])
+}
+
+// branchCommitsResponse is the subset of the undocumented branch_commits
+// endpoint response we need. The endpoint lives on the web host (not the
+// API host) and returns which branches and tags contain a given commit.
+type branchCommitsResponse struct {
+	Branches []struct {
+		Branch string `json:"branch"`
+	} `json:"branches"`
+	Tags []string `json:"tags"`
+}
+
+// branchCommitsCheck uses the undocumented branch_commits endpoint (same
+// approach as zizmor) to verify that a ref's current target is contained in
+// at least one branch of the repository. Fork-network commits appear in the
+// fork network's commit graph but have branches=[] in the upstream repo.
+//
+// Flow: resolve ref → SHA via REST API, then GET /{owner}/{repo}/branch_commits/{sha}.
+func (r *Resolver) branchCommitsCheck(owner, repo, ref string) (ReachabilityStatus, string) {
+	// Step 1: resolve ref to its current SHA
+	var commitResp struct {
+		SHA string `json:"sha"`
+	}
+	commitPath := fmt.Sprintf("repos/%s/%s/commits/%s", owner, repo, url.PathEscape(ref))
+	if err := r.restClient.Get(commitPath, &commitResp); err != nil {
+		return ReachabilityUnknown, fmt.Sprintf("could not resolve ref %s: %s", ref, err)
+	}
+	if commitResp.SHA == "" {
+		return ReachabilityUnknown, fmt.Sprintf("could not resolve ref %s: empty SHA", ref)
+	}
+
+	// Step 2: call branch_commits on the web host (not the API host)
+	webHost := r.hostname
+	bcURL := fmt.Sprintf("https://%s/%s/%s/branch_commits/%s", webHost, owner, repo, commitResp.SHA)
+
+	req, err := http.NewRequest("GET", bcURL, nil)
+	if err != nil {
+		return ReachabilityUnknown, fmt.Sprintf("could not build branch_commits request: %s", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if r.authToken != "" {
+		req.Header.Set("Authorization", "token "+r.authToken)
+	}
+
+	transport := r.httpTransport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		return ReachabilityUnknown, fmt.Sprintf("branch_commits request failed: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ReachabilityUnknown, fmt.Sprintf("branch_commits returned HTTP %d", resp.StatusCode)
+	}
+
+	var bcResp branchCommitsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&bcResp); err != nil {
+		return ReachabilityUnknown, fmt.Sprintf("could not decode branch_commits response: %s", err)
+	}
+
+	if len(bcResp.Branches) == 0 {
+		return Unreachable, fmt.Sprintf(
+			"ref %s resolves to %s which is not on any branch in %s/%s — possible fork-network injection",
+			ref, commitResp.SHA[:12], owner, repo)
+	}
+
+	branchNames := make([]string, len(bcResp.Branches))
+	for i, b := range bcResp.Branches {
+		branchNames[i] = b.Branch
+	}
+	return Reachable, fmt.Sprintf("commit is on branch(es): %s", strings.Join(branchNames, ", "))
 }
 
 // CheckReachabilityAll runs reachability checks on a batch of dependencies,

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -61,7 +61,7 @@ type Resolver struct {
 	cache             map[string]resolvedEntry
 	latestRefCache    map[string]string
 	reachCache        map[string]ReachabilityStatus
-	bcCache           map[string]*branchCommitsResponse // owner/repo/sha → cached branch_commits response (nil = error/429)
+	bcCache           map[string]bcCacheEntry // owner/repo/sha → cached branch_commits result
 	// parentMap tracks child dep key → parent dep keys from last ResolveAllRecursive call.
 	parentMap map[string][]string
 	// checkReachFn overrides the default REST-based reachability check (for tests).
@@ -114,7 +114,7 @@ func NewWithOptions(opts api.ClientOptions) (*Resolver, error) {
 		cache:             make(map[string]resolvedEntry),
 		latestRefCache:    make(map[string]string),
 		reachCache:        make(map[string]ReachabilityStatus),
-		bcCache:           make(map[string]*branchCommitsResponse),
+		bcCache:           make(map[string]bcCacheEntry),
 	}, nil
 }
 
@@ -144,12 +144,6 @@ func (r *Resolver) SetCheckReachabilityFunc(fn func(owner, repo, sha, ref string
 // given ref within the repository. This catches fork-network injection where
 // a SHA exists in GitHub's shared object store but is not actually part of
 // the canonical repository's history.
-//
-// Uses the GitHub Compare API and checks merge_base identity:
-//   - merge_base == pinnedSHA → Reachable (SHA is a true ancestor of ref)
-//   - merge_base != pinnedSHA → Unreachable (fork/imposter commit)
-//   - 404 (no common ancestor or not found) → Unreachable
-//   - 403/429 (rate limit) or other error → Unknown
 //
 // CheckReachability verifies that a dependency's commit is reachable from a
 // branch in the repository, catching fork-network injection attacks.
@@ -220,6 +214,13 @@ type branchCommitsResponse struct {
 	Tags []string `json:"tags"`
 }
 
+// bcCacheEntry holds a cached branch_commits result. A nil resp with a non-empty
+// errDetail indicates a failed request (429, 500, network error, decode error).
+type bcCacheEntry struct {
+	resp      *branchCommitsResponse
+	errDetail string
+}
+
 // branchCommitsCheck uses the undocumented branch_commits endpoint (same
 // approach as zizmor) to verify that a ref's current target is contained in
 // at least one branch of the repository. Fork-network commits appear in the
@@ -256,16 +257,16 @@ func (r *Resolver) branchCommitsCheck(owner, repo, ref string) (ReachabilityStat
 	// Step 2: check bcCache for this SHA to avoid duplicate HTTP calls.
 	bcKey := owner + "/" + repo + "/" + commitResp.SHA
 	if cached, ok := r.bcCache[bcKey]; ok {
-		if cached == nil {
-			return ReachabilityUnknown, "branch_commits returned HTTP 429"
+		if cached.resp == nil {
+			return ReachabilityUnknown, cached.errDetail
 		}
-		if len(cached.Branches) == 0 {
+		if len(cached.resp.Branches) == 0 {
 			return Unreachable, fmt.Sprintf(
 				"ref %s resolves to %s which is not on any branch in %s/%s — possible fork-network injection",
 				ref, commitResp.SHA[:12], owner, repo)
 		}
-		branchNames := make([]string, len(cached.Branches))
-		for i, b := range cached.Branches {
+		branchNames := make([]string, len(cached.resp.Branches))
+		for i, b := range cached.resp.Branches {
 			branchNames[i] = b.Branch
 		}
 		return Reachable, fmt.Sprintf("commit is on branch(es): %s", strings.Join(branchNames, ", "))
@@ -290,22 +291,25 @@ func (r *Resolver) branchCommitsCheck(owner, repo, ref string) (ReachabilityStat
 	}
 	resp, err := transport.RoundTrip(req)
 	if err != nil {
-		r.bcCache[bcKey] = nil
-		return ReachabilityUnknown, fmt.Sprintf("branch_commits request failed: %s", err)
+		detail := fmt.Sprintf("branch_commits request failed: %s", err)
+		r.bcCache[bcKey] = bcCacheEntry{errDetail: detail}
+		return ReachabilityUnknown, detail
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		r.bcCache[bcKey] = nil
-		return ReachabilityUnknown, fmt.Sprintf("branch_commits returned HTTP %d", resp.StatusCode)
+		detail := fmt.Sprintf("branch_commits returned HTTP %d", resp.StatusCode)
+		r.bcCache[bcKey] = bcCacheEntry{errDetail: detail}
+		return ReachabilityUnknown, detail
 	}
 
 	var bcResp branchCommitsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&bcResp); err != nil {
-		r.bcCache[bcKey] = nil
-		return ReachabilityUnknown, fmt.Sprintf("could not decode branch_commits response: %s", err)
+		detail := fmt.Sprintf("could not decode branch_commits response: %s", err)
+		r.bcCache[bcKey] = bcCacheEntry{errDetail: detail}
+		return ReachabilityUnknown, detail
 	}
-	r.bcCache[bcKey] = &bcResp
+	r.bcCache[bcKey] = bcCacheEntry{resp: &bcResp}
 
 	if len(bcResp.Branches) == 0 {
 		return Unreachable, fmt.Sprintf(

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -61,6 +61,7 @@ type Resolver struct {
 	cache             map[string]resolvedEntry
 	latestRefCache    map[string]string
 	reachCache        map[string]ReachabilityStatus
+	bcCache           map[string]*branchCommitsResponse // owner/repo/sha → cached branch_commits response (nil = error/429)
 	// parentMap tracks child dep key → parent dep keys from last ResolveAllRecursive call.
 	parentMap map[string][]string
 	// checkReachFn overrides the default REST-based reachability check (for tests).
@@ -113,6 +114,7 @@ func NewWithOptions(opts api.ClientOptions) (*Resolver, error) {
 		cache:             make(map[string]resolvedEntry),
 		latestRefCache:    make(map[string]string),
 		reachCache:        make(map[string]ReachabilityStatus),
+		bcCache:           make(map[string]*branchCommitsResponse),
 	}, nil
 }
 
@@ -149,9 +151,14 @@ func (r *Resolver) SetCheckReachabilityFunc(fn func(owner, repo, sha, ref string
 //   - 404 (no common ancestor or not found) → Unreachable
 //   - 403/429 (rate limit) or other error → Unknown
 //
-// When ref is itself a raw SHA (the "uses: owner/repo@SHA" anti-pattern),
-// the compare becomes {sha}...{sha} which trivially returns "identical" and
-// cannot detect fork commits. In this case, a warning is returned instead.
+// CheckReachability verifies that a dependency's commit is reachable from a
+// branch in the repository, catching fork-network injection attacks.
+//
+// Uses the undocumented branch_commits endpoint (same approach as zizmor):
+// resolve ref → SHA, then check if that SHA appears on any branch. Fork
+// commits have branches=[] in the upstream repo.
+//
+// See: https://docs.zizmor.sh/audits/#impostor-commit
 func (r *Resolver) CheckReachability(owner, repo, sha, ref string) ReachabilityResult {
 	result := ReachabilityResult{
 		Owner: owner,
@@ -170,106 +177,37 @@ func (r *Resolver) CheckReachability(owner, repo, sha, ref string) ReachabilityR
 	// Allow tests to inject a fake implementation
 	if r.checkReachFn != nil {
 		result.Status, result.Detail = r.checkReachFn(owner, repo, sha, ref)
-		if result.Status != ReachabilityUnknown {
-			r.reachCache[cacheKey] = result.Status
-		}
+		r.reachCache[cacheKey] = result.Status
 		return result
 	}
 
-	// SHA-as-ref: compare/{sha}...{sha} is trivially identical and cannot
-	// detect fork commits. Instead, check against the repo's default branch
-	// which proves the commit exists in the canonical repo's history. Note:
-	// Note: runtime enforcement for bare-SHA refs is TBD — it's expensive.
+	// For bare-SHA refs, check the SHA directly. For named refs, resolve
+	// the ref to its current SHA first.
+	checkRef := ref
 	if lockfile.IsFullSHA(ref) {
-		status, detail := r.apiReachabilityCheck(owner, repo, sha, "HEAD")
-		switch status {
+		checkRef = sha
+	}
+
+	result.Status, result.Detail = r.branchCommitsCheck(owner, repo, checkRef)
+
+	// Annotate bare-SHA refs with guidance to prefer tags.
+	if lockfile.IsFullSHA(ref) {
+		switch result.Status {
 		case Reachable:
-			result.Status = Reachable
-			result.Detail = "pinned to a bare SHA; commit is reachable from default branch but origin cannot be verified at job runtime — prefer pinning to a tag"
-			r.reachCache[cacheKey] = result.Status
+			result.Detail = "pinned to a bare SHA; commit is on a branch but origin cannot be verified at job runtime — prefer pinning to a tag"
 		case Unreachable:
-			result.Status = Unreachable
-			result.Detail = "pinned to a bare SHA; commit is NOT reachable from default branch — possible fork-network commit"
-			r.reachCache[cacheKey] = result.Status
-		default:
-			result.Status = ReachabilityUnknown
+			result.Detail = "pinned to a bare SHA; commit is NOT on any branch — possible fork-network commit"
+		case ReachabilityUnknown:
 			result.Detail = fmt.Sprintf(
 				"pinned to a bare SHA — unable to verify commit origin (%s); pin to a tag instead: https://github.com/%s/%s/releases",
-				detail, owner, repo)
+				result.Detail, owner, repo)
 		}
-		return result
 	}
 
-	status, detail := r.apiReachabilityCheck(owner, repo, sha, ref)
-	result.Status = status
-	result.Detail = detail
-
-	// When the ancestry check passes for a named ref, verify the ref's
-	// current target is actually contained in a branch of this repository
-	// — not just reachable through the fork network. The Compare API
-	// transparently spans the fork network, so a fork commit that preserves
-	// lineage (normal git commit with an upstream parent) passes the
-	// ancestry check. We catch this using the undocumented branch_commits
-	// endpoint (same approach as zizmor): if the resolved SHA has no
-	// branches in this repo, it's a fork-network commit.
-	//
-	// See: https://docs.zizmor.sh/audits/#impostor-commit
-	if status == Reachable {
-		containStatus, containDetail := r.branchCommitsCheck(owner, repo, ref)
-		if containStatus == Unreachable {
-			result.Status = Unreachable
-			result.Detail = containDetail
-		}
-		// If containment check is Unknown (rate limit etc), keep the
-		// Reachable result — we don't downgrade on uncertainty.
-	}
-
-	if result.Status != ReachabilityUnknown {
-		r.reachCache[cacheKey] = result.Status
-	}
+	// Cache all results including Unknown — within a single CLI run, re-hitting
+	// the same endpoint after a 429 just makes the rate limit worse.
+	r.reachCache[cacheKey] = result.Status
 	return result
-}
-
-// compareResponse is the subset of the GitHub Compare API response we need.
-type compareResponse struct {
-	MergeBaseCommit struct {
-		SHA string `json:"sha"`
-	} `json:"merge_base_commit"`
-	Status string `json:"status"`
-}
-
-// apiReachabilityCheck uses the GitHub Compare API to verify that sha is an
-// ancestor of ref. The key insight: merge_base(ancestor, descendant) == ancestor.
-// If the merge_base is NOT the pinned SHA, the commit lives on the fork network.
-func (r *Resolver) apiReachabilityCheck(owner, repo, sha, ref string) (ReachabilityStatus, string) {
-	path := fmt.Sprintf("repos/%s/%s/compare/%s...%s",
-		owner, repo, url.PathEscape(sha), url.PathEscape(ref))
-
-	var resp compareResponse
-	err := r.restClient.Get(path, &resp)
-	if err != nil {
-		var httpErr *api.HTTPError
-		if errors.As(err, &httpErr) {
-			switch {
-			case httpErr.StatusCode == http.StatusNotFound:
-				return Unreachable, "no common ancestor or commit not found"
-			case httpErr.StatusCode == http.StatusForbidden || httpErr.StatusCode == http.StatusTooManyRequests:
-				detail := fmt.Sprintf("rate limited (HTTP %d)", httpErr.StatusCode)
-				if reset := httpErr.Headers.Get("X-RateLimit-Reset"); reset != "" {
-					detail += "; resets at " + reset
-				}
-				return ReachabilityUnknown, detail
-			default:
-				return ReachabilityUnknown, fmt.Sprintf("API error (HTTP %d): %s", httpErr.StatusCode, httpErr.Message)
-			}
-		}
-		return ReachabilityUnknown, err.Error()
-	}
-
-	if resp.MergeBaseCommit.SHA == sha {
-		return Reachable, "ancestor of " + ref + " (compare: " + resp.Status + ")"
-	}
-	return Unreachable, fmt.Sprintf("merge base is %s, not the pinned SHA — likely a fork-network commit", resp.MergeBaseCommit.SHA[:12])
 }
 
 // branchCommitsResponse is the subset of the undocumented branch_commits
@@ -287,6 +225,20 @@ type branchCommitsResponse struct {
 // at least one branch of the repository. Fork-network commits appear in the
 // fork network's commit graph but have branches=[] in the upstream repo.
 //
+// Why not the documented Compare API? Compare requires a known base ref
+// (e.g. refs/heads/main...{sha}), and for tags — the common pinning target —
+// the tag itself is the attack vector (comparing a tampered tag against its
+// own commit is trivially "identical"). You'd need to enumerate all branches
+// and compare each one, which is O(branches) API calls.
+//
+// branch_commits answers "is this SHA on ANY branch?" in a single call.
+// It wraps spokesd ListReferences with RefListOptions.contains under the hood.
+//
+// To stop relying on this undocumented endpoint, GitHub would need to expose
+// a documented "commit contains" API (e.g. GET /repos/{owner}/{repo}/commits/{sha}/refs
+// or a `contains` parameter on the existing list-branches endpoint).
+// See: https://docs.zizmor.sh/audits/#impostor-commit
+//
 // Flow: resolve ref → SHA via REST API, then GET /{owner}/{repo}/branch_commits/{sha}.
 func (r *Resolver) branchCommitsCheck(owner, repo, ref string) (ReachabilityStatus, string) {
 	// Step 1: resolve ref to its current SHA
@@ -301,7 +253,25 @@ func (r *Resolver) branchCommitsCheck(owner, repo, ref string) (ReachabilityStat
 		return ReachabilityUnknown, fmt.Sprintf("could not resolve ref %s: empty SHA", ref)
 	}
 
-	// Step 2: call branch_commits on the web host (not the API host)
+	// Step 2: check bcCache for this SHA to avoid duplicate HTTP calls.
+	bcKey := owner + "/" + repo + "/" + commitResp.SHA
+	if cached, ok := r.bcCache[bcKey]; ok {
+		if cached == nil {
+			return ReachabilityUnknown, "branch_commits returned HTTP 429"
+		}
+		if len(cached.Branches) == 0 {
+			return Unreachable, fmt.Sprintf(
+				"ref %s resolves to %s which is not on any branch in %s/%s — possible fork-network injection",
+				ref, commitResp.SHA[:12], owner, repo)
+		}
+		branchNames := make([]string, len(cached.Branches))
+		for i, b := range cached.Branches {
+			branchNames[i] = b.Branch
+		}
+		return Reachable, fmt.Sprintf("commit is on branch(es): %s", strings.Join(branchNames, ", "))
+	}
+
+	// Step 3: call branch_commits on the web host (not the API host)
 	webHost := r.hostname
 	bcURL := fmt.Sprintf("https://%s/%s/%s/branch_commits/%s", webHost, owner, repo, commitResp.SHA)
 
@@ -320,18 +290,22 @@ func (r *Resolver) branchCommitsCheck(owner, repo, ref string) (ReachabilityStat
 	}
 	resp, err := transport.RoundTrip(req)
 	if err != nil {
+		r.bcCache[bcKey] = nil
 		return ReachabilityUnknown, fmt.Sprintf("branch_commits request failed: %s", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		r.bcCache[bcKey] = nil
 		return ReachabilityUnknown, fmt.Sprintf("branch_commits returned HTTP %d", resp.StatusCode)
 	}
 
 	var bcResp branchCommitsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&bcResp); err != nil {
+		r.bcCache[bcKey] = nil
 		return ReachabilityUnknown, fmt.Sprintf("could not decode branch_commits response: %s", err)
 	}
+	r.bcCache[bcKey] = &bcResp
 
 	if len(bcResp.Branches) == 0 {
 		return Unreachable, fmt.Sprintf(

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -439,18 +439,26 @@ func TestCheckReachabilityAll_DeduplicatesRequests(t *testing.T) {
 	}
 }
 
-func TestCheckReachability_SHAAsRef_ChecksDefaultBranch(t *testing.T) {
+func TestCheckReachability_SHAAsRef_ChecksViaBranchCommits(t *testing.T) {
 	sha := "abc123abc123abc123abc123abc123abc123abc1"
 
-	t.Run("reachable from HEAD", func(t *testing.T) {
+	t.Run("on a branch", func(t *testing.T) {
 		reg := &httpmock.Registry{}
+		// Resolve SHA (ref == sha, so checkRef == sha)
 		reg.Register(
-			httpmock.REST("GET", "repos/actions/checkout/compare/"),
+			httpmock.REST("GET", "repos/actions/checkout/commits/abc123"),
 			httpmock.JSONResponse(map[string]any{
-				"status": "ahead",
-				"merge_base_commit": map[string]any{
-					"sha": sha,
+				"sha": sha,
+			}),
+		)
+		// branch_commits — commit is on main
+		reg.Register(
+			httpmock.REST("GET", "actions/checkout/branch_commits/abc123"),
+			httpmock.JSONResponse(map[string]any{
+				"branches": []map[string]any{
+					{"branch": "main", "prs": []any{}},
 				},
+				"tags": []string{},
 			}),
 		)
 		r, err := NewWithTransport("github.com", reg)
@@ -467,15 +475,19 @@ func TestCheckReachability_SHAAsRef_ChecksDefaultBranch(t *testing.T) {
 		reg.Verify(t)
 	})
 
-	t.Run("unreachable from HEAD", func(t *testing.T) {
+	t.Run("not on any branch", func(t *testing.T) {
 		reg := &httpmock.Registry{}
 		reg.Register(
-			httpmock.REST("GET", "repos/actions/checkout/compare/"),
+			httpmock.REST("GET", "repos/actions/checkout/commits/abc123"),
 			httpmock.JSONResponse(map[string]any{
-				"status": "diverged",
-				"merge_base_commit": map[string]any{
-					"sha": "different_sha_000000000000000000000000000",
-				},
+				"sha": sha,
+			}),
+		)
+		reg.Register(
+			httpmock.REST("GET", "actions/checkout/branch_commits/abc123"),
+			httpmock.JSONResponse(map[string]any{
+				"branches": []any{},
+				"tags":     []string{},
 			}),
 		)
 		r, err := NewWithTransport("github.com", reg)
@@ -493,31 +505,21 @@ func TestCheckReachability_SHAAsRef_ChecksDefaultBranch(t *testing.T) {
 	})
 }
 
-func TestApiReachabilityCheck_Reachable(t *testing.T) {
+func TestBranchCommitsCheck_Reachable(t *testing.T) {
 	reg := &httpmock.Registry{}
-	// First call: ancestry check (compare/sha...ref) — merge_base matches pinned SHA
-	reg.Register(
-		httpmock.REST("GET", "repos/actions/checkout/compare/abc123"),
-		httpmock.JSONResponse(map[string]any{
-			"status": "ahead",
-			"merge_base_commit": map[string]any{
-				"sha": "abc123abc123abc123abc123abc123abc123abc1",
-			},
-		}),
-	)
-	// Second call: resolve ref to SHA
+	// Resolve ref to SHA
 	reg.Register(
 		httpmock.REST("GET", "repos/actions/checkout/commits/v6"),
 		httpmock.JSONResponse(map[string]any{
 			"sha": "def456def456def456def456def456def456def4",
 		}),
 	)
-	// Third call: branch_commits — commit is on a branch
+	// branch_commits — commit is on a branch
 	reg.Register(
 		httpmock.REST("GET", "actions/checkout/branch_commits/def456"),
 		httpmock.JSONResponse(map[string]any{
 			"branches": []map[string]any{
-				{"branch": "main", "prs": []any{}},
+				{"branch": "releases/v6", "prs": []any{}},
 			},
 			"tags": []string{"v6"},
 		}),
@@ -535,95 +537,12 @@ func TestApiReachabilityCheck_Reachable(t *testing.T) {
 	reg.Verify(t)
 }
 
-func TestApiReachabilityCheck_Unreachable_ForkCommit(t *testing.T) {
-	reg := &httpmock.Registry{}
-	reg.Register(
-		httpmock.REST("GET", "repos/actions/checkout/compare/"),
-		httpmock.JSONResponse(map[string]any{
-			"status": "behind",
-			"merge_base_commit": map[string]any{
-				"sha": "different_sha_000000000000000000000000000",
-			},
-		}),
-	)
-
-	r, err := NewWithTransport("github.com", reg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := r.CheckReachability("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "v6")
-	if result.Status != Unreachable {
-		t.Fatalf("expected Unreachable, got %s (%s)", result.Status, result.Detail)
-	}
-	if !strings.Contains(result.Detail, "fork-network") {
-		t.Fatalf("expected detail to mention fork-network, got %q", result.Detail)
-	}
-	reg.Verify(t)
-}
-
-func TestApiReachabilityCheck_Unreachable_404(t *testing.T) {
-	reg := &httpmock.Registry{}
-	reg.Register(
-		httpmock.REST("GET", "repos/actions/checkout/compare/"),
-		httpmock.StatusResponse(404),
-	)
-
-	r, err := NewWithTransport("github.com", reg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := r.CheckReachability("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "v6")
-	if result.Status != Unreachable {
-		t.Fatalf("expected Unreachable for 404, got %s (%s)", result.Status, result.Detail)
-	}
-	reg.Verify(t)
-}
-
-func TestApiReachabilityCheck_Unknown_RateLimit(t *testing.T) {
-	reg := &httpmock.Registry{}
-	reg.Register(
-		httpmock.REST("GET", "repos/actions/checkout/compare/"),
-		httpmock.StatusResponse(429),
-	)
-
-	r, err := NewWithTransport("github.com", reg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := r.CheckReachability("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "v6")
-	if result.Status != ReachabilityUnknown {
-		t.Fatalf("expected Unknown for rate limit, got %s (%s)", result.Status, result.Detail)
-	}
-	if !strings.Contains(result.Detail, "rate limited") {
-		t.Fatalf("expected detail to mention rate limit, got %q", result.Detail)
-	}
-	reg.Verify(t)
-}
-
-// TestApiReachabilityCheck_ForkInjection_PreservedLineage tests the critical
-// scenario where a tag has been moved to point at a fork-network commit that
-// preserves lineage (its parent is a real upstream commit). The ancestry check
-// passes (merge_base == pinnedSHA) but the branch_commits check catches it
-// because the fork commit is not on any branch in the upstream repo.
-func TestApiReachabilityCheck_ForkInjection_PreservedLineage(t *testing.T) {
-	pinnedSHA := "abc123abc123abc123abc123abc123abc123abc1"
+// TestBranchCommitsCheck_ForkInjection tests that a fork-network commit
+// (no branches in the upstream repo) is detected as Unreachable.
+func TestBranchCommitsCheck_ForkInjection(t *testing.T) {
 	forkSHA := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
 	reg := &httpmock.Registry{}
-	// Ancestry check: compare(pinnedSHA...tampered) → merge_base matches
-	// because the fork commit descends from pinnedSHA through the fork network
-	reg.Register(
-		httpmock.REST("GET", "repos/actions/checkout/compare/abc123"),
-		httpmock.JSONResponse(map[string]any{
-			"status": "ahead",
-			"merge_base_commit": map[string]any{
-				"sha": pinnedSHA,
-			},
-		}),
-	)
 	// Resolve ref to the fork commit SHA
 	reg.Register(
 		httpmock.REST("GET", "repos/actions/checkout/commits/tampered"),
@@ -631,7 +550,7 @@ func TestApiReachabilityCheck_ForkInjection_PreservedLineage(t *testing.T) {
 			"sha": forkSHA,
 		}),
 	)
-	// branch_commits: fork commit has NO branches (only the tampered tag)
+	// branch_commits: fork commit has NO branches
 	reg.Register(
 		httpmock.REST("GET", "actions/checkout/branch_commits/deadbeefdead"),
 		httpmock.JSONResponse(map[string]any{
@@ -645,9 +564,9 @@ func TestApiReachabilityCheck_ForkInjection_PreservedLineage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := r.CheckReachability("actions", "checkout", pinnedSHA, "tampered")
+	result := r.CheckReachability("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "tampered")
 	if result.Status != Unreachable {
-		t.Fatalf("expected Unreachable for fork injection with preserved lineage, got %s (%s)", result.Status, result.Detail)
+		t.Fatalf("expected Unreachable for fork injection, got %s (%s)", result.Status, result.Detail)
 	}
 	if !strings.Contains(result.Detail, "fork-network") {
 		t.Fatalf("expected detail to mention fork-network, got %q", result.Detail)
@@ -655,23 +574,10 @@ func TestApiReachabilityCheck_ForkInjection_PreservedLineage(t *testing.T) {
 	reg.Verify(t)
 }
 
-// TestApiReachabilityCheck_BranchCommitsUnknown_KeepsReachable verifies that when
-// the ancestry check passes but the branch_commits check returns Unknown (e.g.
-// API failure), we keep the Reachable result rather than downgrading.
-func TestApiReachabilityCheck_BranchCommitsUnknown_KeepsReachable(t *testing.T) {
-	pinnedSHA := "abc123abc123abc123abc123abc123abc123abc1"
-
+// TestBranchCommitsCheck_Unknown_KeepsUnknown verifies that when the
+// branch_commits endpoint fails, we return Unknown (not a false positive).
+func TestBranchCommitsCheck_Unknown_KeepsUnknown(t *testing.T) {
 	reg := &httpmock.Registry{}
-	// Ancestry check passes
-	reg.Register(
-		httpmock.REST("GET", "repos/actions/checkout/compare/abc123"),
-		httpmock.JSONResponse(map[string]any{
-			"status": "ahead",
-			"merge_base_commit": map[string]any{
-				"sha": pinnedSHA,
-			},
-		}),
-	)
 	// Resolve ref to SHA
 	reg.Register(
 		httpmock.REST("GET", "repos/actions/checkout/commits/v6"),
@@ -679,7 +585,7 @@ func TestApiReachabilityCheck_BranchCommitsUnknown_KeepsReachable(t *testing.T) 
 			"sha": "def456def456def456def456def456def456def4",
 		}),
 	)
-	// branch_commits fails (e.g. 500)
+	// branch_commits fails
 	reg.Register(
 		httpmock.REST("GET", "actions/checkout/branch_commits/def456"),
 		httpmock.StatusResponse(500),
@@ -690,9 +596,31 @@ func TestApiReachabilityCheck_BranchCommitsUnknown_KeepsReachable(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	result := r.CheckReachability("actions", "checkout", pinnedSHA, "v6")
-	if result.Status != Reachable {
-		t.Fatalf("expected Reachable when branch_commits check is Unknown, got %s (%s)", result.Status, result.Detail)
+	result := r.CheckReachability("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "v6")
+	if result.Status != ReachabilityUnknown {
+		t.Fatalf("expected Unknown when branch_commits fails, got %s (%s)", result.Status, result.Detail)
+	}
+	reg.Verify(t)
+}
+
+// TestBranchCommitsCheck_RefResolveFails verifies graceful degradation
+// when the ref can't be resolved to a SHA.
+func TestBranchCommitsCheck_RefResolveFails(t *testing.T) {
+	reg := &httpmock.Registry{}
+	// Resolve ref fails with 404
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/commits/nonexistent"),
+		httpmock.StatusResponse(404),
+	)
+
+	r, err := NewWithTransport("github.com", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := r.CheckReachability("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "nonexistent")
+	if result.Status != ReachabilityUnknown {
+		t.Fatalf("expected Unknown when ref resolve fails, got %s (%s)", result.Status, result.Detail)
 	}
 	reg.Verify(t)
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -495,13 +495,31 @@ func TestCheckReachability_SHAAsRef_ChecksDefaultBranch(t *testing.T) {
 
 func TestApiReachabilityCheck_Reachable(t *testing.T) {
 	reg := &httpmock.Registry{}
+	// First call: ancestry check (compare/sha...ref) — merge_base matches pinned SHA
 	reg.Register(
-		httpmock.REST("GET", "repos/actions/checkout/compare/"),
+		httpmock.REST("GET", "repos/actions/checkout/compare/abc123"),
 		httpmock.JSONResponse(map[string]any{
 			"status": "ahead",
 			"merge_base_commit": map[string]any{
 				"sha": "abc123abc123abc123abc123abc123abc123abc1",
 			},
+		}),
+	)
+	// Second call: resolve ref to SHA
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/commits/v6"),
+		httpmock.JSONResponse(map[string]any{
+			"sha": "def456def456def456def456def456def456def4",
+		}),
+	)
+	// Third call: branch_commits — commit is on a branch
+	reg.Register(
+		httpmock.REST("GET", "actions/checkout/branch_commits/def456"),
+		httpmock.JSONResponse(map[string]any{
+			"branches": []map[string]any{
+				{"branch": "main", "prs": []any{}},
+			},
+			"tags": []string{"v6"},
 		}),
 	)
 
@@ -581,6 +599,100 @@ func TestApiReachabilityCheck_Unknown_RateLimit(t *testing.T) {
 	}
 	if !strings.Contains(result.Detail, "rate limited") {
 		t.Fatalf("expected detail to mention rate limit, got %q", result.Detail)
+	}
+	reg.Verify(t)
+}
+
+// TestApiReachabilityCheck_ForkInjection_PreservedLineage tests the critical
+// scenario where a tag has been moved to point at a fork-network commit that
+// preserves lineage (its parent is a real upstream commit). The ancestry check
+// passes (merge_base == pinnedSHA) but the branch_commits check catches it
+// because the fork commit is not on any branch in the upstream repo.
+func TestApiReachabilityCheck_ForkInjection_PreservedLineage(t *testing.T) {
+	pinnedSHA := "abc123abc123abc123abc123abc123abc123abc1"
+	forkSHA := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	reg := &httpmock.Registry{}
+	// Ancestry check: compare(pinnedSHA...tampered) → merge_base matches
+	// because the fork commit descends from pinnedSHA through the fork network
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/compare/abc123"),
+		httpmock.JSONResponse(map[string]any{
+			"status": "ahead",
+			"merge_base_commit": map[string]any{
+				"sha": pinnedSHA,
+			},
+		}),
+	)
+	// Resolve ref to the fork commit SHA
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/commits/tampered"),
+		httpmock.JSONResponse(map[string]any{
+			"sha": forkSHA,
+		}),
+	)
+	// branch_commits: fork commit has NO branches (only the tampered tag)
+	reg.Register(
+		httpmock.REST("GET", "actions/checkout/branch_commits/deadbeefdead"),
+		httpmock.JSONResponse(map[string]any{
+			"branches": []any{},
+			"tags":     []string{"tampered"},
+		}),
+	)
+
+	r, err := NewWithTransport("github.com", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := r.CheckReachability("actions", "checkout", pinnedSHA, "tampered")
+	if result.Status != Unreachable {
+		t.Fatalf("expected Unreachable for fork injection with preserved lineage, got %s (%s)", result.Status, result.Detail)
+	}
+	if !strings.Contains(result.Detail, "fork-network") {
+		t.Fatalf("expected detail to mention fork-network, got %q", result.Detail)
+	}
+	reg.Verify(t)
+}
+
+// TestApiReachabilityCheck_BranchCommitsUnknown_KeepsReachable verifies that when
+// the ancestry check passes but the branch_commits check returns Unknown (e.g.
+// API failure), we keep the Reachable result rather than downgrading.
+func TestApiReachabilityCheck_BranchCommitsUnknown_KeepsReachable(t *testing.T) {
+	pinnedSHA := "abc123abc123abc123abc123abc123abc123abc1"
+
+	reg := &httpmock.Registry{}
+	// Ancestry check passes
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/compare/abc123"),
+		httpmock.JSONResponse(map[string]any{
+			"status": "ahead",
+			"merge_base_commit": map[string]any{
+				"sha": pinnedSHA,
+			},
+		}),
+	)
+	// Resolve ref to SHA
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/commits/v6"),
+		httpmock.JSONResponse(map[string]any{
+			"sha": "def456def456def456def456def456def456def4",
+		}),
+	)
+	// branch_commits fails (e.g. 500)
+	reg.Register(
+		httpmock.REST("GET", "actions/checkout/branch_commits/def456"),
+		httpmock.StatusResponse(500),
+	)
+
+	r, err := NewWithTransport("github.com", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := r.CheckReachability("actions", "checkout", pinnedSHA, "v6")
+	if result.Status != Reachable {
+		t.Fatalf("expected Reachable when branch_commits check is Unknown, got %s (%s)", result.Status, result.Detail)
 	}
 	reg.Verify(t)
 }

--- a/internal/resolver/retry.go
+++ b/internal/resolver/retry.go
@@ -31,15 +31,16 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			// Network-level error — retry.
 			if attempt < rt.maxRetries {
-				rt.backoff(attempt, nil)
+				rt.backoff(attempt)
 				continue
 			}
 			return nil, err
 		}
 		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
 			if attempt < rt.maxRetries {
-				rt.backoff(attempt, resp)
+				retryAfter := resp.Header.Get("Retry-After")
 				resp.Body.Close()
+				rt.backoffWithRetryAfter(attempt, retryAfter)
 				continue
 			}
 		}
@@ -48,16 +49,18 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func (rt *retryTransport) backoff(attempt int, resp *http.Response) {
+func (rt *retryTransport) backoffWithRetryAfter(attempt int, retryAfter string) {
 	// Respect Retry-After header if present (common on 429s).
-	if resp != nil {
-		if ra := resp.Header.Get("Retry-After"); ra != "" {
-			if secs, err := strconv.Atoi(ra); err == nil && secs > 0 && secs <= 120 {
-				time.Sleep(time.Duration(secs) * time.Second)
-				return
-			}
+	if retryAfter != "" {
+		if secs, err := strconv.Atoi(retryAfter); err == nil && secs > 0 && secs <= 120 {
+			time.Sleep(time.Duration(secs) * time.Second)
+			return
 		}
 	}
+	rt.backoff(attempt)
+}
+
+func (rt *retryTransport) backoff(attempt int) {
 	delay := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 	if delay > 10*time.Second {
 		delay = 10 * time.Second

--- a/internal/resolver/retry.go
+++ b/internal/resolver/retry.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"math"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -30,15 +31,15 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			// Network-level error — retry.
 			if attempt < rt.maxRetries {
-				rt.backoff(attempt)
+				rt.backoff(attempt, nil)
 				continue
 			}
 			return nil, err
 		}
 		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
 			if attempt < rt.maxRetries {
+				rt.backoff(attempt, resp)
 				resp.Body.Close()
-				rt.backoff(attempt)
 				continue
 			}
 		}
@@ -47,10 +48,19 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func (rt *retryTransport) backoff(attempt int) {
-	delay := time.Duration(math.Pow(2, float64(attempt))) * 500 * time.Millisecond
-	if delay > 5*time.Second {
-		delay = 5 * time.Second
+func (rt *retryTransport) backoff(attempt int, resp *http.Response) {
+	// Respect Retry-After header if present (common on 429s).
+	if resp != nil {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.Atoi(ra); err == nil && secs > 0 && secs <= 120 {
+				time.Sleep(time.Duration(secs) * time.Second)
+				return
+			}
+		}
+	}
+	delay := time.Duration(math.Pow(2, float64(attempt))) * time.Second
+	if delay > 10*time.Second {
+		delay = 10 * time.Second
 	}
 	time.Sleep(delay)
 }


### PR DESCRIPTION
## Summary

Replace the Compare API reachability check with the `branch_commits` web endpoint (same approach as [zizmor](https://docs.zizmor.sh/audits/#impostor-commit)) to detect fork-network injection attacks. Demote `REF_MOVED` to a warning, add pin-time impostor blocking, and improve check output UX.

Stacked on #10 (transitive grouping).

## Motivation

The Compare API cannot distinguish a fork-network commit from a legitimate old tag — `merge_base` returns identity for both. The `branch_commits` endpoint returns which branches/tags contain a commit, so fork-network commits (which have no branches in the upstream repo) are reliably detected as impostors. This may not make it in the final cut. We can, however, use the compare API to determine if a lockfile has been forged with a sha that is present in no ref in the state nwo.

## What changed

### Reachability engine
- **`resolver.go`**: replace Compare API with `/{owner}/{repo}/branch_commits/{sha}` web endpoint for fork-network detection
- **`resolver_test.go`**: updated tests for `branch_commits` approach
- **`retry.go`**: retry logic for web endpoint (429/5xx)
- **`reachability_integration_test.go`**: live integration tests against test fixtures

### Severity and behavior
- **`finding.go`**: `REF_MOVED` demoted to `SeverityWarning` — tag drift is informational, not blocking
- **`compare.go`**: set `LiveSHA` on `REF_MOVED` findings for compare links
- **`apply.go`**: pin-time reachability gate — `CheckReachabilityAll` before lockfile write; unreachable or unknown = refuse to pin (fail closed)
- **`diagnose.go`**: `IMPOSTER_COMMIT` detail from reachability result

### Check output UX
- **`check.go`**: split summary copy — security alerts get "requires investigation — do not auto-fix" with dep listing; interactive items keep separate copy. Compare links in `REF_MOVED` warnings. JSON output exits non-zero when findings are invalid.
- **`remediate.go`**: `AlertedDeps` tracking for `IMPOSTER_COMMIT`/`MISLEADING_SHA`; `REF_MOVED` skipped in remediation loop
- **`command_test.go`**: updated tests for JSON exit code

### Demo scenarios
- **`workflows-pwned/1-5`**: all scenario comments rewritten for `branch_commits` behavior
- **`vhs/*.tape`**: recording scripts updated
- **`try-it.sh`**: demo runner updated

## Scenario behavior matrix

| Scenario | Before | After |
|---|---|---|
| S1: fork injection (tag moved to fork commit) | `REF_MOVED` ✗ | `REF_MOVED` ⚠ + `IMPOSTER_COMMIT` ✗ |
| S2: backward tag move (same-repo rewrite) | `REF_MOVED` ✗ + `IMPOSTER_COMMIT` ✗ | `REF_MOVED` ⚠ only |
| S3: re-pin after compromise | invisible ✓ | invisible ✓ (but pin-time gate now blocks) |
| S4: never pinned, walking into compromised repo | invisible ✓ | `IMPOSTER_COMMIT` ✗ (blocked at pin time) |
| S5: legitimate upstream update | `REF_MOVED` ✗ | `REF_MOVED` ⚠ (with compare link) |

## Verification

- `go test ./...`
- `demo/try-it.sh ref-moved`
- `demo/try-it.sh imposter-commit`
- `demo/try-it.sh json-output`
