### PR TITLE
feat: detect lockfile forgery + gate reachability behind config

### DIFF
--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -420,11 +420,20 @@ func presentCheckResults(out *ui.UI, report *doctor.Report, valid bool, willReme
 				label := strings.ToUpper(string(f.Category))
 				out.Detail("! %s %s", out.Dim(label), dep)
 				out.Detail("  %s", f.Detail)
+				if f.Category == doctor.CategoryLockfileForgery && f.Dependency != nil {
+					owner, repo := f.Dependency.OwnerRepo()
+					out.Detail("  %s", out.Bold("⚠ The pinned SHA was never in this ref's history."))
+					out.Detail("  %s", "This lockfile entry may have been injected maliciously.")
+					if owner != "" {
+						out.Detail("  → %s", out.Dim(fmt.Sprintf("https://github.com/%s/%s/releases", owner, repo)))
+					}
+				}
 			}
 		}
 
 		parts := []string{}
 		for _, cat := range []doctor.Category{
+			doctor.CategoryLockfileForgery,
 			doctor.CategoryRefChanged, doctor.CategoryNotPinned,
 			doctor.CategoryStale, doctor.CategoryMisleadingSHA, doctor.CategoryImposterCommit,
 		} {

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -123,6 +123,10 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 	if err != nil {
 		return err
 	}
+	// Respect test overrides — only apply config when no test func is injected.
+	if !r.HasReachabilityFunc() {
+		r.DisableReachability = !doctor.ReachabilityEnabled()
+	}
 
 	// Single pass: doctor.Diagnose handles all validation.
 	total := len(opts.WorkflowPaths)

--- a/cmd/gh-actions-pin/command_test.go
+++ b/cmd/gh-actions-pin/command_test.go
@@ -451,34 +451,34 @@ dependencies:
 // shows the pinned SHA is NOT an ancestor of the live SHA, the finding is
 // promoted from REF_MOVED to LOCKFILE_FORGERY.
 func TestCheck_LockfileForgery_NotAncestor(t *testing.T) {
-reg := &httpmock.Registry{}
-defer reg.Verify(t)
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
 
-pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
-// GraphQL resolution returns the live SHA (different from pinned).
-reg.Register(
-httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
-httpmock.JSONResponse(map[string]any{
-"data": map[string]any{
-"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
-},
-}),
-)
+	// GraphQL resolution returns the live SHA (different from pinned).
+	reg.Register(
+		httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
+			},
+		}),
+	)
 
-// Compare API: merge_base ≠ pinnedSHA → not an ancestor.
-reg.Register(
-httpmock.REST("GET", "repos/example/action/compare/"),
-httpmock.JSONResponse(map[string]any{
-"status": "diverged",
-"merge_base_commit": map[string]any{
-"sha": "cccccccccccccccccccccccccccccccccccccccc",
-},
-}),
-)
+	// Compare API: merge_base ≠ pinnedSHA → not an ancestor.
+	reg.Register(
+		httpmock.REST("GET", "repos/example/action/compare/"),
+		httpmock.JSONResponse(map[string]any{
+			"status": "diverged",
+			"merge_base_commit": map[string]any{
+				"sha": "cccccccccccccccccccccccccccccccccccccccc",
+			},
+		}),
+	)
 
-workflowPath := writeTempWorkflow(t, `
+	workflowPath := writeTempWorkflow(t, `
 name: ci
 on: push
 jobs:
@@ -492,57 +492,57 @@ dependencies:
   - github.com/example/action@v1:sha1-`+pinnedSHA+`
 `)
 
-stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
-"check", "--json=valid,findings", workflowPath,
-)
-require.ErrorIs(t, err, errSilent, "JSON mode should exit non-zero for forgery findings")
+	stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
+		"check", "--json=valid,findings", workflowPath,
+	)
+	require.ErrorIs(t, err, errSilent, "JSON mode should exit non-zero for forgery findings")
 
-var payload struct {
-Valid    bool           `json:"valid"`
-Findings []checkFinding `json:"findings"`
-}
-require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
-assert.False(t, payload.Valid)
+	var payload struct {
+		Valid    bool           `json:"valid"`
+		Findings []checkFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.False(t, payload.Valid)
 
-categories := map[string]bool{}
-for _, f := range payload.Findings {
-categories[f.Category] = true
-}
-assert.True(t, categories["lockfile_forgery"], "should detect lockfile forgery: %+v", payload.Findings)
-assert.False(t, categories["ref_moved"], "should NOT have ref_moved (promoted to forgery): %+v", payload.Findings)
+	categories := map[string]bool{}
+	for _, f := range payload.Findings {
+		categories[f.Category] = true
+	}
+	assert.True(t, categories["lockfile_forgery"], "should detect lockfile forgery: %+v", payload.Findings)
+	assert.False(t, categories["ref_moved"], "should NOT have ref_moved (promoted to forgery): %+v", payload.Findings)
 }
 
 // TestCheck_LockfileForgery_LegitAncestor verifies that when the Compare API
 // confirms the pinned SHA IS an ancestor of the live SHA, the finding stays
 // as REF_MOVED (legitimate tag movement, not forgery).
 func TestCheck_LockfileForgery_LegitAncestor(t *testing.T) {
-reg := &httpmock.Registry{}
-defer reg.Verify(t)
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
 
-pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
-reg.Register(
-httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
-httpmock.JSONResponse(map[string]any{
-"data": map[string]any{
-"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
-},
-}),
-)
+	reg.Register(
+		httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
+			},
+		}),
+	)
 
-// Compare API: merge_base == pinnedSHA → legitimate ancestor.
-reg.Register(
-httpmock.REST("GET", "repos/example/action/compare/"),
-httpmock.JSONResponse(map[string]any{
-"status": "ahead",
-"merge_base_commit": map[string]any{
-"sha": pinnedSHA,
-},
-}),
-)
+	// Compare API: merge_base == pinnedSHA → legitimate ancestor.
+	reg.Register(
+		httpmock.REST("GET", "repos/example/action/compare/"),
+		httpmock.JSONResponse(map[string]any{
+			"status": "ahead",
+			"merge_base_commit": map[string]any{
+				"sha": pinnedSHA,
+			},
+		}),
+	)
 
-workflowPath := writeTempWorkflow(t, `
+	workflowPath := writeTempWorkflow(t, `
 name: ci
 on: push
 jobs:
@@ -556,51 +556,51 @@ dependencies:
   - github.com/example/action@v1:sha1-`+pinnedSHA+`
 `)
 
-stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
-"check", "--json=valid,findings", workflowPath,
-)
-require.NoError(t, err, "ref_moved is a warning, should not error")
+	stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
+		"check", "--json=valid,findings", workflowPath,
+	)
+	require.NoError(t, err, "ref_moved is a warning, should not error")
 
