### PR TITLE
refactor(pkg/lockfile): tighten public surface for v0.1.0

### DIFF
--- a/actions-lockfile/README.md
+++ b/actions-lockfile/README.md
@@ -144,11 +144,10 @@ graph entries with `uses:` links to direct dependencies).
 - The lockfile schema is versioned independently. The current schema version
   is `v0.0.1`, embedded in the package and emitted as the `version` field of
   every lockfile.
-- Pre-1.0, the package reserves the right to remove incidentally-exported
-  helpers (notably `BuildPinIndex`, `UsesIndexKey`, and `IsValidPin` are
-  candidates). The 15 symbols documented in the
-  [Usage](#usage) and [What this package does](#what-this-package-does)
-  sections are the intended stable surface.
+- Pre-1.0, the package reserves the right to remove any incidentally-exported
+  helper not covered by the [Usage](#usage) and
+  [What this package does](#what-this-package-does) sections. Those sections
+  define the intended stable surface.
 - Schema changes follow the rules in `RELEASING.md`: backward-compatible
   additions can ship in a minor schema version; breaking changes require a
   new schema `$id` and bumped `version` const.

--- a/pkg/lockfile/path.go
+++ b/pkg/lockfile/path.go
@@ -2,13 +2,13 @@ package lockfile
 
 import "strings"
 
-// UsesIndexKey parses a workflow step `uses:` value into the canonical
+// usesIndexKey parses a workflow step `uses:` value into the canonical
 // lockfile IndexKey ("owner/repo@ref"). Sub-action paths
 // ("owner/repo/path@ref") collapse to "owner/repo@ref" because the
 // lockfile keys on the repository — matching the runner's tarball download
 // identity. Local actions ("./...", ".\\...") and "docker://" references
 // are not lockable; ok=false. Malformed inputs also return ok=false.
-func UsesIndexKey(uses string) (string, bool) {
+func usesIndexKey(uses string) (string, bool) {
 	if strings.HasPrefix(uses, "./") || strings.HasPrefix(uses, ".\\") || strings.HasPrefix(uses, "docker://") {
 		return "", false
 	}

--- a/pkg/lockfile/path_test.go
+++ b/pkg/lockfile/path_test.go
@@ -23,9 +23,9 @@ func TestUsesIndexKey(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := UsesIndexKey(tc.in)
+			got, ok := usesIndexKey(tc.in)
 			if ok != tc.wantOk || got != tc.want {
-				t.Fatalf("UsesIndexKey(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.wantOk)
+				t.Fatalf("usesIndexKey(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.wantOk)
 			}
 		})
 	}

--- a/pkg/lockfile/pin.go
+++ b/pkg/lockfile/pin.go
@@ -125,9 +125,9 @@ func ParsePin(s string) (Pin, bool) {
 	}.Canonical(), true
 }
 
-// IsValidPin checks that a pin string matches the canonical
+// isValidPin checks that a pin string matches the canonical
 // "OWNER/REPO@REF:ALGO-HEX" form.
-func IsValidPin(s string) bool {
+func isValidPin(s string) bool {
 	_, ok := ParsePin(s)
 	return ok
 }
@@ -147,12 +147,12 @@ func IsFullSha(s string) bool {
 	return true
 }
 
-// BuildPinIndex parses a slice of plain pin strings (canonical
+// buildPinIndex parses a slice of plain pin strings (canonical
 // "OWNER/REPO@REF:ALGO-HEX" form) into a lookup map keyed by IndexKey
 // ("OWNER/REPO@REF"). Any duplicate IndexKey is an error: callers receive
 // already-deduplicated lists from the parser, so a duplicate here indicates
 // corruption upstream.
-func BuildPinIndex(deps []string) (map[string]Pin, error) {
+func buildPinIndex(deps []string) (map[string]Pin, error) {
 	index := make(map[string]Pin, len(deps))
 	for _, dep := range deps {
 		pin, ok := ParsePin(dep)

--- a/pkg/lockfile/pin_test.go
+++ b/pkg/lockfile/pin_test.go
@@ -60,7 +60,7 @@ func TestParsePin(t *testing.T) {
 			got, ok := ParsePin(tt.entry)
 			require.True(t, ok)
 			assert.Equal(t, tt.want, got)
-			assert.True(t, IsValidPin(tt.entry))
+			assert.True(t, isValidPin(tt.entry))
 			// Round-trip: serializing the parsed pin reproduces the entry.
 			assert.Equal(t, tt.entry, got.String())
 		})
@@ -91,7 +91,7 @@ func TestParsePin_Invalid(t *testing.T) {
 			got, ok := ParsePin(tt.entry)
 			assert.False(t, ok)
 			assert.Equal(t, Pin{}, got)
-			assert.False(t, IsValidPin(tt.entry))
+			assert.False(t, isValidPin(tt.entry))
 		})
 	}
 }


### PR DESCRIPTION
Pre-`v0.1.0` audit of the three exports flagged in `actions-lockfile/README.md`'s "Compatibility and stability" section. All three had no callers outside `pkg/lockfile/` itself, so they unexport cleanly:

| Export | Resolution | Reason |
| --- | --- | --- |
| `BuildPinIndex` | unexported → `buildPinIndex` | Only callers were intra-package. |
| `UsesIndexKey` | unexported → `usesIndexKey` | Only caller was its own test. |
| `IsValidPin` | unexported → `isValidPin` | Only callers were its own tests. |

Also updates `actions-lockfile/README.md` so "Compatibility and stability" no longer names those three. The stable surface is now defined positively by Usage and What this package does; remaining incidental exports stay subject to pre-1.0 churn without a hardcoded list to maintain.

`CONTRIBUTING.md` schema-change policy left as-is — no schema, YAML field, or pin grammar changes here.

### Verification
- `make test` ✅
- `go build ./...` ✅
- `cd pkg/lockfile && go test ./...` ✅ (the staged repo will inherit only this module)

### Out of scope
- Cutting the real `github/actions-lockfile` repo — gated on this card AND `internal-lockfile-type-leak-plug`.
- Plugging the `parserlock.*` type leak in `internal/lockfile/`.

Off `nodeselector/fix-sha-pin-destruction`. Do not merge.