### PR TITLE
feat: add Confidence axis to Finding (zizmor model)

### DIFF
--- a/cmd/gh-actions-pin/format/json.go
+++ b/cmd/gh-actions-pin/format/json.go
@@ -19,6 +19,7 @@ type Finding struct {
 	Workflow    string `json:"workflow"`
 	Category    string `json:"category"`
 	Severity    string `json:"severity"`
+	Confidence  string `json:"confidence,omitempty"`
 	Dependency  string `json:"dependency,omitempty"`
 	RequiredBy  string `json:"required_by,omitempty"`
 	Detail      string `json:"detail"`
@@ -52,6 +53,7 @@ func findingFromDoctor(f doctor.Finding) Finding {
 		Workflow:    f.WorkflowPath,
 		Category:    string(f.Category),
 		Severity:    string(f.Severity),
+		Confidence:  string(f.Confidence),
 		Detail:      f.Detail,
 		Remediation: f.Remediation,
 		DocURL:      f.DocURL,

--- a/cmd/gh-actions-pin/provenance_test.go
+++ b/cmd/gh-actions-pin/provenance_test.go
@@ -26,6 +26,7 @@ func TestBuildProvenanceReport_RecordsObservedSHA(t *testing.T) {
 		WorkflowPath: ".github/workflows/ci.yml",
 		Category:     doctor.Category("misleading_sha"),
 		Severity:     doctor.SeverityWarning,
+		Confidence:   doctor.ConfidenceHigh,
 		Dependency:   dep,
 		ObservedSHA:  observedSHA,
 	}
@@ -64,6 +65,7 @@ func TestBuildProvenanceReport_OmitsObservedSHAWhenEqual(t *testing.T) {
 		WorkflowPath: ".github/workflows/ci.yml",
 		Category:     doctor.Category("stale"),
 		Severity:     doctor.SeverityInfo,
+		Confidence:   doctor.ConfidenceHigh,
 		Dependency:   dep,
 		ObservedSHA:  sha, // matches pinned SHA — nothing to flag
 	}
@@ -148,6 +150,7 @@ func TestBuildProvenanceReport_RecordsObservedSHA_AllDivergenceCategories(t *tes
 				WorkflowPath: ".github/workflows/ci.yml",
 				Category:     tc.category,
 				Severity:     doctor.SeverityError,
+				Confidence:   doctor.ConfidenceHigh,
 				Dependency:   dep,
 				ObservedSHA:  tc.observedSHA,
 			}

--- a/internal/doctor/check_misleading.go
+++ b/internal/doctor/check_misleading.go
@@ -30,7 +30,10 @@ func checkMisleadingSha(pw ParsedWorkflow, r checkResolver) []Finding {
 		if peeled, ok := r.PeelTagObject(ref.Owner, ref.Repo, ref.Ref); ok && strings.EqualFold(peeled, sha) {
 			continue
 		}
-		f := newRefFinding(pw, ref, CategoryMisleadingSHA, SeverityError)
+		// High confidence: ref string is SHA-shaped, resolver returned a
+		// different commit, and we ruled out the legitimate tag-object
+		// shape via PeelTagObject. Direct string comparison.
+		f := newRefFinding(pw, ref, CategoryMisleadingSHA, SeverityError, ConfidenceHigh)
 		f.ObservedSHA = sha
 		f.Dependency = synthDep(ref, ref.Ref)
 		f.Detail = fmt.Sprintf("ref %s resolves to %s — the ref string looks like a SHA but isn't this commit", shortSha(ref.Ref), shortSha(sha))
@@ -62,21 +65,32 @@ func checkRefMovedAndForgery(pw ParsedWorkflow, depIndex map[string]parserlock.P
 			continue
 		}
 		ancestry := r.CheckAncestry(ref.Owner, ref.Repo, pin.Hex, sha)
-		f := newRefFinding(pw, ref, "", "")
+		f := newRefFinding(pw, ref, "", "", "")
 		f.ObservedSHA = sha
 		f.Dependency = synthDep(ref, pin.Hex)
 		switch ancestry {
 		case resolver.AncestryNotAncestor:
+			// High confidence: the Compare API gave us an authoritative
+			// "not an ancestor" answer.
 			f.Category = CategoryLockfileForgery
 			f.Severity = SeverityError
+			f.Confidence = ConfidenceHigh
 			f.Detail = fmt.Sprintf("pinned %s is not an ancestor of %s — lockfile may have been tampered with", shortSha(pin.Hex), shortSha(sha))
 			f.Remediation = "investigate immediately — verify the lockfile entry against upstream history"
 		default:
 			f.Category = CategoryRefMoved
 			f.Severity = SeverityWarning
-			f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s", ref.Ref, shortSha(sha), shortSha(pin.Hex))
+			// Medium confidence when ancestry is unknown: we inferred
+			// from the SHA mismatch alone because the Compare API was
+			// rate-limited or errored (see resolver.go CheckAncestry
+			// fallback ~line 1361). Otherwise we got AncestryConfirmed
+			// and the move is benign-but-known.
 			if ancestry == resolver.AncestryUnknown {
-				f.Detail += " (ancestry check inconclusive)"
+				f.Confidence = ConfidenceMedium
+				f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s (ancestry check inconclusive)", ref.Ref, shortSha(sha), shortSha(pin.Hex))
+			} else {
+				f.Confidence = ConfidenceHigh
+				f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s", ref.Ref, shortSha(sha), shortSha(pin.Hex))
 			}
 			f.Remediation = "re-run `gh actions-pin` to refresh the lock entry"
 		}
@@ -108,7 +122,10 @@ func checkImposterCommit(pw ParsedWorkflow, depIndex map[string]parserlock.Pin, 
 		if status != resolver.Unreachable {
 			continue
 		}
-		f := newRefFinding(pw, ref, CategoryImposterCommit, SeverityError)
+		// High confidence: branch_commits gave us an authoritative answer
+		// that the locked SHA is not reachable from any branch of the
+		// upstream repo (classic fork-network imposter shape).
+		f := newRefFinding(pw, ref, CategoryImposterCommit, SeverityError, ConfidenceHigh)
 		f.Dependency = synthDep(ref, pin.Hex)
 		f.Detail = fmt.Sprintf("locked %s is not reachable from %s — classic fork-network imposter-commit shape", shortSha(pin.Hex), ref.Ref)
 		f.Remediation = "investigate immediately — the lockfile entry may have been injected"

--- a/internal/doctor/check_run.go
+++ b/internal/doctor/check_run.go
@@ -73,12 +73,14 @@ func collectForgeryKeys(findings []Finding) map[string]bool {
 // newRefFinding builds a Finding with the common header fields populated
 // from a uses: ref. Category/Severity can be empty when the caller fills
 // them in based on a downstream branch (e.g. ref-moved vs forgery).
-func newRefFinding(pw ParsedWorkflow, ref parserlock.ActionRef, cat Category, sev Severity) Finding {
+// Confidence is required at construction — see Finding.Confidence.
+func newRefFinding(pw ParsedWorkflow, ref parserlock.ActionRef, cat Category, sev Severity, conf Confidence) Finding {
 	refCopy := ref
 	return Finding{
 		WorkflowPath: pw.Path,
 		Category:     cat,
 		Severity:     sev,
+		Confidence:   conf,
 		ActionRef:    &refCopy,
 	}
 }

--- a/internal/doctor/check_structural.go
+++ b/internal/doctor/check_structural.go
@@ -31,7 +31,7 @@ func checkNotPinned(pw ParsedWorkflow, depPins []parserlock.Pin, depIndex map[st
 		if knownAction[nwoLower(ref.Owner, ref.Repo)] {
 			continue
 		}
-		f := newRefFinding(pw, ref, CategoryNotPinned, SeverityError)
+		f := newRefFinding(pw, ref, CategoryNotPinned, SeverityError, ConfidenceHigh)
 		f.Detail = fmt.Sprintf("used in workflow but not pinned in lockfile (%s@%s)", formatUseName(ref.Owner, ref.Repo, ref.Path), ref.Ref)
 		f.Remediation = "pin with `gh actions-pin`"
 		out = append(out, f)
@@ -49,7 +49,7 @@ func checkShaAsRef(pw ParsedWorkflow, depIndex map[string]parserlock.Pin) []Find
 		if !parserlock.IsFullSha(ref.Ref) {
 			continue
 		}
-		f := newRefFinding(pw, ref, CategorySHAAsRef, SeverityWarning)
+		f := newRefFinding(pw, ref, CategorySHAAsRef, SeverityWarning, ConfidenceHigh)
 		f.Detail = "pinned to a bare SHA without a symbolic ref — weakens supply-chain traceability"
 		f.Remediation = fmt.Sprintf("pin to a tag instead: https://github.com/%s/releases", nwoLower(ref.Owner, ref.Repo))
 		lockedSha := ref.Ref
@@ -96,7 +96,9 @@ func checkRefChanged(pw ParsedWorkflow, depPins []parserlock.Pin) []Finding {
 			continue
 		}
 		p := candidates[0]
-		f := newRefFinding(pw, ref, CategoryRefChanged, SeverityError)
+		// High confidence: this is the lockfile-vs-workflow string mismatch
+		// — exact comparison of two strings we control, no inference.
+		f := newRefFinding(pw, ref, CategoryRefChanged, SeverityError, ConfidenceHigh)
 		f.Detail = fmt.Sprintf("workflow uses ref %q but lockfile pins %q", ref.Ref, p.Ref)
 		f.Remediation = "re-run `gh actions-pin` to refresh the lockfile, or revert the uses: line"
 		f.Dependency = synthDep(ref, p.Hex)
@@ -135,6 +137,7 @@ func checkStale(pw ParsedWorkflow, depPins []parserlock.Pin) []Finding {
 			WorkflowPath: pw.Path,
 			Category:     CategoryStale,
 			Severity:     SeverityWarning,
+			Confidence:   ConfidenceHigh,
 			Detail:       fmt.Sprintf("lockfile pins %s@%s but no uses: in this workflow references it", nwoLower(p.Owner, p.Repo), p.Ref),
 			Remediation:  "remove the entry or re-run `gh actions-pin`",
 			Dependency: &lockfile.Dependency{

--- a/internal/doctor/check_test.go
+++ b/internal/doctor/check_test.go
@@ -306,3 +306,116 @@ func TestRunChecks_NoResolver_SkipsResolverChecks(t *testing.T) {
 		t.Fatalf("expected zero findings with no resolver, got %#v", got)
 	}
 }
+
+// TestRunChecks_AllFindingsCarryConfidence is the fail-fast guard the
+// confidence-axis card requires: every finding emitted by any check
+// path must carry a non-empty Confidence. A zero value here would mean
+// a new check (or an edit to an existing one) forgot to set the field,
+// and the JSON/SARIF surface would leak `""`.
+func TestRunChecks_AllFindingsCarryConfidence(t *testing.T) {
+// Cover every check path runChecks dispatches to.
+lf := checkNewLockfile(map[string][]string{
+".github/workflows/ci.yml": {
+checkPinKey("actions", "checkout", "v4", shaCheckoutV3), // ref_moved/forgery seed
+checkPinKey("actions", "unused", "v1", shaSetupGoV5),    // stale seed
+},
+})
+pw := checkParsedWF(".github/workflows/ci.yml",
+checkRef("actions", "checkout", "v4"),       // ref_moved or forgery
+checkRef("actions", "setup-node", "v3"),     // not_pinned
+checkRef("actions", "bare-sha", shaImposter), // sha_as_ref + misleading
+)
+r := &stubCheckResolver{
+refs: map[string]string{
+"actions/checkout@v4":         shaCheckoutV4,
+"actions/bare-sha@" + shaImposter: shaSetupGoV5,
+},
+ancestry: map[string]resolver.AncestryStatus{
+"actions/checkout:" + shaCheckoutV3 + ":" + shaCheckoutV4: resolver.AncestryConfirmed,
+},
+reach: map[string]resolver.ReachabilityStatus{
+"actions/checkout:" + shaCheckoutV3 + ":v4": resolver.Reachable,
+},
+}
+got := runChecks(pw, lf, r)
+if len(got) == 0 {
+t.Fatal("expected findings to exercise the confidence guard")
+}
+for i, f := range got {
+if f.Confidence == "" {
+t.Errorf("finding[%d] category=%s has empty Confidence — every construction site must set it", i, f.Category)
+}
+}
+}
+
+// TestRunChecks_RefMoved_AncestryUnknown_IsMedium pins the
+// rate-limit-fallback contract from the confidence-axis card: when the
+// Compare API can't give us an authoritative ancestry answer
+// (AncestryUnknown — rate limit, transient API error, see
+// resolver/resolver.go CheckAncestry), the resulting ref_moved finding
+// downgrades from High to Medium so consumers know we inferred from the
+// SHA mismatch alone.
+func TestRunChecks_RefMoved_AncestryUnknown_IsMedium(t *testing.T) {
+lf := checkNewLockfile(map[string][]string{
+".github/workflows/ci.yml": {checkPinKey("actions", "checkout", "v4", shaCheckoutV3)},
+})
+pw := checkParsedWF(".github/workflows/ci.yml", checkRef("actions", "checkout", "v4"))
+r := &stubCheckResolver{
+refs: map[string]string{
+"actions/checkout@v4": shaCheckoutV4,
+},
+// No ancestry entry → stub returns AncestryUnknown.
+reach: map[string]resolver.ReachabilityStatus{
+"actions/checkout:" + shaCheckoutV3 + ":v4": resolver.Reachable,
+},
+}
+got := runChecks(pw, lf, r)
+var rm *Finding
+for i := range got {
+if got[i].Category == CategoryRefMoved {
+rm = &got[i]
+break
+}
+}
+if rm == nil {
+t.Fatalf("expected a ref_moved finding, got %v", findingCategories(got))
+}
+if rm.Confidence != ConfidenceMedium {
+t.Errorf("Confidence: got %q, want %q (AncestryUnknown is the rate-limit fallback path)", rm.Confidence, ConfidenceMedium)
+}
+}
+
+// TestRunChecks_RefMoved_AncestryConfirmed_IsHigh is the positive counterpart:
+// when the Compare API gives us AncestryConfirmed the ref_moved finding is
+// High-confidence because we have authoritative upstream data.
+func TestRunChecks_RefMoved_AncestryConfirmed_IsHigh(t *testing.T) {
+lf := checkNewLockfile(map[string][]string{
+".github/workflows/ci.yml": {checkPinKey("actions", "checkout", "v4", shaCheckoutV3)},
+})
+pw := checkParsedWF(".github/workflows/ci.yml", checkRef("actions", "checkout", "v4"))
+r := &stubCheckResolver{
+refs: map[string]string{
+"actions/checkout@v4": shaCheckoutV4,
+},
+ancestry: map[string]resolver.AncestryStatus{
+"actions/checkout:" + shaCheckoutV3 + ":" + shaCheckoutV4: resolver.AncestryConfirmed,
+},
+reach: map[string]resolver.ReachabilityStatus{
+"actions/checkout:" + shaCheckoutV3 + ":v4": resolver.Reachable,
+},
+}
+got := runChecks(pw, lf, r)
+var rm *Finding
+for i := range got {
+if got[i].Category == CategoryRefMoved {
+rm = &got[i]
+break
+}
+}
+if rm == nil {
+t.Fatalf("expected a ref_moved finding, got %v", findingCategories(got))
+}
+if rm.Confidence != ConfidenceHigh {
+t.Errorf("Confidence: got %q, want %q (AncestryConfirmed is authoritative)", rm.Confidence, ConfidenceHigh)
+}
+}

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -163,8 +163,10 @@ func diagnoseOneParsed(pw ParsedWorkflow, r *resolver.Resolver, store *lockfile.
 			WorkflowPath: pw.Path,
 			Category:     CategoryNotPinned,
 			Severity:     SeverityError,
-			Detail:       fmt.Sprintf("failed to load workflow: %s", pw.LoadErr),
-			DocURL:       DocURLFor(CategoryNotPinned),
+			// High: the YAML failed to load — concrete, file-level fact.
+			Confidence:  ConfidenceHigh,
+			Detail:      fmt.Sprintf("failed to load workflow: %s", pw.LoadErr),
+			DocURL:      DocURLFor(CategoryNotPinned),
 		})
 		return wr
 	}
@@ -177,6 +179,7 @@ func diagnoseOneParsed(pw ParsedWorkflow, r *resolver.Resolver, store *lockfile.
 			WorkflowPath: pw.Path,
 			Category:     CategoryRunOnly,
 			Severity:     SeverityOK,
+			Confidence:   ConfidenceHigh,
 			Detail:       "no action references found",
 		})
 		return wr
@@ -187,6 +190,7 @@ func diagnoseOneParsed(pw ParsedWorkflow, r *resolver.Resolver, store *lockfile.
 			WorkflowPath: pw.Path,
 			Category:     CategoryNotPinned,
 			Severity:     SeverityError,
+			Confidence:   ConfidenceHigh,
 			Detail:       fmt.Sprintf("failed to read dependencies: %s", pw.DepsErr),
 			Remediation:  "fix or regenerate the dependencies: section with `gh actions-pin`",
 			DocURL:       DocURLFor(CategoryNotPinned),
@@ -209,10 +213,13 @@ func diagnoseOneParsed(pw ParsedWorkflow, r *resolver.Resolver, store *lockfile.
 		var resolveErr error
 		liveDeps, resolvedParents, resolveErr = r.ResolveAllRecursive(pw.Refs)
 		if resolveErr != nil {
+			// Low: we're surfacing the resolver failure itself, not a
+			// verdict about any specific dependency.
 			wr.Findings = append(wr.Findings, Finding{
 				WorkflowPath: pw.Path,
 				Category:     CategoryValid,
 				Severity:     SeverityWarning,
+				Confidence:   ConfidenceLow,
 				Detail:       fmt.Sprintf("could not re-resolve actions: %s", resolveErr),
 			})
 		}
@@ -265,6 +272,7 @@ func diagnoseOneParsed(pw ParsedWorkflow, r *resolver.Resolver, store *lockfile.
 			WorkflowPath: pw.Path,
 			Category:     CategoryValid,
 			Severity:     SeverityOK,
+			Confidence:   ConfidenceHigh,
 			Detail:       "all dependencies pinned and verified",
 		})
 	}
@@ -461,10 +469,13 @@ func reachabilityComplementFindings(
 			if forgeryKeys[rr.DepKey] {
 				continue
 			}
+			// High: branch_commits returned an authoritative
+			// "unreachable" for this transitive pin.
 			out = append(out, Finding{
 				WorkflowPath: path,
 				Category:     CategoryImposterCommit,
 				Severity:     SeverityError,
+				Confidence:   ConfidenceHigh,
 				Dependency:   &depCopy,
 				ParentNWO:    parent,
 				Detail:       rr.Detail,
@@ -476,10 +487,12 @@ func reachabilityComplementFindings(
 			if direct {
 				remediation = "reachability check inconclusive — retry when network/API is available"
 			}
+			// Low: we couldn't get a reachability answer at all.
 			out = append(out, Finding{
 				WorkflowPath: path,
 				Category:     CategoryValid,
 				Severity:     SeverityWarning,
+				Confidence:   ConfidenceLow,
 				Dependency:   &depCopy,
 				ParentNWO:    parent,
 				Detail:       rr.Detail,

--- a/internal/doctor/finding.go
+++ b/internal/doctor/finding.go
@@ -32,6 +32,30 @@ const (
 	CategoryRunOnly Category = "run_only"
 )
 
+// Confidence describes how strongly the check stands behind a finding,
+// modeled on zizmor's audit output. It complements Severity (how bad the
+// issue would be if real) by capturing how certain we are that it IS
+// real. The three levels are deliberately coarse — finer gradations
+// invite bikeshedding without helping consumers act.
+type Confidence string
+
+const (
+	// ConfidenceLow signals the finding is informational or rests on a
+	// signal we couldn't fully verify (e.g. resolver/network failure,
+	// reachability inconclusive). Treat as a hint, not a verdict.
+	ConfidenceLow Confidence = "low"
+	// ConfidenceMedium signals the finding rests on a fallback inference
+	// — we couldn't get an authoritative answer (rate limit, partial
+	// API response) and inferred from secondary shape (e.g. tag-object
+	// peel, AncestryUnknown). Likely real but worth double-checking.
+	ConfidenceMedium Confidence = "medium"
+	// ConfidenceHigh signals the finding rests on direct, authoritative
+	// data: a string mismatch the user can verify by eye, an exact SHA
+	// comparison, or an ancestry/reachability answer we got from the
+	// upstream API. Act on these.
+	ConfidenceHigh Confidence = "high"
+)
+
 // Severity indicates how serious a finding is.
 type Severity string
 
@@ -54,6 +78,10 @@ type Finding struct {
 	Category Category
 	// Severity of the finding.
 	Severity Severity
+	// Confidence of the finding — see the Confidence type docs. Always
+	// populated at construction; an empty value is a bug and the
+	// no-empty-confidence test will catch it.
+	Confidence Confidence
 	// ActionRef is the action reference this finding relates to (nil for workflow-level findings).
 	ActionRef *parserlock.ActionRef
 	// Dependency is the existing pinned dep if any.

--- a/internal/doctor/imposter_suggestion_test.go
+++ b/internal/doctor/imposter_suggestion_test.go
@@ -99,6 +99,7 @@ func TestEnrichImposterFindings_MarksSearched(t *testing.T) {
 			Path: ".github/workflows/test.yml",
 			Findings: []Finding{{
 				Category:   CategoryImposterCommit,
+				Confidence: ConfidenceHigh,
 				Dependency: &lockfile.Dependency{NWO: "acme/widget", Ref: "v1"},
 			}},
 		}},
@@ -134,6 +135,7 @@ func TestEnrichImposterFindings_PopulatesSuggestion(t *testing.T) {
 			Path: ".github/workflows/test.yml",
 			Findings: []Finding{{
 				Category:   CategoryImposterCommit,
+				Confidence: ConfidenceHigh,
 				Dependency: &lockfile.Dependency{NWO: "acme/widget", Ref: "v1"},
 			}},
 		}},


### PR DESCRIPTION
## Summary

Adds a `Confidence` enum (`Low | Medium | High`) to `doctor.Finding`, modeled on zizmor's audit output. Surfaces implicit confidence cliffs in the existing checks so SARIF and human consumers can tell "the lockfile is forged" (we have authoritative Compare API data) apart from "the lockfile might be forged" (Compare API was rate-limited, we inferred from the SHA mismatch alone).

Severity and Confidence are orthogonal: Severity asks *how bad if real*, Confidence asks *how sure are we*.

## Per-check assignments

| Check | Confidence | Why |
|---|---|---|
| `not_pinned`, `sha_as_ref`, `ref_changed`, `stale` | **High** | Lockfile-vs-workflow string mismatches. No inference, exact comparison. |
| `misleading_sha` | **High** | SHA-shaped ref + resolver mismatch + tag-object peel ruled out. |
| `lockfile_forgery` (ancestry == `AncestryNotAncestor`) | **High** | Compare API gave us an authoritative "not an ancestor" answer. |
| `ref_moved` (ancestry == `AncestryConfirmed`) | **High** | Compare API gave us authoritative ancestry data. |
| `ref_moved` (ancestry == `AncestryUnknown`) | **Medium** | The rate-limit/transient-error fallback path in `resolver.CheckAncestry` (`resolver/resolver.go` ~L1361). We inferred from the SHA mismatch alone. |
| `imposter_commit` (`branch_commits` Unreachable) | **High** | Authoritative `branch_commits` answer. |
| Resolver-failed workflow warning, `ReachabilityUnknown` complement | **Low** | Surfacing inability to check, not a verdict. |

## Wire format

- Internal field on `doctor.Finding`.
- JSON: `"confidence": "high"` via `confidence,omitempty` (zizmor convention, lowercased).
- SARIF emission is downstream — see `zizmor-sarif-emit`. Not in scope here.

## Fail-fast guard

`TestRunChecks_AllFindingsCarryConfidence` walks every finding from a multi-category `runChecks` run and asserts non-empty `Confidence`. A new check forgetting to set the field will fail CI rather than leak `""` to JSON.

`TestRunChecks_RefMoved_AncestryUnknown_IsMedium` and `TestRunChecks_RefMoved_AncestryConfirmed_IsHigh` pin the rate-limit-fallback contract for the medium-confidence path specifically.

## Out of scope

- SARIF emission (`zizmor-sarif-emit`).
- Category/rule-id rewiring (`zizmor-impostor-spelling-fix`, `zizmor-kebab-rule-ids`).

## Tests

- `make test` — all green.
- `go build ./...` — clean.
- `go vet ./...` — clean.

## Do not merge

This PR is part of the zizmor-alignment stack. Base is `nodeselector/fix-sha-pin-destruction`. Hold until the SARIF emit / category-rewire siblings are reviewed together.