-var payload struct {
-Valid    bool           `json:"valid"`
-Findings []checkFinding `json:"findings"`
-}
-require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
-assert.True(t, payload.Valid, "ref_moved is a warning, workflow is still valid")
+	var payload struct {
+		Valid    bool           `json:"valid"`
+		Findings []checkFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.True(t, payload.Valid, "ref_moved is a warning, workflow is still valid")
 
-categories := map[string]bool{}
-for _, f := range payload.Findings {
-categories[f.Category] = true
-}
-assert.True(t, categories["ref_moved"], "should keep as ref_moved for legit ancestor: %+v", payload.Findings)
-assert.False(t, categories["lockfile_forgery"], "should NOT have lockfile_forgery: %+v", payload.Findings)
+	categories := map[string]bool{}
+	for _, f := range payload.Findings {
+		categories[f.Category] = true
+	}
+	assert.True(t, categories["ref_moved"], "should keep as ref_moved for legit ancestor: %+v", payload.Findings)
+	assert.False(t, categories["lockfile_forgery"], "should NOT have lockfile_forgery: %+v", payload.Findings)
 }
 
 // TestCheck_LockfileForgery_RateLimited verifies that when the ancestry check
 // is rate-limited, the finding stays as REF_MOVED (fail open).
 func TestCheck_LockfileForgery_RateLimited(t *testing.T) {
-reg := &httpmock.Registry{}
-defer reg.Verify(t)
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
 
-pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
-reg.Register(
-httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
-httpmock.JSONResponse(map[string]any{
-"data": map[string]any{
-"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
-},
-}),
-)
+	reg.Register(
+		httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
+			},
+		}),
+	)
 
-// Compare API: rate limited.
-reg.Register(
-httpmock.REST("GET", "repos/example/action/compare/"),
-httpmock.StatusResponse(429),
-)
+	// Compare API: rate limited.
+	reg.Register(
+		httpmock.REST("GET", "repos/example/action/compare/"),
+		httpmock.StatusResponse(429),
+	)
 
