### PR TITLE
fix: imposter → impostor (align with zizmor + ecosystem spelling)

### DIFF
--- a/.github/copilot/skills/cli-design-proposal/SKILL.md
+++ b/.github/copilot/skills/cli-design-proposal/SKILL.md
@@ -191,4 +191,4 @@ These are the user-facing finding categories shown in CLI output and JSON:
 | `STALE` | Lock entry references an action no longer in the workflow |
 | `REF_CHANGED` | Workflow ref was edited; lock needs updating |
 | `MISLEADING_SHA` | Ref looks like a SHA but resolves to a different commit |
-| `IMPOSTER_COMMIT` | Locked SHA is not in the ref's history |
+| `IMPOSTOR_COMMIT` | Locked SHA is not in the ref's history |

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -60,7 +60,7 @@ func newCheckCmd(f *pinFactory) *cobra.Command {
 			  STALE         - lock entry references an action no longer in the workflow
 			  REF_CHANGED   - workflow ref was edited; lock needs updating
 			  MISLEADING_SHA - ref looks like a SHA but resolves to a different commit
-			  IMPOSTER_COMMIT   - locked SHA is not in the ref's history
+			  IMPOSTOR_COMMIT   - locked SHA is not in the ref's history
 		`),
 		Example: heredoc.Doc(`
 			# Verify all workflows
@@ -282,7 +282,7 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 	// Build a shared REST client + TagLister up-front. The diagnostics
 	// engine now uses the resolver's PeelTagObject directly to recognize
 	// annotated-tag-object SHA pins, so no tagger is needed for that path.
-	// The TagLister is still reused by EnrichImposterFindings and the
+	// The TagLister is still reused by EnrichImpostorFindings and the
 	// Remediator (best-patch-for-SHA lookups, release tag hints) so we
 	// don't refetch tags downstream.
 	hostname := resolveHostname(opts.Hostname)
@@ -298,16 +298,16 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 	// Compute validity from findings.
 	valid := report.IsValid()
 
-	// Enrich imposter-commit findings with a suggested re-pin target — the
+	// Enrich impostor-commit findings with a suggested re-pin target — the
 	// most recent stable release whose commit is still reachable from a
 	// branch in the action repo. Bounded network walk per affected action;
-	// skipped entirely when no imposter findings exist.
-	if hasImposterFindings(report) {
+	// skipped entirely when no impostor findings exist.
+	if hasImpostorFindings(report) {
 		if tagger != nil {
-			doctor.EnrichImposterFindings(report, tagger, r)
+			doctor.EnrichImpostorFindings(report, tagger, r)
 		} else if rc, err := api.NewRESTClient(api.ClientOptions{Host: hostname}); err == nil {
 			tl := doctor.NewTagLister(rc)
-			doctor.EnrichImposterFindings(report, tl, r)
+			doctor.EnrichImpostorFindings(report, tl, r)
 		}
 	}
 
@@ -351,7 +351,7 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 	var alertedSuggestions map[string]string
 	var alertedSearched map[string]bool
 	var fullScanDeps []string
-	var autoFixedImposters []doctor.AutoFixedImposter
+	var autoFixedImpostors []doctor.AutoFixedImpostor
 	printed := false
 
 	var repoOwner, repoName string
@@ -400,8 +400,8 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 		// sane-release suggestion into actual rewrites + re-pins. Runs
 		// after Remediate so applyPin/applySHAToTag have had a chance to
 		// surface the impostor signal first; the rewrites consume the
-		// alerted-suggestions map populated by alertImposter.
-		rem.AutoFixAlertedImposters()
+		// alerted-suggestions map populated by alertImpostor.
+		rem.AutoFixAlertedImpostors()
 
 		if err := store.Save(); err != nil {
 			return fmt.Errorf("saving lockfile: %w", err)
@@ -432,7 +432,7 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 		alertedSearched = rem.AlertedSearched
 		fullScanDeps = rem.FullScanDeps
 		unresolvedDeps = rem.UnresolvedDeps
-		autoFixedImposters = rem.AutoFixedImposters
+		autoFixedImpostors = rem.AutoFixedImpostors
 	}
 
 	// Terminal end-state: spinners and narration are done; print the summary.
@@ -473,14 +473,14 @@ func runCheck(f *pinFactory, opts *checkOptions) error {
 	// pin rewrote uses: to that tag instead of alerting. The substitution may
 	// cross a major-version boundary (e.g. v1.25.0 → v3.0.3) so the user
 	// must eyeball each one — flag it loudly with the publisher-docs link.
-	if len(autoFixedImposters) > 0 {
+	if len(autoFixedImpostors) > 0 {
 		if printed {
 			f.UI.TermBlank()
 		}
 		printed = true
 		f.UI.TermWarn("%d %s auto-pinned to a safer release — review for sanity:",
-			len(autoFixedImposters), ui.Pluralize(len(autoFixedImposters), "action", "actions"))
-		for _, fix := range autoFixedImposters {
+			len(autoFixedImpostors), ui.Pluralize(len(autoFixedImpostors), "action", "actions"))
+		for _, fix := range autoFixedImpostors {
 			short := fix.NewSHA
 			if len(short) > 7 {
 				short = short[:7]
@@ -617,16 +617,16 @@ func isFullyRecorded(pw doctor.ParsedWorkflow) bool {
 	return true
 }
 
-// hasImposterFindings reports whether any workflow in the report carries a
-// CategoryImposterCommit finding. Used to gate the bounded tag-walk that
+// hasImpostorFindings reports whether any workflow in the report carries a
+// CategoryImpostorCommit finding. Used to gate the bounded tag-walk that
 // enriches those findings with a sane-release suggestion.
-func hasImposterFindings(r *doctor.Report) bool {
+func hasImpostorFindings(r *doctor.Report) bool {
 	if r == nil {
 		return false
 	}
 	for _, wr := range r.Workflows {
 		for _, f := range wr.Findings {
-			if f.Category == doctor.CategoryImposterCommit {
+			if f.Category == doctor.CategoryImpostorCommit {
 				return true
 			}
 		}

--- a/cmd/gh-actions-pin/command_test.go
+++ b/cmd/gh-actions-pin/command_test.go
@@ -399,11 +399,11 @@ jobs:
 		categories[f.Category] = true
 	}
 	assert.True(t, categories["ref_moved"], "should detect SHA changed: %+v", payload.Findings)
-	assert.True(t, categories["imposter_commit"], "should detect unreachable commit: %+v", payload.Findings)
+	assert.True(t, categories["impostor_commit"], "should detect unreachable commit: %+v", payload.Findings)
 }
 
 // TestCheck_UnreachableOnly verifies that when a pinned SHA matches live
-// resolution but is not reachable from the ref, an IMPOSTER_COMMIT error is reported.
+// resolution but is not reachable from the ref, an IMPOSTOR_COMMIT error is reported.
 func TestCheck_UnreachableOnly(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
@@ -445,7 +445,7 @@ jobs:
 
 	hasUnreachable := false
 	for _, f := range payload.Findings {
-		if f.Category == "imposter_commit" {
+		if f.Category == "impostor_commit" {
 			hasUnreachable = true
 		}
 	}

--- a/cmd/gh-actions-pin/format/terminal.go
+++ b/cmd/gh-actions-pin/format/terminal.go
@@ -119,7 +119,7 @@ func PresentResults(out *ui.UI, report *doctor.Report, valid bool, willRemediate
 		for _, cat := range []doctor.Category{
 			doctor.CategoryLockfileForgery,
 			doctor.CategoryRefChanged, doctor.CategoryNotPinned,
-			doctor.CategoryStale, doctor.CategoryMisleadingSHA, doctor.CategoryImposterCommit,
+			doctor.CategoryStale, doctor.CategoryMisleadingSHA, doctor.CategoryImpostorCommit,
 		} {
 			if n, ok := catCounts[cat]; ok {
 				parts = append(parts, fmt.Sprintf("%d %s", n, string(cat)))
@@ -257,7 +257,7 @@ func PresentResults(out *ui.UI, report *doctor.Report, valid bool, willRemediate
 // remediator should not re-print it in non-interactive mode).
 func IsAlertedCategory(c doctor.Category) bool {
 	switch c {
-	case doctor.CategoryImposterCommit, doctor.CategoryLockfileForgery, doctor.CategoryMisleadingSHA:
+	case doctor.CategoryImpostorCommit, doctor.CategoryLockfileForgery, doctor.CategoryMisleadingSHA:
 		return true
 	}
 	return false

--- a/demo/try-it.sh
+++ b/demo/try-it.sh
@@ -124,7 +124,7 @@ scenarios=(
   "ref-changed"
   "stale"
   "ref-moved"
-  "imposter-commit"
+  "impostor-commit"
   "lockfile-forgery"
   "json-output"
 )
@@ -149,7 +149,7 @@ usage() {
   echo "    ref-changed        Workflow ref edited; lockfile pins different ref"
   echo "    stale              Lockfile entry orphaned (no uses: references it)"
   echo "    ref-moved          Tag moved forward (routine release)"
-  echo "    imposter-commit    Tag hijacked to fork-network commit (fork injection)"
+  echo "    impostor-commit    Tag hijacked to fork-network commit (fork injection)"
   echo "    lockfile-forgery   Lockfile entry replaced with fork commit SHA"
   echo "    json-output        JSON output for CI integration"
   echo ""
@@ -348,8 +348,8 @@ scenario_ref_moved() {
   ( cd "$scratch" && run gh actions-pin check "$wf" )
 }
 
-scenario_imposter_commit() {
-  banner "Imposter commit — fork injection"
+scenario_impostor_commit() {
+  banner "Impostor commit — fork injection"
   bash "$RESET"
   local scratch wf
   scratch="$(stage_workflow demo/workflows-pwned/1-pinned-before-hijack.yml)"
@@ -461,7 +461,7 @@ run_all() {
   scenario_ref_changed
   scenario_stale
   scenario_ref_moved
-  scenario_imposter_commit
+  scenario_impostor_commit
   scenario_lockfile_forgery
   scenario_json_output
   banner "All non-interactive scenarios complete"
@@ -481,9 +481,9 @@ case "${1}" in
   ref-changed)        scenario_ref_changed ;;
   stale)              scenario_stale ;;
   ref-moved)          scenario_ref_moved ;;
-  imposter-commit|imposter) scenario_imposter_commit ;;
+  impostor-commit|impostor) scenario_impostor_commit ;;
   lockfile-forgery|forgery) scenario_lockfile_forgery ;;
-  tamper-detection|tamper) scenario_ref_moved; scenario_imposter_commit; scenario_lockfile_forgery ;;
+  tamper-detection|tamper) scenario_ref_moved; scenario_impostor_commit; scenario_lockfile_forgery ;;
   json-output|json)   scenario_json_output ;;
   all)                run_all ;;
   *)                  echo "Unknown scenario: $1"; echo; usage ;;

--- a/demo/vhs/impostor-commit.tape
+++ b/demo/vhs/impostor-commit.tape
@@ -1,4 +1,4 @@
-Output demo/vhs/out/imposter-commit.gif
+Output demo/vhs/out/impostor-commit.gif
 
 Set Shell "zsh"
 Set FontFamily "JetBrainsMono Nerd Font"
@@ -18,7 +18,7 @@ Type "grep -E 'uses:|  -' demo/workflows-pwned/1-pinned-before-hijack.yml"
 Enter
 Sleep 2s
 
-Type "echo '# branch_commits detects the fork injection — IMPOSTER_COMMIT fires'"
+Type "echo '# branch_commits detects the fork injection — IMPOSTOR_COMMIT fires'"
 Enter
 Sleep 1s
 

--- a/demo/workflows-pwned/1-pinned-before-hijack.yml
+++ b/demo/workflows-pwned/1-pinned-before-hijack.yml
@@ -19,7 +19,7 @@ name: "1: Pinned before attack — fork-network injection (caught by branch_comm
 #
 # RESULT:  FULLY CAUGHT ✗✗
 #          ⚠ REF_MOVED       — live SHA (7b403c9) ≠ pinned SHA (ea53476)
-#          ✗ IMPOSTER_COMMIT — 7b403c9 is not on any branch in
+#          ✗ IMPOSTOR_COMMIT — 7b403c9 is not on any branch in
 #                              nodeselector/actions-test-fixtures
 #                              (fork-network injection detected via
 #                              branch_commits endpoint)
@@ -30,7 +30,7 @@ name: "1: Pinned before attack — fork-network injection (caught by branch_comm
 # upstream repo — branch_commits returns empty → impostor.
 #
 # REF_MOVED is a warning (tag movement is expected for routine
-# releases). IMPOSTER_COMMIT is the error — the commit doesn't
+# releases). IMPOSTOR_COMMIT is the error — the commit doesn't
 # belong to this repo.
 #
 # CONTRAST WITH SCENARIO 5:

--- a/demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml
+++ b/demo/workflows-pwned/2-pinned-before-lineage-rewrite.yml
@@ -17,14 +17,14 @@ name: "2: Pinned before attack — tag moved backward (same-repo rollback)"
 #          ✓ REACHABLE — 38b3412 is on branch(es) in the upstream repo
 #                        (it's a real commit, just older)
 #
-# Why no IMPOSTER_COMMIT? The branch_commits endpoint checks whether the
+# Why no IMPOSTOR_COMMIT? The branch_commits endpoint checks whether the
 # tag's CURRENT target is on any branch of the repo. Since 38b3412 is a
 # legitimate commit in nodeselector/actions-test-fixtures, it passes.
 # The old compare-API approach detected backward moves by checking if
 # the pinned SHA was an ancestor of the live SHA — but that conflated
 # "tag moved backward" with "fork injection". With branch_commits, we
 # separate the concerns:
-#   • Fork injection (foreign code) → IMPOSTER_COMMIT (error)
+#   • Fork injection (foreign code) → IMPOSTOR_COMMIT (error)
 #   • Tag movement (same-repo code) → REF_MOVED (warning)
 #
 # A backward move to same-repo code is suspicious but not code injection.

--- a/demo/workflows-pwned/3-repinned-bypass.yml
+++ b/demo/workflows-pwned/3-repinned-bypass.yml
@@ -23,7 +23,7 @@ name: "3: Re-pinned after backward move — false baseline"
 # NOTE: This scenario only works with same-repo tag movement (scenario 2).
 # Fork injection (scenario 1) cannot be re-pinned — `gh actions-pin` now
 # runs reachability checks at pin time and refuses to pin fork-network
-# commits (IMPOSTER_COMMIT blocks the pin operation).
+# commits (IMPOSTOR_COMMIT blocks the pin operation).
 #
 # The lockfile is a tamper-EVIDENT seal, not tamper-proof. For same-repo
 # backward moves, REF_MOVED is the only signal — and if the victim

--- a/demo/workflows-pwned/4-never-pinned-pwned.yml
+++ b/demo/workflows-pwned/4-never-pinned-pwned.yml
@@ -25,7 +25,7 @@ name: "4: Never pinned — fork injection caught even without prior baseline"
 #
 # RESULT:  CAUGHT ✗
 #          ✓ NOT TAMPERED    — pinned SHA matches live resolution (both 7b403c9)
-#          ✗ IMPOSTER_COMMIT — 7b403c9 is not on any branch in
+#          ✗ IMPOSTOR_COMMIT — 7b403c9 is not on any branch in
 #                              nodeselector/actions-test-fixtures
 #                              (fork-network commit detected)
 #

--- a/demo/workflows-pwned/5-pinned-before-update.yml
+++ b/demo/workflows-pwned/5-pinned-before-update.yml
@@ -24,7 +24,7 @@ name: "5: Pinned before routine update — legitimate tag movement"
 # CONTRAST WITH SCENARIO 1:
 #   Both show REF_MOVED. The difference: scenario 1's new SHA (7b403c9)
 #   is a fork-network commit with no branches in the upstream repo →
-#   IMPOSTER_COMMIT fires. Here, the new SHA is on a real branch →
+#   IMPOSTOR_COMMIT fires. Here, the new SHA is on a real branch →
 #   reachability passes. branch_commits distinguishes the two cases
 #   that the old compare-API approach could not.
 #

--- a/internal/doctor/apply.go
+++ b/internal/doctor/apply.go
@@ -12,7 +12,7 @@ import (
 )
 
 // splitNWO splits "owner/repo" into its components. Returns ("", "") for
-// inputs without a slash. Used to feed alertImposter coords carved out of
+// inputs without a slash. Used to feed alertImpostor coords carved out of
 // ImpostorError.NWO, which packs owner+repo as a single field.
 func splitNWO(nwo string) (string, string) {
 	i := strings.IndexByte(nwo, '/')
@@ -109,7 +109,7 @@ func (rem *Remediator) applyPin(wr WorkflowReport) error {
 	for _, rr := range reachResults {
 		switch rr.Status {
 		case resolver.Unreachable:
-			rem.alertImposter(wr.Path, rr.Owner, rr.Repo, rr.Ref,
+			rem.alertImpostor(wr.Path, rr.Owner, rr.Repo, rr.Ref,
 				fmt.Sprintf("refusing to pin: impostor commit detected for %s/%s@%s — %s", rr.Owner, rr.Repo, rr.Ref, rr.Detail))
 			return errWorkflowAlerted
 		case resolver.ReachabilityUnknown:
@@ -177,7 +177,7 @@ func (rem *Remediator) applyPin(wr WorkflowReport) error {
 		var imp *resolver.ImpostorError
 		if errors.As(err, &imp) {
 			owner, repo := splitNWO(imp.NWO)
-			rem.alertImposter(wr.Path, owner, repo, imp.Ref, imp.Error())
+			rem.alertImpostor(wr.Path, owner, repo, imp.Ref, imp.Error())
 			return errWorkflowAlerted
 		}
 		return fmt.Errorf("%s: normalizing containing refs: %w", wr.Path, err)
@@ -312,7 +312,7 @@ func (rem *Remediator) normalizeAndRewrite(workflowPath string, deps []lockfile.
 		var imp *resolver.ImpostorError
 		if errors.As(err, &imp) {
 			owner, repo := splitNWO(imp.NWO)
-			rem.alertImposter(workflowPath, owner, repo, imp.Ref, imp.Error())
+			rem.alertImpostor(workflowPath, owner, repo, imp.Ref, imp.Error())
 			return parentMap, errWorkflowAlerted
 		}
 		return parentMap, fmt.Errorf("%s: normalizing containing refs: %w", workflowPath, err)
@@ -353,16 +353,16 @@ func writeWorkflowFile(path string, content []byte) error {
 	return os.WriteFile(path, content, mode)
 }
 
-// AutoFixAlertedImposters walks the alerted-impostor state populated during
+// AutoFixAlertedImpostors walks the alerted-impostor state populated during
 // Remediate and rewrites uses: lines for any dep that already has a
 // sane-release suggestion attached. Each matched workflow is rewritten to
 // the suggested tag and re-pinned via applyPin. Successful fixes are moved
-// from the alerted summary into AutoFixedImposters so the end-of-run output
+// from the alerted summary into AutoFixedImpostors so the end-of-run output
 // can announce them as "auto-pinned — review for sanity" instead of
 // continuing to flag them as unfixable. Workflows whose re-pin fails (e.g.
 // the suggested tag is also unreachable) are left in the alerted set with
 // the rewritten file on disk so the user can inspect manually.
-func (rem *Remediator) AutoFixAlertedImposters() {
+func (rem *Remediator) AutoFixAlertedImpostors() {
 	if len(rem.AlertedSuggestions) == 0 {
 		return
 	}
@@ -439,7 +439,7 @@ func (rem *Remediator) AutoFixAlertedImposters() {
 			continue
 		}
 		for _, fx := range fixes {
-			rem.recordAutoFixedImposter(wp, fx.owner+"/"+fx.repo, fx.oldRef, fx.newTag, fx.newSHA)
+			rem.recordAutoFixedImpostor(wp, fx.owner+"/"+fx.repo, fx.oldRef, fx.newTag, fx.newSHA)
 			fixedKeys[fx.depKey] = true
 		}
 	}

--- a/internal/doctor/check_misleading.go
+++ b/internal/doctor/check_misleading.go
@@ -85,10 +85,10 @@ func checkRefMovedAndForgery(pw ParsedWorkflow, depIndex map[string]parserlock.P
 	return out
 }
 
-// checkImposterCommit emits CategoryImposterCommit when the locked SHA is
+// checkImpostorCommit emits CategoryImpostorCommit when the locked SHA is
 // not reachable from the ref's history. Skips entries already covered by
 // a forgery finding (forgery is the stronger signal).
-func checkImposterCommit(pw ParsedWorkflow, depIndex map[string]parserlock.Pin, r checkResolver, forgeryKeys map[string]bool) []Finding {
+func checkImpostorCommit(pw ParsedWorkflow, depIndex map[string]parserlock.Pin, r checkResolver, forgeryKeys map[string]bool) []Finding {
 	if len(depIndex) == 0 {
 		return nil
 	}
@@ -108,9 +108,9 @@ func checkImposterCommit(pw ParsedWorkflow, depIndex map[string]parserlock.Pin, 
 		if status != resolver.Unreachable {
 			continue
 		}
-		f := newRefFinding(pw, ref, CategoryImposterCommit, SeverityError)
+		f := newRefFinding(pw, ref, CategoryImpostorCommit, SeverityError)
 		f.Dependency = synthDep(ref, pin.Hex)
-		f.Detail = fmt.Sprintf("locked %s is not reachable from %s — classic fork-network imposter-commit shape", shortSha(pin.Hex), ref.Ref)
+		f.Detail = fmt.Sprintf("locked %s is not reachable from %s — classic fork-network impostor-commit shape", shortSha(pin.Hex), ref.Ref)
 		f.Remediation = "investigate immediately — the lockfile entry may have been injected"
 		out = append(out, f)
 	}

--- a/internal/doctor/check_run.go
+++ b/internal/doctor/check_run.go
@@ -10,7 +10,7 @@ import (
 // runChecks evaluates all enabled validators against the given parsed
 // workflow and returns findings in catalog order. The lockfile snapshot
 // scopes the structural checks; the resolver enables the resolver-bound
-// checks (misleading_sha, ref_moved, forgery, imposter). When r is nil,
+// checks (misleading_sha, ref_moved, forgery, impostor). When r is nil,
 // resolver-bound checks are skipped silently.
 //
 // Returned findings have their primitive fields populated, plus
@@ -31,7 +31,7 @@ func runChecks(pw ParsedWorkflow, lf parserlock.File, r checkResolver) []Finding
 		out = append(out, checkMisleadingSha(pw, r)...)
 		refMoved := checkRefMovedAndForgery(pw, depIndex, r)
 		out = append(out, refMoved...)
-		out = append(out, checkImposterCommit(pw, depIndex, r, collectForgeryKeys(refMoved))...)
+		out = append(out, checkImpostorCommit(pw, depIndex, r, collectForgeryKeys(refMoved))...)
 	}
 	return out
 }
@@ -54,7 +54,7 @@ func parseWorkflowDeps(rawDeps []string) ([]parserlock.Pin, map[string]parserloc
 }
 
 // collectForgeryKeys returns the set of IndexKeys flagged as forgery so
-// the imposter check can skip them.
+// the impostor check can skip them.
 func collectForgeryKeys(findings []Finding) map[string]bool {
 	if len(findings) == 0 {
 		return nil

--- a/internal/doctor/check_test.go
+++ b/internal/doctor/check_test.go
@@ -59,7 +59,7 @@ const (
 	shaCheckoutV4 = "8e8c483db84b4bee98b60c0593521ed34d9990e8"
 	shaCheckoutV3 = "11bd71901bbe5b1630ceea73d27597364c9af683"
 	shaSetupGoV5  = "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	shaImposter   = "ffffffffffffffffffffffffffffffffffffffff"
+	shaImpostor   = "ffffffffffffffffffffffffffffffffffffffff"
 )
 
 func checkPinKey(owner, repo, ref, sha string) string {
@@ -191,7 +191,7 @@ func TestRunChecks_RefMoved(t *testing.T) {
 
 func TestRunChecks_LockfileForgery(t *testing.T) {
 	lf := checkNewLockfile(map[string][]string{
-		".github/workflows/ci.yml": {checkPinKey("actions", "checkout", "v4", shaImposter)},
+		".github/workflows/ci.yml": {checkPinKey("actions", "checkout", "v4", shaImpostor)},
 	})
 	pw := checkParsedWF(".github/workflows/ci.yml", checkRef("actions", "checkout", "v4"))
 	r := &stubCheckResolver{
@@ -199,7 +199,7 @@ func TestRunChecks_LockfileForgery(t *testing.T) {
 			"actions/checkout@v4": shaCheckoutV4,
 		},
 		ancestry: map[string]resolver.AncestryStatus{
-			"actions/checkout:" + shaImposter + ":" + shaCheckoutV4: resolver.AncestryNotAncestor,
+			"actions/checkout:" + shaImpostor + ":" + shaCheckoutV4: resolver.AncestryNotAncestor,
 		},
 	}
 	got := runChecks(pw, lf, r)
@@ -216,8 +216,8 @@ func TestRunChecks_LockfileForgery(t *testing.T) {
 			if f.ObservedSHA != shaCheckoutV4 {
 				t.Fatalf("ObservedSHA: got %q, want %q (resolver output, makes claim falsifiable)", f.ObservedSHA, shaCheckoutV4)
 			}
-			if f.Dependency == nil || f.Dependency.SHA != shaImposter {
-				t.Fatalf("Dependency.SHA: want pinned %s, got %#v", shaImposter, f.Dependency)
+			if f.Dependency == nil || f.Dependency.SHA != shaImpostor {
+				t.Fatalf("Dependency.SHA: want pinned %s, got %#v", shaImpostor, f.Dependency)
 			}
 		}
 	}
@@ -226,20 +226,20 @@ func TestRunChecks_LockfileForgery(t *testing.T) {
 	}
 }
 
-func TestRunChecks_ImposterCommit(t *testing.T) {
+func TestRunChecks_ImpostorCommit(t *testing.T) {
 	lf := checkNewLockfile(map[string][]string{
-		".github/workflows/ci.yml": {checkPinKey("actions", "checkout", "v4", shaImposter)},
+		".github/workflows/ci.yml": {checkPinKey("actions", "checkout", "v4", shaImpostor)},
 	})
 	pw := checkParsedWF(".github/workflows/ci.yml", checkRef("actions", "checkout", "v4"))
 	r := &stubCheckResolver{
 		// Resolver doesn't know the ref → no ref_moved / forgery path.
 		reach: map[string]resolver.ReachabilityStatus{
-			"actions/checkout:" + shaImposter + ":v4": resolver.Unreachable,
+			"actions/checkout:" + shaImpostor + ":v4": resolver.Unreachable,
 		},
 	}
 	got := runChecks(pw, lf, r)
-	if len(got) != 1 || got[0].Category != CategoryImposterCommit {
-		t.Fatalf("expected single imposter_commit finding, got %#v", got)
+	if len(got) != 1 || got[0].Category != CategoryImpostorCommit {
+		t.Fatalf("expected single impostor_commit finding, got %#v", got)
 	}
 }
 

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -54,7 +54,7 @@ type ParsedWorkflow struct {
 	DepsErr       error
 	// TrustLockfile, when true, instructs DiagnoseParsed to run this
 	// workflow's diagnostics with a nil resolver. Network-bound checks
-	// (REF_MOVED, IMPOSTER_COMMIT) are skipped and the engine relies on
+	// (REF_MOVED, IMPOSTOR_COMMIT) are skipped and the engine relies on
 	// purely structural validation against the on-disk lockfile. Caller
 	// is asserting "this is already pinned and I trust the prior
 	// verification" — typically set on the fast path when every direct
@@ -411,7 +411,7 @@ func partitionReachByLive(existing, live []lockfile.Dependency, skipUnchanged bo
 }
 
 // reachabilityComplementFindings covers the cases the engine doesn't:
-//   - Imposter for transitive (composite-expanded) deps the engine never
+//   - Impostor for transitive (composite-expanded) deps the engine never
 //     visits because they aren't in workflow uses.
 //   - Reachability-Unknown warnings for all deps (engine fails open on
 //     Unknown). Direct + transitive both get a warning so the user knows
@@ -456,20 +456,20 @@ func reachabilityComplementFindings(
 		switch rr.Status {
 		case resolver.Unreachable:
 			if direct {
-				continue // engine emits imposter for direct uses
+				continue // engine emits impostor for direct uses
 			}
 			if forgeryKeys[rr.DepKey] {
 				continue
 			}
 			out = append(out, Finding{
 				WorkflowPath: path,
-				Category:     CategoryImposterCommit,
+				Category:     CategoryImpostorCommit,
 				Severity:     SeverityError,
 				Dependency:   &depCopy,
 				ParentNWO:    parent,
 				Detail:       rr.Detail,
 				Remediation:  "investigate immediately — the lockfile entry may have been injected",
-				DocURL:       DocURLFor(CategoryImposterCommit),
+				DocURL:       DocURLFor(CategoryImpostorCommit),
 			})
 		case resolver.ReachabilityUnknown:
 			remediation := "transitive dependency pinned to a bare SHA — reachability cannot be verified"

--- a/internal/doctor/doc_urls.go
+++ b/internal/doctor/doc_urls.go
@@ -14,7 +14,7 @@ package doctor
 const securityHardeningBase = "https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions"
 
 // PublisherTagReleasesDocURL points to GitHub's guidance for action publishers
-// on tagging releases from a branch. It's surfaced alongside imposter-commit
+// on tagging releases from a branch. It's surfaced alongside impostor-commit
 // findings to help users escalate to the action's maintainer when the pinned
 // SHA is orphaned (off any branch) — a publisher behavior the consumer can't
 // fix locally beyond re-pinning to a sane release.
@@ -31,7 +31,7 @@ var docURLs = map[Category]string{
 	CategoryMisleadingSHA:   securityHardeningBase + "#using-third-party-actions",
 	CategoryRefMoved:        securityHardeningBase + "#using-third-party-actions",
 	CategoryLockfileForgery: securityHardeningBase + "#using-third-party-actions",
-	CategoryImposterCommit:  securityHardeningBase + "#using-third-party-actions",
+	CategoryImpostorCommit:  securityHardeningBase + "#using-third-party-actions",
 }
 
 // DocURLFor returns the documentation URL for a finding category, or ""

--- a/internal/doctor/finding.go
+++ b/internal/doctor/finding.go
@@ -17,8 +17,8 @@ const (
 	CategoryStale Category = "stale"
 	// CategoryRefChanged means the uses: ref was manually changed (e.g. v6.2.0 → v6).
 	CategoryRefChanged Category = "ref_changed"
-	// CategoryImposterCommit means the pinned SHA is not in the ref's git history (possible fork-network commit).
-	CategoryImposterCommit Category = "imposter_commit"
+	// CategoryImpostorCommit means the pinned SHA is not in the ref's git history (possible fork-network commit).
+	CategoryImpostorCommit Category = "impostor_commit"
 	// CategoryMisleadingSHA means a ref looks like a SHA but resolves to a different commit.
 	CategoryMisleadingSHA Category = "misleading_sha"
 	// CategoryLockfileForgery means the pinned SHA is not an ancestor of the
@@ -74,7 +74,7 @@ type Finding struct {
 	DocURL string
 	// SaneSuggestionTag is the most recent stable tag whose commit is
 	// reachable from a branch, populated for unreachable-SHA findings
-	// (CategoryImposterCommit) when one can be found. Empty otherwise.
+	// (CategoryImpostorCommit) when one can be found. Empty otherwise.
 	SaneSuggestionTag string
 	// SaneSuggestionSHA is the commit SHA the suggested tag points to.
 	SaneSuggestionSHA string

--- a/internal/doctor/impostor_suggestion.go
+++ b/internal/doctor/impostor_suggestion.go
@@ -20,7 +20,7 @@ const maxSaneReleaseTagsChecked = 10
 
 // FindSaneRelease walks the action repo's tags newest-first and returns the
 // first stable release whose commit is reachable from a branch. It's the
-// remediation half of the CategoryImposterCommit detection: when we flag a
+// remediation half of the CategoryImpostorCommit detection: when we flag a
 // pinned SHA as orphaned, this answers "what should the user re-pin to?"
 //
 // Returns ("", "") when no qualifying tag is found within the bounded walk
@@ -58,8 +58,8 @@ func FindSaneRelease(tl *TagLister, r reachabilityChecker, owner, repo string) (
 	return "", ""
 }
 
-// EnrichImposterFindings walks the report and attaches a sane-release
-// suggestion to every CategoryImposterCommit finding when one is available.
+// EnrichImpostorFindings walks the report and attaches a sane-release
+// suggestion to every CategoryImpostorCommit finding when one is available.
 // Mutates findings in place. Safe to call when tl or r is nil — becomes a
 // no-op so non-network code paths (tests, --offline) don't trigger lookups.
 //
@@ -68,11 +68,11 @@ func FindSaneRelease(tl *TagLister, r reachabilityChecker, owner, repo string) (
 // — the latter is itself useful signal (e.g. an action whose entire release
 // flow detaches tag commits from any branch, warranting harder escalation
 // to the publisher).
-func EnrichImposterFindings(report *Report, tl *TagLister, r reachabilityChecker) {
+func EnrichImpostorFindings(report *Report, tl *TagLister, r reachabilityChecker) {
 	if report == nil || tl == nil || r == nil {
 		return
 	}
-	// Cache per owner/repo so multiple imposter findings against the same
+	// Cache per owner/repo so multiple impostor findings against the same
 	// action share a single tag walk + reachability sweep.
 	type suggestion struct{ tag, sha string }
 	cache := make(map[cachekey.Repo]suggestion)
@@ -80,7 +80,7 @@ func EnrichImposterFindings(report *Report, tl *TagLister, r reachabilityChecker
 		wf := &report.Workflows[i]
 		for j := range wf.Findings {
 			f := &wf.Findings[j]
-			if f.Category != CategoryImposterCommit || f.Dependency == nil {
+			if f.Category != CategoryImpostorCommit || f.Dependency == nil {
 				continue
 			}
 			owner, repo := f.Dependency.OwnerRepo()

--- a/internal/doctor/impostor_suggestion_test.go
+++ b/internal/doctor/impostor_suggestion_test.go
@@ -82,10 +82,10 @@ func TestFindSaneRelease_NoneReachable(t *testing.T) {
 	}
 }
 
-// TestEnrichImposterFindings_MarksSearched flags imposter findings with the
+// TestEnrichImpostorFindings_MarksSearched flags impostor findings with the
 // search outcome even when no suggestion is found so renderers can surface
 // the "escalate to publisher" hint.
-func TestEnrichImposterFindings_MarksSearched(t *testing.T) {
+func TestEnrichImpostorFindings_MarksSearched(t *testing.T) {
 	reg := &httpmock.Registry{}
 	registerTagWalk(reg, "acme", "widget", []map[string]any{
 		{"name": "v1.0.0", "commit": map[string]any{"sha": "aaaaaaa1111111111111111111111111111111aa"}},
@@ -98,13 +98,13 @@ func TestEnrichImposterFindings_MarksSearched(t *testing.T) {
 		Workflows: []WorkflowReport{{
 			Path: ".github/workflows/test.yml",
 			Findings: []Finding{{
-				Category:   CategoryImposterCommit,
+				Category:   CategoryImpostorCommit,
 				Dependency: &lockfile.Dependency{NWO: "acme/widget", Ref: "v1"},
 			}},
 		}},
 	}
 
-	EnrichImposterFindings(report, tl, rc)
+	EnrichImpostorFindings(report, tl, rc)
 
 	f := report.Workflows[0].Findings[0]
 	if !f.SaneSuggestionSearched {
@@ -115,10 +115,10 @@ func TestEnrichImposterFindings_MarksSearched(t *testing.T) {
 	}
 }
 
-// TestEnrichImposterFindings_PopulatesSuggestion attaches the discovered tag
+// TestEnrichImpostorFindings_PopulatesSuggestion attaches the discovered tag
 // to the finding so downstream renderers (presentCheckResults, summary) can
 // surface a concrete re-pin target.
-func TestEnrichImposterFindings_PopulatesSuggestion(t *testing.T) {
+func TestEnrichImpostorFindings_PopulatesSuggestion(t *testing.T) {
 	reg := &httpmock.Registry{}
 	registerTagWalk(reg, "acme", "widget", []map[string]any{
 		{"name": "v1.0.0", "commit": map[string]any{"sha": "aaaaaaa1111111111111111111111111111111aa"}},
@@ -133,13 +133,13 @@ func TestEnrichImposterFindings_PopulatesSuggestion(t *testing.T) {
 		Workflows: []WorkflowReport{{
 			Path: ".github/workflows/test.yml",
 			Findings: []Finding{{
-				Category:   CategoryImposterCommit,
+				Category:   CategoryImpostorCommit,
 				Dependency: &lockfile.Dependency{NWO: "acme/widget", Ref: "v1"},
 			}},
 		}},
 	}
 
-	EnrichImposterFindings(report, tl, rc)
+	EnrichImpostorFindings(report, tl, rc)
 
 	f := report.Workflows[0].Findings[0]
 	if f.SaneSuggestionTag != "v1.0.0" {

--- a/internal/doctor/remediate.go
+++ b/internal/doctor/remediate.go
@@ -92,7 +92,7 @@ type Remediator struct {
 
 	// AlertedSuggestions maps an alerted dep key to a sane-release
 	// suggestion (e.g. "v1.4.0 a1b2c3d") computed by
-	// doctor.EnrichImposterFindings — the most recent stable release whose
+	// doctor.EnrichImpostorFindings — the most recent stable release whose
 	// commit is still reachable from a branch. Empty for deps with no
 	// available suggestion. Rendered alongside the reason in the summary.
 	AlertedSuggestions map[string]string
@@ -110,18 +110,18 @@ type Remediator struct {
 	// order preserved.
 	FullScanDeps []string
 
-	// AutoFixedImposters records impostor refs that were silently rewritten
+	// AutoFixedImpostors records impostor refs that were silently rewritten
 	// to the latest reachable release tag during pinning. The end-of-run
 	// summary surfaces these as a "✓ auto-pinned to a safer release —
 	// review for sanity" section so the user can verify the substitution
 	// (which may cross a major-version boundary) wasn't disruptive.
 	// Insertion order preserved; deduplicated by (Workflow, NWO).
-	AutoFixedImposters []AutoFixedImposter
+	AutoFixedImpostors []AutoFixedImpostor
 }
 
-// AutoFixedImposter records a single auto-substitution made when an
+// AutoFixedImpostor records a single auto-substitution made when an
 // unreachable pinned ref had a sane-release suggestion available.
-type AutoFixedImposter struct {
+type AutoFixedImpostor struct {
 	Workflow string // workflow path the rewrite was applied to
 	NWO      string // owner/repo (no path)
 	OldRef   string // ref as written before the rewrite (tag or SHA)
@@ -145,22 +145,22 @@ func (rem *Remediator) recordFullScanDep(depKey string) {
 	rem.FullScanDeps = append(rem.FullScanDeps, depKey)
 }
 
-// recordAutoFixedImposter notes that an impostor ref was silently rewritten
+// recordAutoFixedImpostor notes that an impostor ref was silently rewritten
 // to a sane-release tag during pinning. Deduplicated by (Workflow, NWO);
 // first write wins so a workflow with multiple findings against the same
 // action is only surfaced once.
-func (rem *Remediator) recordAutoFixedImposter(workflow, nwo, oldRef, newTag, newSHA string) {
+func (rem *Remediator) recordAutoFixedImpostor(workflow, nwo, oldRef, newTag, newSHA string) {
 	if workflow == "" || nwo == "" || newTag == "" {
 		return
 	}
 	rem.mu.Lock()
 	defer rem.mu.Unlock()
-	for _, fix := range rem.AutoFixedImposters {
+	for _, fix := range rem.AutoFixedImpostors {
 		if fix.Workflow == workflow && fix.NWO == nwo {
 			return
 		}
 	}
-	rem.AutoFixedImposters = append(rem.AutoFixedImposters, AutoFixedImposter{
+	rem.AutoFixedImpostors = append(rem.AutoFixedImpostors, AutoFixedImpostor{
 		Workflow: workflow,
 		NWO:      nwo,
 		OldRef:   oldRef,
@@ -169,7 +169,7 @@ func (rem *Remediator) recordAutoFixedImposter(workflow, nwo, oldRef, newTag, ne
 	})
 }
 
-// tryAutoFixImposters rewrites a workflow's uses: lines for any impostor
+// tryAutoFixImpostors rewrites a workflow's uses: lines for any impostor
 // findings that have an enriched sane-release suggestion AND appear as a
 // direct dep (matching one of wr.ActionRefs). Mutates wr.Findings in place
 // to drop the auto-fixed impostors so the per-finding loop won't alert them
@@ -177,10 +177,10 @@ func (rem *Remediator) recordAutoFixedImposter(workflow, nwo, oldRef, newTag, ne
 // when at least one rewrite was applied — caller should then run applyPin
 // to resolve and pin against the new tag.
 //
-// Auto-fix only applies when SaneSuggestionTag is set (EnrichImposterFindings
+// Auto-fix only applies when SaneSuggestionTag is set (EnrichImpostorFindings
 // already ran) and the dep is direct: transitive composite-action edges
 // can't be fixed by editing the consumer's workflow file.
-func (rem *Remediator) tryAutoFixImposters(wr *WorkflowReport) bool {
+func (rem *Remediator) tryAutoFixImpostors(wr *WorkflowReport) bool {
 	if wr == nil {
 		return false
 	}
@@ -194,7 +194,7 @@ func (rem *Remediator) tryAutoFixImposters(wr *WorkflowReport) bool {
 	var pending []pendingFix
 	keep := wr.Findings[:0:0]
 	for _, f := range wr.Findings {
-		if f.Category != CategoryImposterCommit || f.Dependency == nil || f.SaneSuggestionTag == "" {
+		if f.Category != CategoryImpostorCommit || f.Dependency == nil || f.SaneSuggestionTag == "" {
 			keep = append(keep, f)
 			continue
 		}
@@ -238,7 +238,7 @@ func (rem *Remediator) tryAutoFixImposters(wr *WorkflowReport) bool {
 	wr.ActionRefs = refs2
 	wr.Findings = keep
 	for _, fix := range pending {
-		rem.recordAutoFixedImposter(wr.Path, fix.nwo, fix.oldRef, fix.newTag, fix.newSHA)
+		rem.recordAutoFixedImpostor(wr.Path, fix.nwo, fix.oldRef, fix.newTag, fix.newSHA)
 	}
 	return true
 }
@@ -283,15 +283,15 @@ func (rem *Remediator) alertWorkflow(workflowPath, depKey, reason, detail string
 	rem.AlertedWorkflows[depKey] = append(rem.AlertedWorkflows[depKey], workflowPath)
 }
 
-// alertImposter wraps alertWorkflow with a sane-release lookup against the
+// alertImpostor wraps alertWorkflow with a sane-release lookup against the
 // action repo so the end-of-run summary can suggest a re-pin target (or
 // signal that no recent release is reachable). Call sites that already
 // produce a Finding go through addAlertedDep + recordAlertSuggestion; this
 // path covers the pin-time refusal in apply.go where only the dep coords
 // are in hand.
-func (rem *Remediator) alertImposter(workflowPath, owner, repo, ref, detail string) {
+func (rem *Remediator) alertImpostor(workflowPath, owner, repo, ref, detail string) {
 	depKey := owner + "/" + repo + "@" + ref
-	rem.alertWorkflow(workflowPath, depKey, reasonForCategory(CategoryImposterCommit), detail)
+	rem.alertWorkflow(workflowPath, depKey, reasonForCategory(CategoryImpostorCommit), detail)
 	tag, sha := FindSaneRelease(rem.tagLister, rem.resolver, owner, repo)
 	rem.mu.Lock()
 	defer rem.mu.Unlock()
@@ -620,7 +620,7 @@ func (rem *Remediator) recordAlertSuggestion(depKey string, f Finding) {
 // reasonForCategory maps an investigation category to concise, user-facing copy.
 func reasonForCategory(c Category) string {
 	switch c {
-	case CategoryImposterCommit:
+	case CategoryImpostorCommit:
 		return "pinned SHA isn't reachable from any branch — likely orphaned and benign, but could be an impostor commit; action publishers should tag releases from a branch"
 	case CategoryLockfileForgery:
 		return "pinned SHA was never in this ref's history — possible lockfile tampering"
@@ -715,9 +715,9 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 	// workflow lacks a suggestion (or is transitive) we don't auto-fix any
 	// of them: the consumer needs the alert anyway, and a half-rewritten
 	// workflow would obscure the unfixable cases.
-	if rem.tryAutoFixImposters(&wr) {
+	if rem.tryAutoFixImpostors(&wr) {
 		// All impostor findings handled — return so we don't re-process
-		// stale CategoryImposterCommit entries from before the rewrite.
+		// stale CategoryImpostorCommit entries from before the rewrite.
 		return rem.applyPin(wr)
 	}
 
@@ -749,7 +749,7 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 		// describes the file on disk.
 		if finding.Dependency != nil && rem.shaConvertedForNWO(finding.Dependency.NWO) {
 			switch finding.Category {
-			case CategoryMisleadingSHA, CategoryImposterCommit, CategoryLockfileForgery:
+			case CategoryMisleadingSHA, CategoryImpostorCommit, CategoryLockfileForgery:
 				continue
 			}
 		}
@@ -765,13 +765,13 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 			}
 		}
 
-		// Alerted-only categories (Imposter/Forgery/Misleading) were already
+		// Alerted-only categories (Impostor/Forgery/Misleading) were already
 		// fully presented by presentCheckResults in non-interactive mode.
 		// Just register the alert here without re-printing the per-workflow
 		// header or finding details.
 		if !rem.prompter.IsInteractive() {
 			switch finding.Category {
-			case CategoryImposterCommit, CategoryLockfileForgery, CategoryMisleadingSHA:
+			case CategoryImpostorCommit, CategoryLockfileForgery, CategoryMisleadingSHA:
 				rem.Alerted++
 				rem.addAlertedDep(finding)
 				continue
@@ -813,7 +813,7 @@ func (rem *Remediator) remediateWorkflow(wr WorkflowReport) error {
 				return err
 			}
 
-		case CategoryImposterCommit:
+		case CategoryImpostorCommit:
 			rem.output.Error("%s", finding.Detail)
 			rem.output.Hint("This may indicate a fork-network injection attack. Do not auto-fix.")
 			rem.Alerted++


### PR DESCRIPTION
The codebase was shipping the spelling "imposter" while zizmor docs, Chainguard, and the broader supply-chain ecosystem all use "impostor". This was a typo, not a stylistic choice.

Fixing it is a prerequisite for:
- emitting `ruleId: "impostor-commit"` against the SARIF schema
- citing zizmor's published criterion in our definitional-alignment argument rather than minting our own term

## What changed

- `CategoryImposterCommit` → `CategoryImpostorCommit` (and its string value `"imposter_commit"` → `"impostor_commit"`)
- `AutoFixedImposter`, `EnrichImposterFindings`, `alertImposter`, `tryAutoFixImposters`, `hasImposterFindings`, `recordAutoFixedImposter`, `AutoFixAlertedImposters`, `autoFixedImposters` and friends
- `internal/doctor/imposter_suggestion{,_test}.go` → `impostor_suggestion*`
- `demo/vhs/imposter-commit.tape` → `impostor-commit.tape`
- `IMPOSTER_COMMIT` label in user-facing strings, demo workflows, godocs, README/skill notes, `try-it.sh` scenario keywords

## Wire-format note

The JSON `category` field in CLI `check --json` output changes from `"imposter_commit"` to `"impostor_commit"`. This is the only externally visible string break. The `pkg/lockfile/` schema and YAML field tags are **not** touched — no lockfile format change.

## Out of scope

- kebab-case rule-id rename (`zizmor-kebab-rule-ids`) — separate card, depends on this one
- SARIF emission — downstream

## Verification

- `go build ./...` ✓
- `go test ./...` ✓ (root module + `pkg/lockfile`)
- `bash -n demo/try-it.sh` ✓