### PR TITLE
test: dedupe httpmock fixture builders into a single helper

### DIFF
--- a/cmd/gh-actions-pin/command_test.go
+++ b/cmd/gh-actions-pin/command_test.go
@@ -17,42 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// branchListResponse builds a REST list-branches response body for httpmock.
-// pairs are (name, sha) alternating: branchListResponse("main", "abc", "dev", "def")
-// All entries are marked protected:true so tests model trusted-upstream branches.
-func branchListResponse(pairs ...string) any {
-	out := make([]map[string]any, 0, len(pairs)/2)
-	for i := 0; i+1 < len(pairs); i += 2 {
-		out = append(out, map[string]any{
-			"name":      pairs[i],
-			"commit":    map[string]any{"sha": pairs[i+1]},
-			"protected": true,
-		})
-	}
-	return out
-}
-
-// tagListResponse builds a REST list-tags response body for httpmock.
-// pairs are (name, sha) alternating.
-func tagListResponse(pairs ...string) any {
-	out := make([]map[string]any, 0, len(pairs)/2)
-	for i := 0; i+1 < len(pairs); i += 2 {
-		out = append(out, map[string]any{
-			"name":   pairs[i],
-			"commit": map[string]any{"sha": pairs[i+1]},
-		})
-	}
-	return out
-}
-
-// compareAncestorResponse builds a Compare API response indicating sha is an ancestor.
-func compareAncestorResponse(mergeBaseSHA string) any {
-	return map[string]any{
-		"status":            "ahead",
-		"merge_base_commit": map[string]any{"sha": mergeBaseSHA},
-	}
-}
-
 func TestUpgradeCommand_WriteWithHTTPMocks(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
@@ -88,19 +52,19 @@ func TestUpgradeCommand_WriteWithHTTPMocks(t *testing.T) {
 	// actions/checkout: two SHAs (v4 and v6), no exact HEAD match → compare path.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("main", "co-head-sha")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("main", "co-head-sha")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/compare/34e114`),
-		httpmock.JSONResponse(compareAncestorResponse("34e114876b0b11c390a56381ad16ebd13914f8d5")),
+		httpmock.JSONResponse(httpmock.CompareAncestorResponse("34e114876b0b11c390a56381ad16ebd13914f8d5")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/compare/de0fac`),
-		httpmock.JSONResponse(compareAncestorResponse("de0fac2e4500dabe0009e67214ff5f5447ce83dd")),
+		httpmock.JSONResponse(httpmock.CompareAncestorResponse("de0fac2e4500dabe0009e67214ff5f5447ce83dd")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse(
+		httpmock.JSONResponse(httpmock.TagListResponse(
 			"v4", "34e114876b0b11c390a56381ad16ebd13914f8d5",
 			"v6", "de0fac2e4500dabe0009e67214ff5f5447ce83dd",
 		)),
@@ -108,11 +72,11 @@ func TestUpgradeCommand_WriteWithHTTPMocks(t *testing.T) {
 	// actions/setup-go: exact HEAD match → no compare needed.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/setup-go/branches`),
-		httpmock.JSONResponse(branchListResponse("main", "4a3601121dd01d1626a1e23e37211e3254c1c06c")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("main", "4a3601121dd01d1626a1e23e37211e3254c1c06c")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/setup-go/tags`),
-		httpmock.JSONResponse(tagListResponse("v6", "4a3601121dd01d1626a1e23e37211e3254c1c06c")),
+		httpmock.JSONResponse(httpmock.TagListResponse("v6", "4a3601121dd01d1626a1e23e37211e3254c1c06c")),
 	)
 
 	workflowPath := writeTempWorkflow(t, `

--- a/internal/httpmock/githubfixtures.go
+++ b/internal/httpmock/githubfixtures.go
@@ -1,0 +1,60 @@
+package httpmock
+
+// This file mirrors cli/cli's pkg/httpmock/legacy.go: a small set of
+// cross-cutting GitHub REST response shapes used by tests across multiple
+// packages. Keep the surface narrow — only fixtures that are duplicated in
+// two or more test packages belong here. Per-test bespoke shapes should stay
+// inline at the call site.
+
+// BranchListResponse builds a REST list-branches response body. pairs are
+// (name, sha) alternating, e.g. BranchListResponse("main", "abc", "dev", "def").
+// All entries are marked protected:true so tests model trusted-upstream
+// branches by default; use BranchListResponseProtected to mix protected and
+// unprotected entries.
+func BranchListResponse(pairs ...string) any {
+	out := make([]map[string]any, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, map[string]any{
+			"name":      pairs[i],
+			"commit":    map[string]any{"sha": pairs[i+1]},
+			"protected": true,
+		})
+	}
+	return out
+}
+
+// BranchListResponseProtected builds a REST list-branches response body
+// where each entry is a (name, sha, protected) triple.
+func BranchListResponseProtected(triples ...any) any {
+	out := make([]map[string]any, 0, len(triples)/3)
+	for i := 0; i+2 < len(triples); i += 3 {
+		out = append(out, map[string]any{
+			"name":      triples[i],
+			"commit":    map[string]any{"sha": triples[i+1]},
+			"protected": triples[i+2],
+		})
+	}
+	return out
+}
+
+// TagListResponse builds a REST list-tags response body. pairs are
+// (name, sha) alternating.
+func TagListResponse(pairs ...string) any {
+	out := make([]map[string]any, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, map[string]any{
+			"name":   pairs[i],
+			"commit": map[string]any{"sha": pairs[i+1]},
+		})
+	}
+	return out
+}
+
+// CompareAncestorResponse builds a REST compare response indicating the
+// requested sha is an ancestor of the head, with the given merge-base sha.
+func CompareAncestorResponse(mergeBaseSHA string) any {
+	return map[string]any{
+		"status":            "ahead",
+		"merge_base_commit": map[string]any{"sha": mergeBaseSHA},
+	}
+}

--- a/internal/resolver/discover_test.go
+++ b/internal/resolver/discover_test.go
@@ -8,56 +8,6 @@ import (
 	"github.com/github/gh-actions-pin/internal/lockfile"
 )
 
-// branchListResponse returns a REST branches response for httpmock. All
-// entries are marked protected:true so tests model the trusted-upstream
-// case by default. Use branchListResponseProtected to mix protected and
-// unprotected branches.
-func branchListResponse(pairs ...string) any {
-	out := make([]map[string]any, 0, len(pairs)/2)
-	for i := 0; i+1 < len(pairs); i += 2 {
-		out = append(out, map[string]any{
-			"name":      pairs[i],
-			"commit":    map[string]any{"sha": pairs[i+1]},
-			"protected": true,
-		})
-	}
-	return out
-}
-
-// branchListResponseProtected returns a REST branches response where each
-// entry is a (name, sha, protected) triple.
-func branchListResponseProtected(triples ...any) any {
-	out := make([]map[string]any, 0, len(triples)/3)
-	for i := 0; i+2 < len(triples); i += 3 {
-		out = append(out, map[string]any{
-			"name":      triples[i],
-			"commit":    map[string]any{"sha": triples[i+1]},
-			"protected": triples[i+2],
-		})
-	}
-	return out
-}
-
-// tagListResponse returns a REST tags response for httpmock.
-func tagListResponse(pairs ...string) any {
-	out := make([]map[string]any, 0, len(pairs)/2)
-	for i := 0; i+1 < len(pairs); i += 2 {
-		out = append(out, map[string]any{
-			"name":   pairs[i],
-			"commit": map[string]any{"sha": pairs[i+1]},
-		})
-	}
-	return out
-}
-
-// compareResponse returns a Compare API response indicating sha is an ancestor of the head.
-func compareAncestorResponse(mergeBaseSHA string) any {
-	return map[string]any{
-		"status":            "ahead",
-		"merge_base_commit": map[string]any{"sha": mergeBaseSHA},
-	}
-}
-
 func TestDiscoverContaining_PrefersHintTag(t *testing.T) {
 	// sha="abc", hintRef="v4.2.2" (a tag, not a branch name)
 	// Neither branch HEAD matches "abc", so compare is needed.
@@ -66,15 +16,15 @@ func TestDiscoverContaining_PrefersHintTag(t *testing.T) {
 	reg := &httpmock.Registry{}
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("main", "m000", "releases/v4", "rv4000")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("main", "m000", "releases/v4", "rv4000")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/compare/abc`),
-		httpmock.JSONResponse(compareAncestorResponse("abc")),
+		httpmock.JSONResponse(httpmock.CompareAncestorResponse("abc")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse("v4", "abc", "v4.2.1", "abc", "v4.2.2", "abc")),
+		httpmock.JSONResponse(httpmock.TagListResponse("v4", "abc", "v4.2.1", "abc", "v4.2.2", "abc")),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -100,11 +50,11 @@ func TestDiscoverContaining_BranchOnly(t *testing.T) {
 	reg := &httpmock.Registry{}
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("main", "def")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("main", "def")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse()),
+		httpmock.JSONResponse(httpmock.TagListResponse()),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -130,12 +80,12 @@ func TestDiscoverContaining_NoBranchesFailsClosed(t *testing.T) {
 	// Phase 1: listProtectedBranches (query contains "protected=true") returns empty.
 	reg.Register(
 		httpmock.RESTWithQuery("GET", `repos/actions/checkout/branches`, "protected=true"),
-		httpmock.JSONResponse(branchListResponse()),
+		httpmock.JSONResponse(httpmock.BranchListResponse()),
 	)
 	// Phase 2: listBranches (full listing) also returns empty → impostor error.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse()),
+		httpmock.JSONResponse(httpmock.BranchListResponse()),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -159,15 +109,15 @@ func TestDiscoverContainingDefault_PrefersDefaultBranch(t *testing.T) {
 	reg := &httpmock.Registry{}
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("feature/x", "fx000", "main", "m000", "zzz", "z000")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("feature/x", "fx000", "main", "m000", "zzz", "z000")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/compare/abc`),
-		httpmock.JSONResponse(compareAncestorResponse("abc")),
+		httpmock.JSONResponse(httpmock.CompareAncestorResponse("abc")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse()),
+		httpmock.JSONResponse(httpmock.TagListResponse()),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -198,7 +148,7 @@ func TestDiscoverContaining_AutoDiscoversDefaultAndPrefersProtected(t *testing.T
 	// Phase 1: listProtectedBranches returns only the truly-protected branches.
 	reg.Register(
 		httpmock.RESTWithQuery("GET", `repos/actions/checkout/branches`, "protected=true"),
-		httpmock.JSONResponse(branchListResponseProtected(
+		httpmock.JSONResponse(httpmock.BranchListResponseProtected(
 			"main", "m000", true,
 			"releases/v4", "rv4000", true,
 		)),
@@ -206,16 +156,16 @@ func TestDiscoverContaining_AutoDiscoversDefaultAndPrefersProtected(t *testing.T
 	// First compare hit: abc...m000 (default branch) — not an ancestor.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/compare/abc\.\.\.m000`),
-		httpmock.JSONResponse(compareAncestorResponse("0000")),
+		httpmock.JSONResponse(httpmock.CompareAncestorResponse("0000")),
 	)
 	// Second compare hit: abc...rv4000 (protected) — match.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/compare/abc\.\.\.rv4000`),
-		httpmock.JSONResponse(compareAncestorResponse("abc")),
+		httpmock.JSONResponse(httpmock.CompareAncestorResponse("abc")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse()),
+		httpmock.JSONResponse(httpmock.TagListResponse()),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -239,14 +189,14 @@ func TestDiscoverContaining_UnprotectedOnlyFallsBack(t *testing.T) {
 	reg := &httpmock.Registry{}
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponseProtected(
+		httpmock.JSONResponse(httpmock.BranchListResponseProtected(
 			"main", "abc", false,
 			"dev", "d000", false,
 		)),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse()),
+		httpmock.JSONResponse(httpmock.TagListResponse()),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -272,26 +222,26 @@ func TestDiscoverContaining_CommitOnlyOnUnprotectedBranchFallsBack(t *testing.T)
 	// Phase 1: listProtectedBranches returns only main.
 	reg.Register(
 		httpmock.RESTWithQuery("GET", `repos/actions/checkout/branches`, "protected=true"),
-		httpmock.JSONResponse(branchListResponseProtected(
+		httpmock.JSONResponse(httpmock.BranchListResponseProtected(
 			"main", "m000", true,
 		)),
 	)
 	// Phase 1 compare: abc not an ancestor of main.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/compare/abc\.\.\.m000`),
-		httpmock.JSONResponse(compareAncestorResponse("0000")),
+		httpmock.JSONResponse(httpmock.CompareAncestorResponse("0000")),
 	)
 	// Phase 2: full branch listing includes unprotected dev.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponseProtected(
+		httpmock.JSONResponse(httpmock.BranchListResponseProtected(
 			"main", "m000", true,
 			"dev", "abc", false,
 		)),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse()),
+		httpmock.JSONResponse(httpmock.TagListResponse()),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -314,11 +264,11 @@ func TestNormalizeContaining_PopulatesTagBranchAndRewritesSHAPins(t *testing.T) 
 	reg := &httpmock.Registry{}
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("main", "abc123")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("main", "abc123")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse("v4", "abc123")),
+		httpmock.JSONResponse(httpmock.TagListResponse("v4", "abc123")),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -355,11 +305,11 @@ func TestNormalizeContaining_NoChangeWhenRefAlreadyCanonical(t *testing.T) {
 	reg := &httpmock.Registry{}
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("main", "abc")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("main", "abc")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse("v4", "abc")),
+		httpmock.JSONResponse(httpmock.TagListResponse("v4", "abc")),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -391,7 +341,7 @@ func TestNormalizeContaining_FailsClosedOnImpostor(t *testing.T) {
 	reg := &httpmock.Registry{}
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse()),
+		httpmock.JSONResponse(httpmock.BranchListResponse()),
 	)
 	r, err := NewWithTransport("github.com", reg)
 	if err != nil {
@@ -414,11 +364,11 @@ func TestNormalizeContaining_PreservesBranchRefOverTag(t *testing.T) {
 	reg := &httpmock.Registry{}
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("main", "abc", "releases/v4", "xyz")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("main", "abc", "releases/v4", "xyz")),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(tagListResponse("v4", "abc", "v4.3.1", "abc")),
+		httpmock.JSONResponse(httpmock.TagListResponse("v4", "abc", "v4.3.1", "abc")),
 	)
 
 	r, err := NewWithTransport("github.com", reg)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -755,7 +755,7 @@ func TestCheckReachability_SHAAsRef_ChecksViaBranchCommits(t *testing.T) {
 		// Bare-SHA ref: main HEAD == sha → exact match → Reachable.
 		reg.Register(
 			httpmock.REST("GET", `repos/actions/checkout/branches`),
-			httpmock.JSONResponse(branchListResponse("main", sha)),
+			httpmock.JSONResponse(httpmock.BranchListResponse("main", sha)),
 		)
 		r, err := NewWithTransport("github.com", reg)
 		if err != nil {
@@ -776,7 +776,7 @@ func TestCheckReachability_SHAAsRef_ChecksViaBranchCommits(t *testing.T) {
 		probeBranchesEmpty(reg)
 		reg.Register(
 			httpmock.REST("GET", `repos/actions/checkout/branches`),
-			httpmock.JSONResponse(branchListResponse()),
+			httpmock.JSONResponse(httpmock.BranchListResponse()),
 		)
 		r, err := NewWithTransport("github.com", reg)
 		if err != nil {
@@ -799,7 +799,7 @@ func TestCheckReachability_OnBranch_Reachable(t *testing.T) {
 	// Fast path: releases/v6 HEAD == sha → exact match → Reachable.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("releases/v6", sha)),
+		httpmock.JSONResponse(httpmock.BranchListResponse("releases/v6", sha)),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -824,7 +824,7 @@ func TestCheckReachability_ForkInjection_Unreachable(t *testing.T) {
 	probeBranchesEmpty(reg)
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse()),
+		httpmock.JSONResponse(httpmock.BranchListResponse()),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -855,12 +855,12 @@ func TestCheckReachability_FoundViaFullScan_SetsFullScanUsed(t *testing.T) {
 	// ancestry (Compare) slow path rather than an exact-HEAD match.
 	reg.Register(
 		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(branchListResponse("feature/x", "fx000")),
+		httpmock.JSONResponse(httpmock.BranchListResponse("feature/x", "fx000")),
 	)
 	// Compare confirms sha is an ancestor of the branch HEAD → reachable.
 	reg.Register(
 		httpmock.REST("GET", "repos/actions/checkout/compare/"),
-		httpmock.JSONResponse(compareAncestorResponse(sha)),
+		httpmock.JSONResponse(httpmock.CompareAncestorResponse(sha)),
 	)
 
 	r, err := NewWithTransport("github.com", reg)
@@ -994,7 +994,7 @@ func TestDiscoverContaining_BranchBeyondPageCap_NotImpostor(t *testing.T) {
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/vercel/next.js/tags`),
-		httpmock.JSONResponse(tagListResponse()),
+		httpmock.JSONResponse(httpmock.TagListResponse()),
 	)
 
 	r, err := NewWithTransport("github.com", reg)


### PR DESCRIPTION
Top finding from the cli/cli style audit. The fixture builders `branchListResponse`, `branchListResponseProtected`, `tagListResponse`, and `compareAncestorResponse` were defined twice — once in `internal/resolver/discover_test.go` (package `resolver`) and once in `cmd/gh-actions-pin/command_test.go` (package `main`) — because Go test helpers aren't importable across packages.

## Change

Promote them to `internal/httpmock/githubfixtures.go` as exported free functions. This mirrors cli/cli's `pkg/httpmock/legacy.go` pattern: small cross-cutting GitHub REST response shapes live in the `httpmock` package itself rather than a new sub-package, so any test that already imports `internal/httpmock` can use them with no extra dependency.

Drop the duplicate local definitions and rewrite call sites in:

- `cmd/gh-actions-pin/command_test.go`
- `internal/resolver/discover_test.go`
- `internal/resolver/resolver_test.go`

## Verification

- `go build ./...` ✅
- `make test` ✅ (all packages pass)

## Scope

Test infrastructure only — no production code changes. Unblocks the follow-up `check-test-tabledrive-retype` card.

Based on `nodeselector/fix-sha-pin-destruction`; not for merge yet.