-workflowPath := writeTempWorkflow(t, `
+	workflowPath := writeTempWorkflow(t, `
 name: ci
 on: push
 jobs:
@@ -614,29 +614,29 @@ dependencies:
   - github.com/example/action@v1:sha1-`+pinnedSHA+`
 `)
 
-stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
-"check", "--json=valid,findings", workflowPath,
-)
-require.NoError(t, err, "ref_moved is a warning, should not error")
+	stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
+		"check", "--json=valid,findings", workflowPath,
+	)
+	require.NoError(t, err, "ref_moved is a warning, should not error")
 
-var payload struct {
-Valid    bool           `json:"valid"`
-Findings []checkFinding `json:"findings"`
-}
-require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
-assert.True(t, payload.Valid, "ref_moved is a warning, workflow is still valid")
+	var payload struct {
+		Valid    bool           `json:"valid"`
+		Findings []checkFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.True(t, payload.Valid, "ref_moved is a warning, workflow is still valid")
 
-categories := map[string]bool{}
-for _, f := range payload.Findings {
-categories[f.Category] = true
-}
-assert.True(t, categories["ref_moved"], "should keep as ref_moved when rate limited: %+v", payload.Findings)
-assert.False(t, categories["lockfile_forgery"], "should NOT have lockfile_forgery when rate limited: %+v", payload.Findings)
+	categories := map[string]bool{}
+	for _, f := range payload.Findings {
+		categories[f.Category] = true
+	}
+	assert.True(t, categories["ref_moved"], "should keep as ref_moved when rate limited: %+v", payload.Findings)
+	assert.False(t, categories["lockfile_forgery"], "should NOT have lockfile_forgery when rate limited: %+v", payload.Findings)
 
-// Verify the detail mentions the inconclusive ancestry check.
-for _, f := range payload.Findings {
-if f.Category == "ref_moved" {
-assert.Contains(t, f.Detail, "ancestry check inconclusive")
-}
-}
+	// Verify the detail mentions the inconclusive ancestry check.
+	for _, f := range payload.Findings {
+		if f.Category == "ref_moved" {
+			assert.Contains(t, f.Detail, "ancestry check inconclusive")
+		}
+	}
 }

--- a/cmd/gh-actions-pin/command_test.go
+++ b/cmd/gh-actions-pin/command_test.go
@@ -437,3 +437,206 @@ dependencies:
 	assert.True(t, payload.Valid)
 	assert.Empty(t, payload.Findings)
 }
+
+// ==========================================================================
+// Lockfile Forgery Detection Tests
+//
+// These tests verify that the ancestry check promotes REF_MOVED to
+// LOCKFILE_FORGERY when the pinned SHA is not an ancestor of the live SHA.
+// This detects cases where someone manually injected a SHA into the lockfile
+// that was never part of the ref's legitimate history.
+// ==========================================================================
+
+// TestCheck_LockfileForgery_NotAncestor verifies that when the Compare API
+// shows the pinned SHA is NOT an ancestor of the live SHA, the finding is
+// promoted from REF_MOVED to LOCKFILE_FORGERY.
+func TestCheck_LockfileForgery_NotAncestor(t *testing.T) {
+reg := &httpmock.Registry{}
+defer reg.Verify(t)
+
+pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+// GraphQL resolution returns the live SHA (different from pinned).
+reg.Register(
+httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
+httpmock.JSONResponse(map[string]any{
+"data": map[string]any{
+"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
+},
+}),
+)
+
+// Compare API: merge_base ≠ pinnedSHA → not an ancestor.
+reg.Register(
+httpmock.REST("GET", "repos/example/action/compare/"),
+httpmock.JSONResponse(map[string]any{
+"status": "diverged",
+"merge_base_commit": map[string]any{
+"sha": "cccccccccccccccccccccccccccccccccccccccc",
+},
+}),
+)
+
+workflowPath := writeTempWorkflow(t, `
+name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: example/action@v1
+
+# Automatically generated and managed by: gh actions-pin --write <workflow-path>
+dependencies:
+  - github.com/example/action@v1:sha1-`+pinnedSHA+`
+`)
+
+stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
+"check", "--json=valid,findings", workflowPath,
+)
+require.ErrorIs(t, err, errSilent, "JSON mode should exit non-zero for forgery findings")
+
+var payload struct {
+Valid    bool           `json:"valid"`
+Findings []checkFinding `json:"findings"`
+}
+require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+assert.False(t, payload.Valid)
+
+categories := map[string]bool{}
+for _, f := range payload.Findings {
+categories[f.Category] = true
+}
+assert.True(t, categories["lockfile_forgery"], "should detect lockfile forgery: %+v", payload.Findings)
+assert.False(t, categories["ref_moved"], "should NOT have ref_moved (promoted to forgery): %+v", payload.Findings)
+}
+
+// TestCheck_LockfileForgery_LegitAncestor verifies that when the Compare API
+// confirms the pinned SHA IS an ancestor of the live SHA, the finding stays
+// as REF_MOVED (legitimate tag movement, not forgery).
+func TestCheck_LockfileForgery_LegitAncestor(t *testing.T) {
+reg := &httpmock.Registry{}
+defer reg.Verify(t)
+
+pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+reg.Register(
+httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
+httpmock.JSONResponse(map[string]any{
+"data": map[string]any{
+"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
+},
+}),
+)
+
+// Compare API: merge_base == pinnedSHA → legitimate ancestor.
+reg.Register(
+httpmock.REST("GET", "repos/example/action/compare/"),
+httpmock.JSONResponse(map[string]any{
+"status": "ahead",
+"merge_base_commit": map[string]any{
+"sha": pinnedSHA,
+},
+}),
+)
+
+workflowPath := writeTempWorkflow(t, `
+name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: example/action@v1
+
+# Automatically generated and managed by: gh actions-pin --write <workflow-path>
+dependencies:
+  - github.com/example/action@v1:sha1-`+pinnedSHA+`
+`)
+
+stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
+"check", "--json=valid,findings", workflowPath,
+)
+require.NoError(t, err, "ref_moved is a warning, should not error")
+
+var payload struct {
+Valid    bool           `json:"valid"`
+Findings []checkFinding `json:"findings"`
+}
+require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+assert.True(t, payload.Valid, "ref_moved is a warning, workflow is still valid")
+
+categories := map[string]bool{}
+for _, f := range payload.Findings {
+categories[f.Category] = true
+}
+assert.True(t, categories["ref_moved"], "should keep as ref_moved for legit ancestor: %+v", payload.Findings)
+assert.False(t, categories["lockfile_forgery"], "should NOT have lockfile_forgery: %+v", payload.Findings)
+}
+
+// TestCheck_LockfileForgery_RateLimited verifies that when the ancestry check
+// is rate-limited, the finding stays as REF_MOVED (fail open).
+func TestCheck_LockfileForgery_RateLimited(t *testing.T) {
+reg := &httpmock.Registry{}
+defer reg.Verify(t)
+
+pinnedSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+liveSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+reg.Register(
+httpmock.GraphQL(`repository\(owner: "example", name: "action"\)`),
+httpmock.JSONResponse(map[string]any{
+"data": map[string]any{
+"a0": testRepoResponse("example/action", liveSHA, nodeActionYAML),
+},
+}),
+)
+
+// Compare API: rate limited.
+reg.Register(
+httpmock.REST("GET", "repos/example/action/compare/"),
+httpmock.StatusResponse(429),
+)
+
+workflowPath := writeTempWorkflow(t, `
+name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: example/action@v1
+
+# Automatically generated and managed by: gh actions-pin --write <workflow-path>
+dependencies:
+  - github.com/example/action@v1:sha1-`+pinnedSHA+`
+`)
+
+stdout, _, err := runCommandWithHTTPAndReach(t, reg, reachableFunc(),
+"check", "--json=valid,findings", workflowPath,
+)
+require.NoError(t, err, "ref_moved is a warning, should not error")
+
+var payload struct {
+Valid    bool           `json:"valid"`
+Findings []checkFinding `json:"findings"`
+}
+require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+assert.True(t, payload.Valid, "ref_moved is a warning, workflow is still valid")
+
+categories := map[string]bool{}
+for _, f := range payload.Findings {
+categories[f.Category] = true
+}
+assert.True(t, categories["ref_moved"], "should keep as ref_moved when rate limited: %+v", payload.Findings)
+assert.False(t, categories["lockfile_forgery"], "should NOT have lockfile_forgery when rate limited: %+v", payload.Findings)
+
+// Verify the detail mentions the inconclusive ancestry check.
+for _, f := range payload.Findings {
+if f.Category == "ref_moved" {
+assert.Contains(t, f.Detail, "ancestry check inconclusive")
+}
+}
+}

--- a/demo/try-it.sh
+++ b/demo/try-it.sh
@@ -46,6 +46,7 @@ scenarios=(
   "edit-repin"
   "ref-moved"
   "imposter-commit"
+  "lockfile-forgery"
   "json-output"
 )
 
@@ -68,6 +69,7 @@ usage() {
   echo "  Change detection"
   echo "    ref-moved          Tag moved forward (routine release)"
   echo "    imposter-commit    Tag hijacked to fork-network commit (fork injection)"
+  echo "    lockfile-forgery   Lockfile entry replaced with fork commit SHA"
   echo "    json-output        JSON output for CI integration"
   echo ""
   echo "  all                  Run all scenarios sequentially"
@@ -174,6 +176,15 @@ scenario_imposter_commit() {
   run gh actions-pin check demo/workflows-pwned/1-pinned-before-hijack.yml
 }
 
+scenario_lockfile_forgery() {
+  banner "Lockfile forgery — injected SHA not in ref lineage"
+  bash "$RESET"
+  comment "Lockfile was tampered with — pinned SHA replaced by a fork commit"
+  run show_workflow_summary demo/workflows-pwned/6-lockfile-forgery.yml
+  comment "Check detects the pinned SHA is not an ancestor of the live ref"
+  run gh actions-pin check demo/workflows-pwned/6-lockfile-forgery.yml
+}
+
 scenario_json_output() {
   banner "JSON output for CI integration"
   bash "$RESET"
@@ -193,6 +204,7 @@ run_all() {
   scenario_edit_repin
   scenario_ref_moved
   scenario_imposter_commit
+  scenario_lockfile_forgery
   scenario_json_output
   banner "All non-interactive scenarios complete"
 }
@@ -210,7 +222,8 @@ case "${1}" in
   edit-repin)         scenario_edit_repin ;;
   ref-moved)          scenario_ref_moved ;;
   imposter-commit|imposter) scenario_imposter_commit ;;
-  tamper-detection|tamper) scenario_ref_moved; scenario_imposter_commit ;;
+  lockfile-forgery|forgery) scenario_lockfile_forgery ;;
+  tamper-detection|tamper) scenario_ref_moved; scenario_imposter_commit; scenario_lockfile_forgery ;;
   json-output|json)   scenario_json_output ;;
   all)                run_all ;;
   *)                  echo "Unknown scenario: $1"; echo; usage ;;

--- a/demo/try-it.sh
+++ b/demo/try-it.sh
@@ -19,6 +19,19 @@ RESET_COLOR='\033[0m'
 banner() { echo -e "\n${BOLD}${CYAN}── $1 ──${RESET_COLOR}\n"; }
 comment() { echo -e "${DIM}# $1${RESET_COLOR}"; }
 run() { echo -e "${GREEN}\$ $*${RESET_COLOR}"; "$@"; echo; }
+
+# Enable the reachability check (branch_commits) for scenarios that need it.
+# This undocumented endpoint 429s aggressively so it's off by default.
+# Uses GH_ACTIONS_PIN_CONFIG to avoid mutating real user config.
+enable_reachability() {
+  _DEMO_CONFIG=$(mktemp /tmp/gh-actions-pin-demo-XXXXXX.yml)
+  echo "reachability_check: true" > "$_DEMO_CONFIG"
+  export GH_ACTIONS_PIN_CONFIG="$_DEMO_CONFIG"
+}
+disable_reachability() {
+  unset GH_ACTIONS_PIN_CONFIG
+  rm -f "${_DEMO_CONFIG:-}"
+}
 show_workflow_summary() {
   awk '
     /^# Automatically generated/ { in_deps=1 }
@@ -170,10 +183,14 @@ scenario_ref_moved() {
 scenario_imposter_commit() {
   banner "Imposter commit — fork injection"
   bash "$RESET"
+  enable_reachability
+  trap disable_reachability EXIT
   comment "Workflow pinned BEFORE the tag was hijacked"
   run show_workflow_summary demo/workflows-pwned/1-pinned-before-hijack.yml
   comment "Check detects the tag moved to a fork-network commit"
   run gh actions-pin check demo/workflows-pwned/1-pinned-before-hijack.yml
+  disable_reachability
+  trap - EXIT
 }
 
 scenario_lockfile_forgery() {

--- a/demo/vhs/lockfile-forgery.tape
+++ b/demo/vhs/lockfile-forgery.tape
@@ -1,0 +1,29 @@
+Output lockfile-forgery.gif
+
+Set Shell "zsh"
+Set FontFamily "JetBrainsMono Nerd Font"
+Set FontSize 14
+Set Width 1200
+Set Height 700
+Set Framerate 24
+Set PlaybackSpeed 1.5
+Set TypingSpeed 50ms
+Set Theme "GitHub Dark"
+
+Type "echo '# Lockfile was tampered — pinned SHA replaced with a fork commit'"
+Enter
+Sleep 1s
+
+Type "grep -E 'uses:|  -|FORGED' demo/workflows-pwned/6-lockfile-forgery.yml"
+Enter
+Sleep 2s
+
+Type "echo '# Compare API detects the forged SHA is not in the ref lineage'"
+Enter
+Sleep 1s
+
+Type "gh actions-pin check --no-interactive demo/workflows-pwned/6-lockfile-forgery.yml"
+Enter
+Sleep 10s
+
+Sleep 3s

--- a/demo/workflows-pwned/6-lockfile-forgery.yml
+++ b/demo/workflows-pwned/6-lockfile-forgery.yml
@@ -1,0 +1,35 @@
+name: "6: Lockfile forgery — injected SHA not in ref lineage"
+
+# =============================================================================
+# ATTACKER CAPABILITY: Write access to lockfile (e.g. PR with lockfile edit)
+# TIMELINE:
+#   1. Maintainer releases @updated → ea53476 (legitimate)
+#   2. You pin: lockfile records ea53476 ✓
+#   3. Attacker opens PR that edits the lockfile, replacing ea53476 with
+#      0344cd0 — a commit from a fork (choam-io/actions-test-fixtures-fork)
+#   4. The forged SHA is a valid composite action, so CI runs it
+#   5. You run `gh actions-pin check` → CAUGHT
+#
+# Unlike scenario 1 (tag hijack), the tag was never moved. The ref still
+# resolves to ea53476. The attack is purely in the lockfile: someone
+# injected a SHA that was never part of @updated's lineage.
+#
+# The Compare API reveals this: merge_base(forgedSHA, liveSHA) ≠ forgedSHA,
+# because the forged commit descends from a fork branch, not the tag.
+#
+# RESULT:  CAUGHT ✗
+#          ✗ LOCKFILE_FORGERY — pinned SHA is not an ancestor of live SHA
+#          The lockfile's integrity check catches the injected SHA.
+# =============================================================================
+
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nodeselector/actions-test-fixtures/nested-composite@updated
+
+# Automatically generated and managed by gh-actions-pin
+dependencies:
+  - github.com/nodeselector/actions-test-fixtures/nested-composite@updated:sha1-0344cd079836aa2179e635a5fb1ab7eab52cdb82
+  # ↑ FORGED: this SHA is from choam-io/actions-test-fixtures-fork, NOT from @updated's lineage

--- a/internal/doctor/apply.go
+++ b/internal/doctor/apply.go
@@ -37,17 +37,23 @@ func (rem *Remediator) applyPin(wr WorkflowReport) error {
 	// commits get pinned in the first place. Fail closed: if we can't
 	// verify reachability (e.g. branch_commits returns 429), refuse to
 	// pin rather than silently accepting a potentially poisoned commit.
-	reachResults := rem.resolver.CheckReachabilityAll(deps)
-	for _, rr := range reachResults {
-		switch rr.Status {
-		case resolver.Unreachable:
-			rem.output.Error("%s/%s@%s: %s", rr.Owner, rr.Repo, rr.Ref, rr.Detail)
-			rem.Alerted++
-			return fmt.Errorf("refusing to pin: impostor commit detected for %s/%s@%s", rr.Owner, rr.Repo, rr.Ref)
-		case resolver.ReachabilityUnknown:
-			rem.output.Error("%s/%s@%s: could not verify commit reachability — %s", rr.Owner, rr.Repo, rr.Ref, rr.Detail)
-			rem.Alerted++
-			return fmt.Errorf("refusing to pin: cannot verify reachability for %s/%s@%s (try again later)", rr.Owner, rr.Repo, rr.Ref)
+	//
+	// When reachability is disabled via config, skip this gate entirely —
+	// the branch_commits endpoint would return "disabled" for every dep,
+	// which would block all pinning.
+	if !rem.resolver.DisableReachability {
+		reachResults := rem.resolver.CheckReachabilityAll(deps)
+		for _, rr := range reachResults {
+			switch rr.Status {
+			case resolver.Unreachable:
+				rem.output.Error("%s/%s@%s: %s", rr.Owner, rr.Repo, rr.Ref, rr.Detail)
+				rem.Alerted++
+				return fmt.Errorf("refusing to pin: impostor commit detected for %s/%s@%s", rr.Owner, rr.Repo, rr.Ref)
+			case resolver.ReachabilityUnknown:
+				rem.output.Error("%s/%s@%s: could not verify commit reachability — %s", rr.Owner, rr.Repo, rr.Ref, rr.Detail)
+				rem.Alerted++
+				return fmt.Errorf("refusing to pin: cannot verify reachability for %s/%s@%s (try again later)", rr.Owner, rr.Repo, rr.Ref)
+			}
 		}
 	}
 

--- a/internal/doctor/config.go
+++ b/internal/doctor/config.go
@@ -1,0 +1,52 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// configPath returns the path to the config file, respecting
+// GH_ACTIONS_PIN_CONFIG for testing/demos.
+func configPath() string {
+	if p := os.Getenv("GH_ACTIONS_PIN_CONFIG"); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "gh-actions-pin", "config.yml")
+}
+
+// ReachabilityEnabled reads the reachability_check flag from the config file.
+// Defaults to false (disabled).
+//
+// The reachability check uses the undocumented /{owner}/{repo}/branch_commits/{sha}
+// web endpoint to detect fork-network injection (impostor commits). This endpoint
+// is aggressive with 429 rate limits and has no public API equivalent. Until GitHub
+// exposes a documented "commit reachability" or "commit contains" API, this feature
+// is dead in the water for most users and disabled by default.
+//
+// To enable:
+//
+//	# ~/.config/gh-actions-pin/config.yml
+//	reachability_check: true
+func ReachabilityEnabled() bool {
+	p := configPath()
+	if p == "" {
+		return false
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return false
+	}
+	var file struct {
+		ReachabilityCheck bool `yaml:"reachability_check"`
+	}
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return false
+	}
+	return file.ReachabilityCheck
+}

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -189,6 +189,7 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 		switch status {
 		case resolver.AncestryNotAncestor:
 			f.Category = CategoryLockfileForgery
+			f.Severity = SeverityError
 			f.Detail = fmt.Sprintf("pinned %s is not an ancestor of %s — %s",
 				f.Dependency.SHA[:12], live.SHA[:12], detail)
 			f.Remediation = "investigate immediately — the lockfile may have been tampered with"
@@ -248,10 +249,6 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 			depByKey[d.Key()] = d
 		}
 		for _, rr := range reachResults {
-			depID := rr.DepKey
-			if depID == "" {
-				depID = fmt.Sprintf("%s/%s@%s", rr.Owner, rr.Repo, rr.Ref)
-			}
 			var depPtr *lockfile.Dependency
 			if d, ok := depByKey[rr.DepKey]; ok {
 				depPtr = &d

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -199,6 +199,15 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 		// AncestryConfirmed: leave as REF_MOVED — legitimate tag movement.
 	}
 
+	// Build set of dep keys already promoted to LOCKFILE_FORGERY so we don't
+	// also flag them as IMPOSTER_COMMIT — the two are mutually exclusive.
+	forgeryKeys := make(map[string]bool)
+	for _, f := range wr.Findings {
+		if f.Category == CategoryLockfileForgery && f.Dependency != nil {
+			forgeryKeys[f.Dependency.Key()] = true
+		}
+	}
+
 	// Build set of NWOs with ref-changed findings to avoid duplicate "not pinned" findings.
 	refChangedNWOs := make(map[string]bool)
 	for _, f := range wr.Findings {
@@ -248,6 +257,9 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 		}
 		switch rr.Status {
 		case resolver.Unreachable:
+			if forgeryKeys[rr.DepKey] {
+				continue // already flagged as LOCKFILE_FORGERY — reachability is implied
+			}
 			wr.Findings = append(wr.Findings, Finding{
 				WorkflowPath: path,
 				Category:     CategoryImposterCommit,

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -168,6 +168,37 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 	// Compare pinned deps against live resolution.
 	wr.Findings = append(wr.Findings, compareSnapshots(path, existingDeps, liveDeps, directNWOs)...)
 
+	// LOCKFILE_FORGERY: for each REF_MOVED finding, check if the pinned SHA
+	// is actually an ancestor of the live SHA. If not, the lockfile entry was
+	// likely injected or tampered with (or upstream rewrote history).
+	liveByKey := make(map[string]lockfile.Dependency, len(liveDeps))
+	for _, dep := range liveDeps {
+		liveByKey[dep.Key()] = dep
+	}
+	for i := range wr.Findings {
+		f := &wr.Findings[i]
+		if f.Category != CategoryRefMoved || f.Dependency == nil {
+			continue
+		}
+		live, ok := liveByKey[f.Dependency.Key()]
+		if !ok {
+			continue
+		}
+		owner, repo := f.Dependency.OwnerRepo()
+		status, detail := r.CheckAncestry(owner, repo, f.Dependency.SHA, live.SHA)
+		switch status {
+		case resolver.AncestryNotAncestor:
+			f.Category = CategoryLockfileForgery
+			f.Detail = fmt.Sprintf("pinned %s is not an ancestor of %s — %s",
+				f.Dependency.SHA[:12], live.SHA[:12], detail)
+			f.Remediation = "investigate immediately — the lockfile may have been tampered with"
+		case resolver.AncestryUnknown:
+			// Fail open: keep as REF_MOVED, add a note about the ancestry check.
+			f.Detail += fmt.Sprintf(" (ancestry check inconclusive: %s)", detail)
+		}
+		// AncestryConfirmed: leave as REF_MOVED — legitimate tag movement.
+	}
+
 	// Build set of NWOs with ref-changed findings to avoid duplicate "not pinned" findings.
 	refChangedNWOs := make(map[string]bool)
 	for _, f := range wr.Findings {

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -239,60 +239,62 @@ func diagnoseOneWorkflow(path string, r *resolver.Resolver) WorkflowReport {
 		}
 	}
 
-	// Reachability checks.
-	reachResults := r.CheckReachabilityAll(existingDeps)
-	// Build dep lookup by key for attaching to reachability findings.
-	depByKey := make(map[string]lockfile.Dependency, len(existingDeps))
-	for _, d := range existingDeps {
-		depByKey[d.Key()] = d
-	}
-	for _, rr := range reachResults {
-		depID := rr.DepKey
-		if depID == "" {
-			depID = fmt.Sprintf("%s/%s@%s", rr.Owner, rr.Repo, rr.Ref)
+	// Reachability checks (skip entirely when disabled — no warnings, no findings).
+	if !r.DisableReachability {
+		reachResults := r.CheckReachabilityAll(existingDeps)
+		// Build dep lookup by key for attaching to reachability findings.
+		depByKey := make(map[string]lockfile.Dependency, len(existingDeps))
+		for _, d := range existingDeps {
+			depByKey[d.Key()] = d
 		}
-		var depPtr *lockfile.Dependency
-		if d, ok := depByKey[rr.DepKey]; ok {
-			depPtr = &d
-		}
-		switch rr.Status {
-		case resolver.Unreachable:
-			if forgeryKeys[rr.DepKey] {
-				continue // already flagged as LOCKFILE_FORGERY — reachability is implied
+		for _, rr := range reachResults {
+			depID := rr.DepKey
+			if depID == "" {
+				depID = fmt.Sprintf("%s/%s@%s", rr.Owner, rr.Repo, rr.Ref)
 			}
-			wr.Findings = append(wr.Findings, Finding{
-				WorkflowPath: path,
-				Category:     CategoryImposterCommit,
-				Severity:     SeverityError,
-				Dependency:   depPtr,
-				Detail:       rr.Detail,
-			})
-		case resolver.ReachabilityUnknown:
-			isTransitive := !directNWOs[rr.Owner+"/"+rr.Repo]
-			parentNWO := ""
-			if isTransitive {
-				if parents := r.ParentMap()[rr.DepKey]; len(parents) > 0 {
-					parentNWO = parents[0]
+			var depPtr *lockfile.Dependency
+			if d, ok := depByKey[rr.DepKey]; ok {
+				depPtr = &d
+			}
+			switch rr.Status {
+			case resolver.Unreachable:
+				if forgeryKeys[rr.DepKey] {
+					continue // already flagged as LOCKFILE_FORGERY — reachability is implied
 				}
-			}
-			wr.Findings = append(wr.Findings, Finding{
-				WorkflowPath: path,
-				Category:     CategoryValid,
-				Severity:     SeverityWarning,
-				Detail:       rr.Detail,
-				Dependency: &lockfile.Dependency{
-					NWO: rr.Owner + "/" + rr.Repo,
-					Ref: rr.Ref,
-					SHA: rr.SHA,
-				},
-				ParentNWO: parentNWO,
-				Remediation: func() string {
-					if isTransitive {
-						return "transitive dependency pinned to a bare SHA — reachability cannot be verified"
+				wr.Findings = append(wr.Findings, Finding{
+					WorkflowPath: path,
+					Category:     CategoryImposterCommit,
+					Severity:     SeverityError,
+					Dependency:   depPtr,
+					Detail:       rr.Detail,
+				})
+			case resolver.ReachabilityUnknown:
+				isTransitive := !directNWOs[rr.Owner+"/"+rr.Repo]
+				parentNWO := ""
+				if isTransitive {
+					if parents := r.ParentMap()[rr.DepKey]; len(parents) > 0 {
+						parentNWO = parents[0]
 					}
-					return "reachability check inconclusive"
-				}(),
-			})
+				}
+				wr.Findings = append(wr.Findings, Finding{
+					WorkflowPath: path,
+					Category:     CategoryValid,
+					Severity:     SeverityWarning,
+					Detail:       rr.Detail,
+					Dependency: &lockfile.Dependency{
+						NWO: rr.Owner + "/" + rr.Repo,
+						Ref: rr.Ref,
+						SHA: rr.SHA,
+					},
+					ParentNWO: parentNWO,
+					Remediation: func() string {
+						if isTransitive {
+							return "transitive dependency pinned to a bare SHA — reachability cannot be verified"
+						}
+						return "reachability check inconclusive"
+					}(),
+				})
+			}
 		}
 	}
 

--- a/internal/doctor/finding.go
+++ b/internal/doctor/finding.go
@@ -18,6 +18,9 @@ const (
 	CategoryImposterCommit Category = "imposter_commit"
 	// CategoryMisleadingSHA means a ref looks like a SHA but resolves to a different commit.
 	CategoryMisleadingSHA Category = "misleading_sha"
+	// CategoryLockfileForgery means the pinned SHA is not an ancestor of the
+	// current ref — the lockfile entry was likely injected or tampered with.
+	CategoryLockfileForgery Category = "lockfile_forgery"
 	// CategoryRefMoved means the upstream tag now resolves to a different SHA than what's locked.
 	CategoryRefMoved Category = "ref_moved"
 	// CategoryValid means the dependency is pinned and verified.

--- a/internal/doctor/remediate.go
+++ b/internal/doctor/remediate.go
@@ -224,6 +224,7 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 			rem.output.Error("LOCKFILE_FORGERY %s: %s", rem.depKey(finding), finding.Detail)
 			rem.output.Hint("The pinned SHA was never in this ref's lineage — possible lockfile tampering.")
 			rem.Alerted++
+			rem.addAlertedDep(finding)
 
 		case CategoryMisleadingSHA:
 			rem.output.Error("MISLEADING_SHA %s: %s", rem.depKey(finding), finding.Detail)

--- a/internal/doctor/remediate.go
+++ b/internal/doctor/remediate.go
@@ -220,6 +220,11 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 			rem.Alerted++
 			rem.addAlertedDep(finding)
 
+		case CategoryLockfileForgery:
+			rem.output.Error("LOCKFILE_FORGERY %s: %s", rem.depKey(finding), finding.Detail)
+			rem.output.Hint("The pinned SHA was never in this ref's lineage — possible lockfile tampering.")
+			rem.Alerted++
+
 		case CategoryMisleadingSHA:
 			rem.output.Error("MISLEADING_SHA %s: %s", rem.depKey(finding), finding.Detail)
 			rem.output.Hint("This ref may be a deceptive branch or tag name masquerading as a commit hash.")

--- a/internal/doctor/tags.go
+++ b/internal/doctor/tags.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"sort"
 	"time"
 
@@ -246,11 +245,11 @@ func LoadCooldownConfig() CooldownConfig {
 		RepoOverrides: make(map[string]int),
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
+	p := configPath()
+	if p == "" {
 		return cfg
 	}
-	data, err := os.ReadFile(filepath.Join(home, ".config", "gh-actions-pin", "config.yml"))
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return cfg
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -66,6 +66,10 @@ type Resolver struct {
 	parentMap map[string][]string
 	// checkReachFn overrides the default REST-based reachability check (for tests).
 	checkReachFn func(owner, repo, sha, ref string) (ReachabilityStatus, string)
+
+	// DisableReachability skips the branch_commits reachability check entirely.
+	// When true, CheckReachability returns ReachabilityUnknown immediately.
+	DisableReachability bool
 }
 
 // ParentMap returns the child dep key → parent dep keys mapping from the last ResolveAllRecursive call.
@@ -166,6 +170,11 @@ func (r *Resolver) SetCheckReachabilityFunc(fn func(owner, repo, sha, ref string
 	r.checkReachFn = fn
 }
 
+// HasReachabilityFunc reports whether a test reachability function has been injected.
+func (r *Resolver) HasReachabilityFunc() bool {
+	return r.checkReachFn != nil
+}
+
 // CheckReachability verifies that a resolved SHA is on the lineage of the
 // given ref within the repository. This catches fork-network injection where
 // a SHA exists in GitHub's shared object store but is not actually part of
@@ -197,6 +206,14 @@ func (r *Resolver) CheckReachability(owner, repo, sha, ref string) ReachabilityR
 	// Allow tests to inject a fake implementation
 	if r.checkReachFn != nil {
 		result.Status, result.Detail = r.checkReachFn(owner, repo, sha, ref)
+		r.reachCache[cacheKey] = result.Status
+		return result
+	}
+
+	// Feature-flagged: skip branch_commits when disabled.
+	if r.DisableReachability {
+		result.Status = ReachabilityUnknown
+		result.Detail = "reachability check disabled via config"
 		r.reachCache[cacheKey] = result.Status
 		return result
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -350,6 +350,62 @@ func (r *Resolver) branchCommitsCheck(owner, repo, ref string) (ReachabilityStat
 	return Reachable, fmt.Sprintf("commit is on branch(es): %s", strings.Join(branchNames, ", "))
 }
 
+// AncestryStatus represents whether a pinned SHA is a legitimate ancestor of the live SHA.
+type AncestryStatus int
+
+const (
+	// AncestryConfirmed means the pinned SHA is an ancestor of the live SHA.
+	AncestryConfirmed AncestryStatus = iota
+	// AncestryNotAncestor means the pinned SHA is NOT an ancestor — possible forgery.
+	AncestryNotAncestor
+	// AncestryUnknown means the check could not be completed (rate limit, API error).
+	AncestryUnknown
+)
+
+// compareResponse is the subset of the GitHub Compare API response we need.
+type compareResponse struct {
+	Status          string `json:"status"`
+	MergeBaseCommit struct {
+		SHA string `json:"sha"`
+	} `json:"merge_base_commit"`
+}
+
+// CheckAncestry uses the Compare API to test whether pinnedSHA is an ancestor
+// of liveSHA. This detects lockfile forgery: if someone injects a SHA that was
+// never in the ref's lineage, merge_base(pinned, live) ≠ pinned.
+func (r *Resolver) CheckAncestry(owner, repo, pinnedSHA, liveSHA string) (AncestryStatus, string) {
+	path := fmt.Sprintf("repos/%s/%s/compare/%s...%s",
+		owner, repo, url.PathEscape(pinnedSHA), url.PathEscape(liveSHA))
+
+	var resp compareResponse
+	err := r.restClient.Get(path, &resp)
+	if err != nil {
+		var httpErr *api.HTTPError
+		if errors.As(err, &httpErr) {
+			switch httpErr.StatusCode {
+			case http.StatusNotFound:
+				return AncestryNotAncestor, "commit not found in repository"
+			case http.StatusConflict: // 409 — no common ancestor
+				return AncestryNotAncestor, "no common ancestor between pinned and live SHA"
+			case http.StatusForbidden, http.StatusTooManyRequests:
+				detail := fmt.Sprintf("rate limited (HTTP %d)", httpErr.StatusCode)
+				if reset := httpErr.Headers.Get("X-RateLimit-Reset"); reset != "" {
+					detail += "; resets at " + reset
+				}
+				return AncestryUnknown, detail
+			default:
+				return AncestryUnknown, fmt.Sprintf("API error (HTTP %d): %s", httpErr.StatusCode, httpErr.Message)
+			}
+		}
+		return AncestryUnknown, err.Error()
+	}
+
+	if strings.EqualFold(resp.MergeBaseCommit.SHA, pinnedSHA) {
+		return AncestryConfirmed, fmt.Sprintf("pinned SHA is ancestor of live SHA (compare: %s)", resp.Status)
+	}
+	return AncestryNotAncestor, fmt.Sprintf("merge base is %s, not the pinned SHA — possible lockfile forgery or upstream history rewrite", resp.MergeBaseCommit.SHA[:12])
+}
+
 // CheckReachabilityAll runs reachability checks on a batch of dependencies,
 // deduplicating by owner/repo/sha/ref.
 func (r *Resolver) CheckReachabilityAll(deps []lockfile.Dependency) []ReachabilityResult {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -624,3 +624,126 @@ func TestBranchCommitsCheck_RefResolveFails(t *testing.T) {
 	}
 	reg.Verify(t)
 }
+
+func TestCheckAncestry_Confirmed(t *testing.T) {
+	pinnedSHA := "abc123abc123abc123abc123abc123abc123abc1"
+	liveSHA := "def456def456def456def456def456def456def4"
+
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/compare/"),
+		httpmock.JSONResponse(map[string]any{
+			"status": "ahead",
+			"merge_base_commit": map[string]any{
+				"sha": pinnedSHA,
+			},
+		}),
+	)
+
+	r, err := NewWithTransport("github.com", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, _ := r.CheckAncestry("actions", "checkout", pinnedSHA, liveSHA)
+	if status != AncestryConfirmed {
+		t.Fatalf("expected AncestryConfirmed, got %d", status)
+	}
+	reg.Verify(t)
+}
+
+func TestCheckAncestry_NotAncestor_DifferentMergeBase(t *testing.T) {
+	pinnedSHA := "abc123abc123abc123abc123abc123abc123abc1"
+	liveSHA := "def456def456def456def456def456def456def4"
+
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/compare/"),
+		httpmock.JSONResponse(map[string]any{
+			"status": "diverged",
+			"merge_base_commit": map[string]any{
+				"sha": "unrelated_000000000000000000000000000000",
+			},
+		}),
+	)
+
+	r, err := NewWithTransport("github.com", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, detail := r.CheckAncestry("actions", "checkout", pinnedSHA, liveSHA)
+	if status != AncestryNotAncestor {
+		t.Fatalf("expected AncestryNotAncestor, got %d", status)
+	}
+	if !strings.Contains(detail, "not the pinned SHA") {
+		t.Fatalf("expected detail about merge base mismatch, got %q", detail)
+	}
+	reg.Verify(t)
+}
+
+func TestCheckAncestry_NotAncestor_404(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/compare/"),
+		httpmock.StatusResponse(404),
+	)
+
+	r, err := NewWithTransport("github.com", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, detail := r.CheckAncestry("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "def456def456def456def456def456def456def4")
+	if status != AncestryNotAncestor {
+		t.Fatalf("expected AncestryNotAncestor for 404, got %d", status)
+	}
+	if !strings.Contains(detail, "not found") {
+		t.Fatalf("expected 'not found' detail, got %q", detail)
+	}
+	reg.Verify(t)
+}
+
+func TestCheckAncestry_NotAncestor_409(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/compare/"),
+		httpmock.StatusResponse(409),
+	)
+
+	r, err := NewWithTransport("github.com", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, detail := r.CheckAncestry("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "def456def456def456def456def456def456def4")
+	if status != AncestryNotAncestor {
+		t.Fatalf("expected AncestryNotAncestor for 409, got %d", status)
+	}
+	if !strings.Contains(detail, "no common ancestor") {
+		t.Fatalf("expected 'no common ancestor' detail, got %q", detail)
+	}
+	reg.Verify(t)
+}
+
+func TestCheckAncestry_Unknown_RateLimit(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/actions/checkout/compare/"),
+		httpmock.StatusResponse(429),
+	)
+
+	r, err := NewWithTransport("github.com", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, detail := r.CheckAncestry("actions", "checkout", "abc123abc123abc123abc123abc123abc123abc1", "def456def456def456def456def456def456def4")
+	if status != AncestryUnknown {
+		t.Fatalf("expected AncestryUnknown for rate limit, got %d", status)
+	}
+	if !strings.Contains(detail, "rate limited") {
+		t.Fatalf("expected 'rate limited' detail, got %q", detail)
+	}
+	reg.Verify(t)
+}


### PR DESCRIPTION
## Summary

Adds **LOCKFILE_FORGERY** detection — a new tamper-detection category that catches cases where a lockfile SHA was never in the pinned ref's git lineage. Also gates the `branch_commits` reachability check behind a config flag since the undocumented endpoint 429s aggressively (as it should, we shouldn't be using it for this, just keeping it for demo purposes).

Depends on #12 (reachability v2 landing on main).

## What changed

### Lockfile forgery detection (commits 1-3)

Uses the **Compare API** (`compare/{pinnedSHA}...{liveSHA}`) to check ancestry. If `merge_base ≠ pinnedSHA`, the pinned SHA was never an ancestor of the live ref — the lockfile entry was forged.

- New `CheckAncestry()` in resolver — Compare API ancestry check with 404/409/rate-limit handling
- Post-processes `REF_MOVED` findings in `diagnose.go` — promotes to `LOCKFILE_FORGERY` when ancestry fails
- **Fail-open**: rate limits or API errors keep the finding as `REF_MOVED` with "(ancestry check inconclusive)" annotation
- **Mutually exclusive** with `IMPOSTER_COMMIT` — forgery implies unreachability, so we don't stack both

### Reachability feature flag (commit 4)

The `branch_commits` endpoint has no public API equivalent and 429s constantly. Disabled by default until and if we ship a documented commit reachability API.

```yaml
# ~/.config/gh-actions-pin/config.yml
reachability_check: true  # default: false
```

When disabled:
- `check`: reachability block skipped entirely (no warnings), lockfile forgery still works (Compare API)
- `pin`/`apply`: reachability gate skipped (allows pinning without branch_commits)

Architecture cleanup in this commit:
- Config loading extracted to `internal/doctor/config.go` with `GH_ACTIONS_PIN_CONFIG` env var override
- Demo uses temp config file via env var (no real `~/.config` mutation)
- Removed dead reachability wiring from `upgrade.go`
- Fixed missing `addAlertedDep()` for forgery in `remediate.go`

## Demo

![Lockfile forgery detection](https://vhs.charm.sh/vhs-lIxYHsBBaqndzAm3t2trm.gif)

## Detection behavior matrix

| Scenario | Compare API says | branch_commits says | Finding |
|---|---|---|---|
| Legit tag move | ancestor ✓ | reachable ✓ | `REF_MOVED` (warning) |
| Lockfile tampered | **not ancestor** | n/a | `LOCKFILE_FORGERY` (error) |
| Tag hijacked to fork | ancestor ✓ | **unreachable** | `IMPOSTER_COMMIT` (error) |
| Lockfile tampered + fork | **not ancestor** | unreachable | `LOCKFILE_FORGERY` only (mutual exclusion) |
| API rate limited | unknown | unknown | `REF_MOVED` + "(inconclusive)" |

## Verification

```bash
# All tests pass
go test ./...

# Lockfile forgery demo (works with reachability disabled)
./demo/try-it.sh lockfile-forgery

# Imposter commit demo (requires reachability_check: true)
./demo/try-it.sh imposter-commit
```

## Commits

1. `feat: detect lockfile forgery via Compare API ancestry check` — core feature + tests
2. `demo: add lockfile-forgery try-it scenario` — fixture + demo script
3. `fix: make LOCKFILE_FORGERY and IMPOSTER_COMMIT mutually exclusive` — don't stack findings
4. `feat: gate branch_commits reachability behind config flag` — feature flag + arch cleanup