### PR TITLE
refactor(ghapi): introduce unified GitHub API client

### DIFF
--- a/internal/doctor/picker.go
+++ b/internal/doctor/picker.go
@@ -18,11 +18,11 @@ type pickerTag struct {
 type pickerAction int
 
 const (
-	pickerApply        pickerAction = iota // user selected a tag
-	pickerSkip                             // user chose "Skip"
-	pickerShowAll                          // user chose "Show all tags"
-	pickerOpenReleases                     // user chose "Open releases"
-	pickerDefaultBranch                    // user chose the default branch
+	pickerApply         pickerAction = iota // user selected a tag
+	pickerSkip                              // user chose "Skip"
+	pickerShowAll                           // user chose "Show all tags"
+	pickerOpenReleases                      // user chose "Open releases"
+	pickerDefaultBranch                     // user chose the default branch
 )
 
 // pickerResult holds the outcome of a picker prompt.

--- a/internal/doctor/version.go
+++ b/internal/doctor/version.go
@@ -1,87 +1,87 @@
 package doctor
 
 import (
-"strings"
+	"strings"
 
-"github.com/github/gh-actions-pin/internal/lockfile"
+	"github.com/github/gh-actions-pin/internal/lockfile"
 )
 
 // IsMutableVersionTag returns true if ref looks like a mutable version tag
 // (major-only like "v4" or minor-only like "v4.2") that should be narrowed
 // to a specific patch version for pinning.
 func IsMutableVersionTag(ref string) bool {
-sv, ok := lockfile.ParseSemver(ref)
-if !ok {
-return false
-}
-return !sv.IsFullSemver()
+	sv, ok := lockfile.ParseSemver(ref)
+	if !ok {
+		return false
+	}
+	return !sv.IsFullSemver()
 }
 
 // IsNarrowedVersion returns true if narrowed is a more specific patch version
 // of mutable. For example: mutable="v4", narrowed="v4.1.0" → true.
 // mutable="v4.2", narrowed="v4.2.1" → true. mutable="v4", narrowed="v5.0.0" → false.
 func IsNarrowedVersion(mutable, narrowed string) bool {
-mv, mOK := lockfile.ParseSemver(mutable)
-nv, nOK := lockfile.ParseSemver(narrowed)
-if !mOK || !nOK {
-return false
-}
-if !nv.IsFullSemver() {
-return false
-}
-if mv.Major != nv.Major {
-return false
-}
-if mutable != mv.MajorTag() && mv.Minor != nv.Minor {
-return false
-}
-return true
+	mv, mOK := lockfile.ParseSemver(mutable)
+	nv, nOK := lockfile.ParseSemver(narrowed)
+	if !mOK || !nOK {
+		return false
+	}
+	if !nv.IsFullSemver() {
+		return false
+	}
+	if mv.Major != nv.Major {
+		return false
+	}
+	if mutable != mv.MajorTag() && mv.Minor != nv.Minor {
+		return false
+	}
+	return true
 }
 
 // IsUpgrade returns true if moving from currentRef to latestRef is a real
 // version upgrade. Returns false for noops where the current ref is already
 // at or more specific than the latest (e.g. v4.0.0 → v4, v3.1.1 → v3).
 func IsUpgrade(currentRef, latestRef string) bool {
-if currentRef == latestRef {
-return false
-}
-cur, curOK := lockfile.ParseSemver(currentRef)
-lat, latOK := lockfile.ParseSemver(latestRef)
-if !curOK || !latOK {
-if !latOK {
-return false
-}
-return true
-}
-if lat.Rest != "" {
-return false
-}
-if lat.Major < cur.Major {
-return false
-}
-if lat.Major == cur.Major {
-if lat.Minor == 0 && lat.Patch == 0 && cur.Minor >= 0 {
-if latestRef == lat.MajorTag() {
-return false
-}
-}
-if lat.Minor == cur.Minor && lat.Patch <= cur.Patch {
-return false
-}
-if lat.Minor < cur.Minor {
-return false
-}
-}
-return true
+	if currentRef == latestRef {
+		return false
+	}
+	cur, curOK := lockfile.ParseSemver(currentRef)
+	lat, latOK := lockfile.ParseSemver(latestRef)
+	if !curOK || !latOK {
+		if !latOK {
+			return false
+		}
+		return true
+	}
+	if lat.Rest != "" {
+		return false
+	}
+	if lat.Major < cur.Major {
+		return false
+	}
+	if lat.Major == cur.Major {
+		if lat.Minor == 0 && lat.Patch == 0 && cur.Minor >= 0 {
+			if latestRef == lat.MajorTag() {
+				return false
+			}
+		}
+		if lat.Minor == cur.Minor && lat.Patch <= cur.Patch {
+			return false
+		}
+		if lat.Minor < cur.Minor {
+			return false
+		}
+	}
+	return true
 }
 
 // isMajorTag returns true if the tag looks like a major-only version (e.g. "v4", "v12").
 func isMajorTag(tag string) bool {
-tag = strings.TrimPrefix(tag, "v")
-for _, c := range tag {
-if c < '0' || c > '9' {
-return false
-}
-}
-return len(tag) > 0
+	tag = strings.TrimPrefix(tag, "v")
+	for _, c := range tag {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return len(tag) > 0
 }

--- a/internal/ghapi/cachekey.go
+++ b/internal/ghapi/cachekey.go
@@ -1,0 +1,151 @@
+// Cache key types: comparable structs for in-memory caches.
+//
+// Constructors centralize normalization: owner, repo, and hex SHAs are
+// lowercased; refs preserve case because git refs are case-sensitive.
+// Struct fields stay unexported so callers cannot build unnormalized keys.
+//
+// String methods are diagnostics-only. Do not parse them or use them as
+// durable identifiers.
+
+package ghapi
+
+import "strings"
+
+// Repo identifies a GitHub repository by owner and name. Both components
+// are lowercased on construction so case variants share a single cache
+// slot.
+type Repo struct {
+	owner string
+	repo  string
+}
+
+// ForRepo builds a Repo key, lowercasing owner and repo.
+func ForRepo(owner, repo string) Repo {
+	return Repo{owner: strings.ToLower(owner), repo: strings.ToLower(repo)}
+}
+
+// String is diagnostics-only.
+func (r Repo) String() string {
+	return r.owner + "/" + r.repo
+}
+
+// NWORef pairs a repo with a git ref (tag, branch, or SHA-as-written).
+// Refs preserve their original case because git refs are case-sensitive.
+type NWORef struct {
+	repo Repo
+	ref  string
+}
+
+// ForNWORef builds an NWORef key.
+func ForNWORef(owner, repo, ref string) NWORef {
+	return NWORef{repo: ForRepo(owner, repo), ref: ref}
+}
+
+// String is diagnostics-only; do not parse.
+func (k NWORef) String() string {
+	return k.repo.String() + "@" + k.ref
+}
+
+// NWOSha pairs a repo with a lowercased commit SHA.
+type NWOSha struct {
+	repo Repo
+	sha  string
+}
+
+// ForNWOSha builds an NWOSha key, lowercasing the SHA.
+func ForNWOSha(owner, repo, sha string) NWOSha {
+	return NWOSha{repo: ForRepo(owner, repo), sha: strings.ToLower(sha)}
+}
+
+// String is diagnostics-only; do not parse.
+func (k NWOSha) String() string {
+	return k.repo.String() + "|" + k.sha
+}
+
+// NWOName pairs a repo with an arbitrary name (e.g. a branch name). The
+// name preserves case; callers that want case-insensitive lookup must
+// normalize before passing in.
+type NWOName struct {
+	repo Repo
+	name string
+}
+
+// ForNWOName builds an NWOName key.
+func ForNWOName(owner, repo, name string) NWOName {
+	return NWOName{repo: ForRepo(owner, repo), name: name}
+}
+
+// String is diagnostics-only; do not parse.
+func (k NWOName) String() string {
+	return k.repo.String() + "|" + k.name
+}
+
+// Compare identifies a Compare API result between two SHAs in a repo,
+// e.g. "is base an ancestor of head?". Both SHAs are lowercased.
+type Compare struct {
+	repo Repo
+	base string
+	head string
+}
+
+// ForCompare builds a Compare key, lowercasing both SHAs.
+func ForCompare(owner, repo, base, head string) Compare {
+	return Compare{
+		repo: ForRepo(owner, repo),
+		base: strings.ToLower(base),
+		head: strings.ToLower(head),
+	}
+}
+
+// String is diagnostics-only; do not parse.
+func (k Compare) String() string {
+	return k.repo.String() + "|" + k.base + "|" + k.head
+}
+
+// Reach is (NWO, sha, ref) — the reachability cache distinguishes the same
+// SHA on different refs because the verdict depends on which ref's history
+// we're walking. The SHA is lowercased; the ref preserves case.
+type Reach struct {
+	repo Repo
+	sha  string
+	ref  string
+}
+
+// ForReach builds a Reach key, lowercasing the SHA.
+func ForReach(owner, repo, sha, ref string) Reach {
+	return Reach{
+		repo: ForRepo(owner, repo),
+		sha:  strings.ToLower(sha),
+		ref:  ref,
+	}
+}
+
+// String is diagnostics-only; do not parse.
+func (k Reach) String() string {
+	return k.repo.String() + "|" + k.sha + "|" + k.ref
+}
+
+// ActionRef is the path-aware key used by the resolver's per-ref cache and
+// the BFS dedup set in ResolveAllRecursive. Sub-action paths must be
+// distinct identities for graph traversal — actions/cache/save@v4 visits
+// a different action.yml than actions/cache@v4 — even though they collapse
+// to the same repo+ref tarball at runner-download granularity. Use NWORef
+// (not ActionRef) when path is irrelevant.
+type ActionRef struct {
+	repo Repo
+	path string
+	ref  string
+}
+
+// ForActionRef builds an ActionRef key.
+func ForActionRef(owner, repo, path, ref string) ActionRef {
+	return ActionRef{repo: ForRepo(owner, repo), path: path, ref: ref}
+}
+
+// String is diagnostics-only; do not parse.
+func (k ActionRef) String() string {
+	if k.path == "" {
+		return k.repo.String() + "@" + k.ref
+	}
+	return k.repo.String() + "/" + k.path + "@" + k.ref
+}

--- a/internal/ghapi/cachekey.go
+++ b/internal/ghapi/cachekey.go
@@ -24,7 +24,8 @@ func ForRepo(owner, repo string) Repo {
 	return Repo{owner: strings.ToLower(owner), repo: strings.ToLower(repo)}
 }
 
-// String is diagnostics-only.
+// String returns the normalized "owner/repo" key, used for cache-key
+// diagnostics and for singleflight coalescing.
 func (r Repo) String() string {
 	return r.owner + "/" + r.repo
 }

--- a/internal/ghapi/cachekey_test.go
+++ b/internal/ghapi/cachekey_test.go
@@ -1,0 +1,86 @@
+package ghapi
+
+import "testing"
+
+func TestRepoNormalizesCase(t *testing.T) {
+	a := ForRepo("Actions", "Checkout")
+	b := ForRepo("actions", "checkout")
+	if a != b {
+		t.Fatalf("expected Repo to be case-insensitive: %v vs %v", a, b)
+	}
+	if got := a.String(); got != "actions/checkout" {
+		t.Fatalf("Repo.String() = %q, want %q", got, "actions/checkout")
+	}
+}
+
+func TestNWORefPreservesRefCase(t *testing.T) {
+	a := ForNWORef("Actions", "Checkout", "Main")
+	b := ForNWORef("actions", "checkout", "Main")
+	c := ForNWORef("actions", "checkout", "main")
+	if a != b {
+		t.Fatalf("expected owner/repo case to fold: %v vs %v", a, b)
+	}
+	if a == c {
+		t.Fatalf("expected ref case to preserve: %v vs %v", a, c)
+	}
+	if got := a.String(); got != "actions/checkout@Main" {
+		t.Fatalf("NWORef.String() = %q", got)
+	}
+}
+
+func TestNWOShaLowercasesSha(t *testing.T) {
+	a := ForNWOSha("actions", "checkout", "ABCDEF")
+	b := ForNWOSha("actions", "checkout", "abcdef")
+	if a != b {
+		t.Fatalf("expected SHA case to fold: %v vs %v", a, b)
+	}
+	if got := a.String(); got != "actions/checkout|abcdef" {
+		t.Fatalf("NWOSha.String() = %q", got)
+	}
+}
+
+func TestCompareLowercasesBothShas(t *testing.T) {
+	a := ForCompare("o", "r", "AAA", "BBB")
+	b := ForCompare("o", "r", "aaa", "bbb")
+	if a != b {
+		t.Fatalf("expected SHAs to fold: %v vs %v", a, b)
+	}
+	// Asymmetry: base and head are not interchangeable.
+	c := ForCompare("o", "r", "bbb", "aaa")
+	if a == c {
+		t.Fatalf("expected base/head to be ordered: %v vs %v", a, c)
+	}
+}
+
+func TestReachLowercasesSha(t *testing.T) {
+	a := ForReach("o", "r", "AAA", "main")
+	b := ForReach("o", "r", "aaa", "main")
+	if a != b {
+		t.Fatalf("expected SHA to fold: %v vs %v", a, b)
+	}
+	if got := a.String(); got != "o/r|aaa|main" {
+		t.Fatalf("Reach.String() = %q", got)
+	}
+}
+
+func TestActionRefDistinguishesPath(t *testing.T) {
+	plain := ForActionRef("actions", "cache", "", "v4")
+	subpath := ForActionRef("actions", "cache", "save", "v4")
+	if plain == subpath {
+		t.Fatalf("expected sub-action path to distinguish: %v vs %v", plain, subpath)
+	}
+	if got := plain.String(); got != "actions/cache@v4" {
+		t.Fatalf("ActionRef.String() pathless = %q", got)
+	}
+	if got := subpath.String(); got != "actions/cache/save@v4" {
+		t.Fatalf("ActionRef.String() with path = %q", got)
+	}
+}
+
+func TestKeysUsableAsMapKeys(t *testing.T) {
+	m := map[NWORef]int{}
+	m[ForNWORef("actions", "checkout", "v4")] = 1
+	if got := m[ForNWORef("Actions", "Checkout", "v4")]; got != 1 {
+		t.Fatalf("expected case-insensitive map lookup, got %d", got)
+	}
+}

--- a/internal/ghapi/client.go
+++ b/internal/ghapi/client.go
@@ -1,0 +1,240 @@
+// Package ghapi provides a unified GitHub API client that owns both REST
+// and GraphQL connections, retry transport, and profiling instrumentation.
+// All GitHub API access in the CLI should go through a single Client
+// instance constructed at startup.
+package ghapi
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/github/gh-actions-pin/internal/profile"
+	"github.com/github/gh-actions-pin/internal/syncmap"
+	"golang.org/x/sync/singleflight"
+)
+
+// Client holds authenticated REST and GraphQL clients for a single
+// GitHub hostname. Construct via New with ClientOption values.
+type Client struct {
+	graphql  *api.GraphQLClient
+	rest     *api.RESTClient
+	Hostname string
+
+	// Caches for raw GitHub resources. These live here so all consumers
+	// (resolver, auditor, tag lister) share a single cache per CLI run.
+	compareCache         syncmap.Map[Compare, bool]
+	repoIDsCache         syncmap.Map[Repo, [2]int64]
+	branchListCache      syncmap.Map[Repo, []BranchHead]
+	branchListSF         singleflight.Group
+	tagListCache         syncmap.Map[Repo, []TagEntry]
+	tagListSF            singleflight.Group
+	defaultBranchCache   syncmap.Map[Repo, string]
+	defaultBranchSF      singleflight.Group
+	namedBranchCache     syncmap.Map[NWOName, BranchHead]
+	protectedBranchCache syncmap.Map[Repo, []BranchHead]
+	protectedBranchSF    singleflight.Group
+}
+
+// ClientOption configures a Client at construction time. Pass to New.
+type ClientOption func(*clientConfig)
+
+type clientConfig struct {
+	transport http.RoundTripper
+	profile   *profile.Session
+	authToken string // non-empty → use explicit token (tests)
+	logIgnore bool   // suppress log env vars (tests)
+}
+
+// WithClientTransport overrides the HTTP transport. Use in tests with httpmock.
+func WithClientTransport(t http.RoundTripper) ClientOption {
+	return func(c *clientConfig) {
+		c.transport = t
+		c.authToken = "test-placeholder-token"
+		c.logIgnore = true
+	}
+}
+
+// WithClientProfile attaches profiling instrumentation to API calls.
+func WithClientProfile(p *profile.Session) ClientOption {
+	return func(c *clientConfig) { c.profile = p }
+}
+
+// New creates an authenticated Client for the given hostname using the
+// ambient gh credential store. Use WithClientTransport for test stubs
+// and WithClientProfile for profiling.
+func New(hostname string, opts ...ClientOption) (*Client, error) {
+	if hostname == "" {
+		hostname = "github.com"
+	}
+
+	var cfg clientConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	apiOpts := api.ClientOptions{Host: hostname}
+
+	switch {
+	case cfg.transport != nil:
+		apiOpts.Transport = cfg.transport
+		apiOpts.AuthToken = cfg.authToken
+		apiOpts.LogIgnoreEnv = cfg.logIgnore
+	default:
+		apiOpts.Transport = newRetryTransport(http.DefaultTransport, 3)
+		if cfg.profile != nil {
+			apiOpts.Transport = cfg.profile.WrapTransport(apiOpts.Transport)
+		}
+	}
+
+	gql, err := api.NewGraphQLClient(apiOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	rest, err := api.NewRESTClient(apiOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		graphql:  gql,
+		rest:     rest,
+		Hostname: hostname,
+	}, nil
+}
+
+// retryTransport wraps an http.RoundTripper with retry logic for transient
+// server errors (5xx), explicit rate limits (429), and GitHub secondary
+// rate limits (403 with Retry-After or X-RateLimit-Reset headers).
+type retryTransport struct {
+	inner      http.RoundTripper
+	maxRetries int
+	sleepFn    func(time.Duration) // for testing; defaults to time.Sleep
+}
+
+func newRetryTransport(t http.RoundTripper, maxRetries int) http.RoundTripper {
+	if t == nil {
+		t = http.DefaultTransport
+	}
+	return &retryTransport{inner: t, maxRetries: maxRetries}
+}
+
+func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Snapshot the body so POST requests can be replayed on retry.
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading request body for retry: %w", err)
+		}
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.ContentLength = int64(len(bodyBytes))
+	}
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt <= rt.maxRetries; attempt++ {
+		if attempt > 0 && bodyBytes != nil {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			req.ContentLength = int64(len(bodyBytes))
+		}
+		resp, err = rt.inner.RoundTrip(req)
+		if err != nil {
+			if attempt < rt.maxRetries {
+				rt.backoff(attempt)
+				continue
+			}
+			return nil, err
+		}
+		if rt.shouldRetry(resp) {
+			if attempt < rt.maxRetries {
+				wait := rt.retryWait(resp, attempt)
+				resp.Body.Close()
+				rt.sleep(wait)
+				continue
+			}
+		}
+		return resp, nil
+	}
+	return resp, err
+}
+
+// shouldRetry returns true for responses that warrant a retry: 5xx server
+// errors, 429 explicit rate limits, and 403 secondary rate limits (indicated
+// by Retry-After or X-RateLimit-Remaining: 0).
+func (rt *retryTransport) shouldRetry(resp *http.Response) bool {
+	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		if resp.Header.Get("Retry-After") != "" {
+			return true
+		}
+		if resp.Header.Get("X-RateLimit-Reset") != "" && resp.Header.Get("X-RateLimit-Remaining") == "0" {
+			return true
+		}
+	}
+	return false
+}
+
+// retryWait picks the sleep duration before the next attempt, honoring
+// Retry-After and X-RateLimit-Reset headers when present.
+func (rt *retryTransport) retryWait(resp *http.Response, attempt int) time.Duration {
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		if secs, err := strconv.Atoi(ra); err == nil && secs > 0 && secs <= 120 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+		if ts, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			if d := time.Until(time.Unix(ts, 0)) + time.Second; d > 0 && d <= 120*time.Second {
+				return d
+			}
+		}
+	}
+	delay := time.Duration(math.Pow(2, float64(attempt))) * time.Second
+	if delay > 10*time.Second {
+		delay = 10 * time.Second
+	}
+	return delay
+}
+
+func (rt *retryTransport) sleep(d time.Duration) {
+	if rt.sleepFn != nil {
+		rt.sleepFn(d)
+		return
+	}
+	time.Sleep(d)
+}
+
+func (rt *retryTransport) backoff(attempt int) {
+	delay := time.Duration(math.Pow(2, float64(attempt))) * time.Second
+	if delay > 10*time.Second {
+		delay = 10 * time.Second
+	}
+	rt.sleep(delay)
+}
+
+// DefaultSleep waits d but returns early when ctx is canceled. Useful for
+// rate-limit retry loops that need to honor cancellation.
+func DefaultSleep(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+}

--- a/internal/ghapi/client.go
+++ b/internal/ghapi/client.go
@@ -30,14 +30,15 @@ type Client struct {
 	// Caches for raw GitHub resources. These live here so all consumers
 	// (resolver, auditor, tag lister) share a single cache per CLI run.
 	compareCache         syncmap.Map[Compare, bool]
-	repoIDsCache         syncmap.Map[Repo, [2]int64]
+	compareSF            singleflight.Group
+	repoMetaCache        syncmap.Map[Repo, repoMeta]
+	repoMetaSF           singleflight.Group
 	branchListCache      syncmap.Map[Repo, []BranchHead]
 	branchListSF         singleflight.Group
 	tagListCache         syncmap.Map[Repo, []TagEntry]
 	tagListSF            singleflight.Group
-	defaultBranchCache   syncmap.Map[Repo, string]
-	defaultBranchSF      singleflight.Group
 	namedBranchCache     syncmap.Map[NWOName, BranchHead]
+	namedBranchSF        singleflight.Group
 	protectedBranchCache syncmap.Map[Repo, []BranchHead]
 	protectedBranchSF    singleflight.Group
 }

--- a/internal/ghapi/client_test.go
+++ b/internal/ghapi/client_test.go
@@ -1,0 +1,182 @@
+package ghapi
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- retry transport tests ---
+
+func TestShouldRetry_429(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	resp := &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}}
+	if !rt.shouldRetry(resp) {
+		t.Fatal("expected 429 to be retryable")
+	}
+}
+
+func TestShouldRetry_5xx(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	for _, code := range []int{500, 502, 503, 504} {
+		resp := &http.Response{StatusCode: code, Header: http.Header{}}
+		if !rt.shouldRetry(resp) {
+			t.Fatalf("expected %d to be retryable", code)
+		}
+	}
+}
+
+func TestShouldRetry_403WithRetryAfter(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{"Retry-After": []string{"60"}},
+	}
+	if !rt.shouldRetry(resp) {
+		t.Fatal("expected 403 with Retry-After to be retryable")
+	}
+}
+
+func TestShouldRetry_403WithRateLimitReset(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header: http.Header{
+			"X-Ratelimit-Reset":     []string{fmt.Sprintf("%d", time.Now().Add(30*time.Second).Unix())},
+			"X-Ratelimit-Remaining": []string{"0"},
+		},
+	}
+	if !rt.shouldRetry(resp) {
+		t.Fatal("expected 403 with rate limit headers to be retryable")
+	}
+}
+
+func TestShouldRetry_403NoHeaders(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	resp := &http.Response{StatusCode: http.StatusForbidden, Header: http.Header{}}
+	if rt.shouldRetry(resp) {
+		t.Fatal("expected plain 403 (no rate limit headers) to NOT be retryable")
+	}
+}
+
+func TestShouldRetry_200(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
+	if rt.shouldRetry(resp) {
+		t.Fatal("expected 200 to NOT be retryable")
+	}
+}
+
+func TestRetryWait_RetryAfterHeader(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"5"}},
+	}
+	got := rt.retryWait(resp, 0)
+	if got != 5*time.Second {
+		t.Fatalf("expected 5s, got %v", got)
+	}
+}
+
+func TestRetryWait_RateLimitResetHeader(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	resetAt := time.Now().Add(10 * time.Second)
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header: http.Header{
+			"X-Ratelimit-Reset":     []string{fmt.Sprintf("%d", resetAt.Unix())},
+			"X-Ratelimit-Remaining": []string{"0"},
+		},
+	}
+	got := rt.retryWait(resp, 0)
+	// Should be approximately 11s (10s until reset + 1s buffer).
+	if got < 9*time.Second || got > 15*time.Second {
+		t.Fatalf("expected ~11s, got %v", got)
+	}
+}
+
+func TestRetryWait_ExponentialBackoff(t *testing.T) {
+	rt := &retryTransport{maxRetries: 3}
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{},
+	}
+	for attempt, want := range []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+	} {
+		got := rt.retryWait(resp, attempt)
+		if got != want {
+			t.Fatalf("attempt %d: expected %v, got %v", attempt, want, got)
+		}
+	}
+}
+
+func TestRetryWait_CappedAt10s(t *testing.T) {
+	rt := &retryTransport{maxRetries: 10}
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{},
+	}
+	got := rt.retryWait(resp, 10) // 2^10 = 1024s, should cap at 10s
+	if got != 10*time.Second {
+		t.Fatalf("expected cap at 10s, got %v", got)
+	}
+}
+
+func TestRetryTransport_ResendsBodyOnRetry(t *testing.T) {
+	wantBody := `{"query":"some graphql"}`
+	var attempts atomic.Int32
+
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		n := attempts.Add(1)
+		got, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("attempt %d: reading body: %v", n, err)
+		}
+		if string(got) != wantBody {
+			t.Fatalf("attempt %d: body = %q, want %q", n, string(got), wantBody)
+		}
+		if n < 3 {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"data":{}}`))),
+		}, nil
+	})
+
+	rt := &retryTransport{inner: inner, maxRetries: 3, sleepFn: func(time.Duration) {}}
+	req, _ := http.NewRequest("POST", "https://api.github.com/graphql",
+		io.NopCloser(bytes.NewReader([]byte(wantBody))))
+	req.ContentLength = int64(len(wantBody))
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+}
+
+// roundTripFunc adapts a function into an http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/ghapi/errors.go
+++ b/internal/ghapi/errors.go
@@ -1,0 +1,54 @@
+package ghapi
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+// StatusCode reports the HTTP status code carried by err when it originates
+// from a REST call. ok is false when err is nil, a transport failure, or a
+// GraphQL error that carries no HTTP status. It lets callers classify failures
+// without importing go-gh, keeping the API transport internal to this package.
+func StatusCode(err error) (code int, ok bool) {
+	var httpErr *api.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode, true
+	}
+	return 0, false
+}
+
+// IsNotFound reports whether err is a 404 from the GitHub REST API.
+func IsNotFound(err error) bool {
+	code, ok := StatusCode(err)
+	return ok && code == http.StatusNotFound
+}
+
+// IsPermissionDenied reports whether err is a 401, or a 403 that is not a
+// rate-limit response. Rate-limit 403s are reported by IsRateLimited instead so
+// callers can back off rather than treat the repo as inaccessible.
+func IsPermissionDenied(err error) bool {
+	code, ok := StatusCode(err)
+	if !ok {
+		return false
+	}
+	if code == http.StatusUnauthorized {
+		return true
+	}
+	return code == http.StatusForbidden && !IsRateLimited(err)
+}
+
+// IsRateLimited reports whether err is a primary rate-limit response (HTTP 429)
+// or a secondary one (HTTP 403 with the rate-limit budget exhausted).
+func IsRateLimited(err error) bool {
+	var httpErr *api.HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	if httpErr.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	return httpErr.StatusCode == http.StatusForbidden &&
+		httpErr.Headers.Get("X-RateLimit-Remaining") == "0"
+}

--- a/internal/ghapi/errors_test.go
+++ b/internal/ghapi/errors_test.go
@@ -1,0 +1,62 @@
+package ghapi
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+func httpErr(status int, headers http.Header) error {
+	return &api.HTTPError{StatusCode: status, Headers: headers}
+}
+
+func TestStatusCode(t *testing.T) {
+	if _, ok := StatusCode(nil); ok {
+		t.Fatal("nil error should not report a status code")
+	}
+	if _, ok := StatusCode(errors.New("transport boom")); ok {
+		t.Fatal("plain error should not report a status code")
+	}
+	code, ok := StatusCode(fmt.Errorf("wrapped: %w", httpErr(404, nil)))
+	if !ok || code != 404 {
+		t.Fatalf("got (%d, %v), want (404, true) through wrapping", code, ok)
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	if !IsNotFound(httpErr(http.StatusNotFound, nil)) {
+		t.Fatal("404 should be not-found")
+	}
+	if IsNotFound(httpErr(http.StatusForbidden, nil)) {
+		t.Fatal("403 should not be not-found")
+	}
+	if IsNotFound(errors.New("boom")) {
+		t.Fatal("non-HTTP error should not be not-found")
+	}
+}
+
+func TestRateLimitVsPermission(t *testing.T) {
+	exhausted := http.Header{}
+	exhausted.Set("X-RateLimit-Remaining", "0")
+
+	tooMany := httpErr(http.StatusTooManyRequests, nil)
+	secondary := httpErr(http.StatusForbidden, exhausted)
+	plainForbidden := httpErr(http.StatusForbidden, nil)
+	unauthorized := httpErr(http.StatusUnauthorized, nil)
+
+	if !IsRateLimited(tooMany) || !IsRateLimited(secondary) {
+		t.Fatal("429 and budget-exhausted 403 should be rate-limited")
+	}
+	if IsRateLimited(plainForbidden) {
+		t.Fatal("403 with budget remaining should not be rate-limited")
+	}
+	if !IsPermissionDenied(plainForbidden) || !IsPermissionDenied(unauthorized) {
+		t.Fatal("plain 403 and 401 should be permission-denied")
+	}
+	if IsPermissionDenied(secondary) {
+		t.Fatal("rate-limit 403 should not be reported as permission-denied")
+	}
+}

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -56,10 +56,44 @@ type repoResponse struct {
 // their action.yml/yaml content in a single batched GraphQL round-trip.
 // Results are returned in the same order as inputs; per-ref failures are
 // recorded in each result's Err field rather than aborting the batch.
+//
+// If the whole query is rejected — transport failure, query cost/complexity,
+// or a secondary rate limit — the batch is split in half and each half
+// retried, recursively down to a single ref, so a few oversized or bad refs
+// can't fail their batch-mates. Splitting is skipped once ctx is canceled so a
+// canceled scan doesn't fan out into a flurry of doomed retries.
 func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileRequest) []ActionFileResult {
 	if len(refs) == 0 {
 		return nil
 	}
+	results, batchErr := c.resolveActionFilesOnce(ctx, refs)
+	if batchErr == nil || len(refs) == 1 || ctx.Err() != nil {
+		return results
+	}
+	mid := len(refs) / 2
+	left := c.ResolveActionFiles(ctx, refs[:mid])
+	// A cancellation during the left half must not fan out the right half into
+	// doomed retries. Synthesize the right results so length and order are
+	// preserved without another round-trip.
+	if ctx.Err() != nil {
+		right := make([]ActionFileResult, len(refs)-mid)
+		for i, r := range refs[mid:] {
+			right[i] = ActionFileResult{
+				Owner: r.Owner, Repo: r.Repo, Path: r.Path, Ref: r.Ref,
+				Err: ctx.Err(),
+			}
+		}
+		return append(left, right...)
+	}
+	right := c.ResolveActionFiles(ctx, refs[mid:])
+	return append(left, right...)
+}
+
+// resolveActionFilesOnce performs one batched round-trip. The returned error is
+// non-nil only for batch-level failures — the whole query was rejected — that
+// splitting may recover from; ordinary per-ref failures are recorded in each
+// result's Err field and do not trigger a split.
+func (c *Client) resolveActionFilesOnce(ctx context.Context, refs []ActionFileRequest) ([]ActionFileResult, error) {
 	query, vars, aliasMap := buildActionFileQuery(refs)
 
 	var data map[string]json.RawMessage
@@ -67,7 +101,8 @@ func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileReques
 	var gqlErr *api.GraphQLError
 	if err != nil {
 		if !errors.As(err, &gqlErr) {
-			// Total transport failure — every result gets the error.
+			// Total transport failure — every result gets the error, and the
+			// batch-level signal tells the caller to split and retry.
 			results := make([]ActionFileResult, len(refs))
 			for i, r := range refs {
 				results[i] = ActionFileResult{
@@ -75,11 +110,33 @@ func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileReques
 					Err: err,
 				}
 			}
-			return results
+			return results, err
 		}
 	}
 
-	return parseActionFileResponse(data, refs, aliasMap, gqlErr, c.Hostname)
+	results := parseActionFileResponse(data, refs, aliasMap, gqlErr, c.Hostname)
+	return results, batchLevelGraphQLErr(gqlErr)
+}
+
+// batchLevelGraphQLErr returns a non-nil error when gqlErr carries a
+// query-level failure: any error item with no alias path (e.g. cost limit,
+// query too complex, secondary rate limit, or a SAML block that GitHub did not
+// pin to a specific alias). Such a failure rejects the whole query, so
+// splitting the batch can recover the refs that would have succeeded on their
+// own — and, for a no-path SAML block, drives the batch down to single refs so
+// the SSO message can be attributed to the one remaining owner. Per-alias
+// errors (which carry a path) return nil — they belong to one ref and splitting
+// wouldn't help.
+func batchLevelGraphQLErr(gqlErr *api.GraphQLError) error {
+	if gqlErr == nil {
+		return nil
+	}
+	for _, e := range gqlErr.Errors {
+		if len(e.Path) == 0 {
+			return gqlErr
+		}
+	}
+	return nil
 }
 
 func buildActionFileQuery(refs []ActionFileRequest) (string, map[string]any, map[string]int) {
@@ -144,14 +201,22 @@ func parseActionFileResponse(data map[string]json.RawMessage, refs []ActionFileR
 	}
 
 	samlOwners := samlBlockedOwners(gqlErr, refs, aliasMap)
+	batchErr := batchLevelGraphQLErr(gqlErr)
 
 	for alias, idx := range aliasMap {
 		ref := refs[idx]
 		raw, ok := data[alias]
 		if !ok {
-			if samlOwners[ref.Owner] {
+			switch {
+			case samlOwners[ref.Owner]:
 				results[idx].Err = fmt.Errorf("%s", ssoRequiredMessage(hostname, ref.Owner))
-			} else {
+			case batchErr != nil:
+				// The whole query was rejected (cost/complexity/rate limit), so
+				// the alias is missing for a batch-level reason, not because the
+				// ref doesn't exist. Surface the real error; the caller splits
+				// and retries rather than mislabeling 20 good refs "not found".
+				results[idx].Err = batchErr
+			default:
 				results[idx].Err = fmt.Errorf("not found in response")
 			}
 			continue
@@ -200,6 +265,14 @@ func samlBlockedOwners(gqlErr *api.GraphQLError, refs []ActionFileRequest, alias
 			continue
 		}
 		if len(e.Path) == 0 {
+			// A SAML block with no alias path can't be tied to one ref. Mark
+			// every owner in the batch. ResolveActionFiles treats a no-path
+			// error as batch-level and splits down to single refs, so by the
+			// time a result survives the split the batch holds one owner and
+			// this attribution is exact.
+			for _, r := range refs {
+				owners[r.Owner] = true
+			}
 			continue
 		}
 		alias, ok := e.Path[0].(string)

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -57,6 +57,9 @@ type repoResponse struct {
 // Results are returned in the same order as inputs; per-ref failures are
 // recorded in each result's Err field rather than aborting the batch.
 func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileRequest) []ActionFileResult {
+	if len(refs) == 0 {
+		return nil
+	}
 	query, vars, aliasMap := buildActionFileQuery(refs)
 
 	var data map[string]json.RawMessage

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -1,0 +1,223 @@
+package ghapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+// ActionFileRequest identifies a GitHub Action ref to resolve via GraphQL.
+type ActionFileRequest struct {
+	Owner string
+	Repo  string
+	Path  string // sub-action path within the repo, may be empty
+	Ref   string // tag, branch, or SHA
+}
+
+// NWO returns "Owner/Repo".
+func (r ActionFileRequest) NWO() string { return r.Owner + "/" + r.Repo }
+
+// ActionFileResult holds the resolved commit OID and action.yml content
+// for one ActionFileRequest. Err is non-nil when this specific ref could
+// not be resolved (e.g. not found, SSO required).
+type ActionFileResult struct {
+	Owner     string
+	Repo      string
+	Path      string
+	Ref       string
+	CommitOID string
+	ActionYML string
+	Err       error
+}
+
+// repoResponse is the raw GraphQL response shape for a single repository alias.
+type repoResponse struct {
+	NameWithOwner string `json:"nameWithOwner"`
+	Object        *struct {
+		OID  string `json:"oid"`
+		File *struct {
+			Object *struct {
+				Text string `json:"text"`
+			} `json:"object"`
+		} `json:"file"`
+		FileYAML *struct {
+			Object *struct {
+				Text string `json:"text"`
+			} `json:"object"`
+		} `json:"fileYaml"`
+	} `json:"object"`
+}
+
+// ResolveActionFiles resolves action refs to commit OIDs and fetches
+// their action.yml/yaml content in a single batched GraphQL round-trip.
+// Results are returned in the same order as inputs; per-ref failures are
+// recorded in each result's Err field rather than aborting the batch.
+func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileRequest) []ActionFileResult {
+	query, vars, aliasMap := buildActionFileQuery(refs)
+
+	var data map[string]json.RawMessage
+	err := c.graphql.DoWithContext(ctx, query, vars, &data)
+	var gqlErr *api.GraphQLError
+	if err != nil {
+		if !errors.As(err, &gqlErr) {
+			// Total transport failure — every result gets the error.
+			results := make([]ActionFileResult, len(refs))
+			for i, r := range refs {
+				results[i] = ActionFileResult{
+					Owner: r.Owner, Repo: r.Repo, Path: r.Path, Ref: r.Ref,
+					Err: err,
+				}
+			}
+			return results
+		}
+	}
+
+	return parseActionFileResponse(data, refs, aliasMap, gqlErr, c.Hostname)
+}
+
+func buildActionFileQuery(refs []ActionFileRequest) (string, map[string]any, map[string]int) {
+	aliasMap := make(map[string]int, len(refs))
+	vars := make(map[string]any, len(refs)*5)
+
+	var decl strings.Builder
+	var body strings.Builder
+	decl.WriteString("query(")
+	body.WriteString(") {")
+
+	for i, ref := range refs {
+		alias := fmt.Sprintf("a%d", i)
+		aliasMap[alias] = i
+
+		ownerVar := fmt.Sprintf("owner%d", i)
+		nameVar := fmt.Sprintf("name%d", i)
+		exprVar := fmt.Sprintf("expr%d", i)
+		ymlVar := fmt.Sprintf("yml%d", i)
+		yamlVar := fmt.Sprintf("yaml%d", i)
+
+		ymlPath := "action.yml"
+		yamlPath := "action.yaml"
+		if ref.Path != "" {
+			ymlPath = ref.Path + "/action.yml"
+			yamlPath = ref.Path + "/action.yaml"
+		}
+
+		vars[ownerVar] = ref.Owner
+		vars[nameVar] = ref.Repo
+		// Peel through annotated tags with `^{commit}` so the
+		// `... on Commit` fragment matches for annotated tag refs.
+		vars[exprVar] = ref.Ref + "^{commit}"
+		vars[ymlVar] = ymlPath
+		vars[yamlVar] = yamlPath
+
+		if i > 0 {
+			decl.WriteString(", ")
+		}
+		fmt.Fprintf(&decl, "$%s: String!, $%s: String!, $%s: String!, $%s: String!, $%s: String!",
+			ownerVar, nameVar, exprVar, ymlVar, yamlVar)
+
+		fmt.Fprintf(&body, " %s: repository(owner: $%s, name: $%s) {", alias, ownerVar, nameVar)
+		body.WriteString(" nameWithOwner")
+		fmt.Fprintf(&body, " object(expression: $%s) {", exprVar)
+		body.WriteString(" ... on Commit { oid")
+		fmt.Fprintf(&body, " file: file(path: $%s) { object { ... on Blob { text } } }", ymlVar)
+		fmt.Fprintf(&body, " fileYaml: file(path: $%s) { object { ... on Blob { text } } }", yamlVar)
+		body.WriteString(" }")
+		body.WriteString(" }")
+		body.WriteString(" }")
+	}
+
+	body.WriteString(" }")
+	return decl.String() + body.String(), vars, aliasMap
+}
+
+func parseActionFileResponse(data map[string]json.RawMessage, refs []ActionFileRequest, aliasMap map[string]int, gqlErr *api.GraphQLError, hostname string) []ActionFileResult {
+	results := make([]ActionFileResult, len(refs))
+	for i, r := range refs {
+		results[i] = ActionFileResult{Owner: r.Owner, Repo: r.Repo, Path: r.Path, Ref: r.Ref}
+	}
+
+	samlOwners := samlBlockedOwners(gqlErr, refs, aliasMap)
+
+	for alias, idx := range aliasMap {
+		ref := refs[idx]
+		raw, ok := data[alias]
+		if !ok {
+			if samlOwners[ref.Owner] {
+				results[idx].Err = fmt.Errorf("%s", ssoRequiredMessage(hostname, ref.Owner))
+			} else {
+				results[idx].Err = fmt.Errorf("not found in response")
+			}
+			continue
+		}
+		if string(raw) == "null" {
+			if samlOwners[ref.Owner] {
+				results[idx].Err = fmt.Errorf("%s", ssoRequiredMessage(hostname, ref.Owner))
+			} else {
+				results[idx].Err = fmt.Errorf("repository not found or not accessible")
+			}
+			continue
+		}
+
+		var repo repoResponse
+		if err := json.Unmarshal(raw, &repo); err != nil {
+			results[idx].Err = fmt.Errorf("failed to parse: %w", err)
+			continue
+		}
+
+		if repo.Object == nil || repo.Object.OID == "" {
+			results[idx].Err = fmt.Errorf("ref %q does not exist", ref.Ref)
+			continue
+		}
+
+		results[idx].CommitOID = repo.Object.OID
+
+		if repo.Object.File != nil && repo.Object.File.Object != nil {
+			results[idx].ActionYML = repo.Object.File.Object.Text
+		} else if repo.Object.FileYAML != nil && repo.Object.FileYAML.Object != nil {
+			results[idx].ActionYML = repo.Object.FileYAML.Object.Text
+		}
+	}
+
+	return results
+}
+
+// samlBlockedOwners returns the set of repository owners whose resolution
+// failed an organization SAML SSO enforcement check.
+func samlBlockedOwners(gqlErr *api.GraphQLError, refs []ActionFileRequest, aliasMap map[string]int) map[string]bool {
+	if gqlErr == nil {
+		return nil
+	}
+	owners := make(map[string]bool)
+	for _, e := range gqlErr.Errors {
+		if blocked, _ := e.Extensions["saml_failure"].(bool); !blocked {
+			continue
+		}
+		if len(e.Path) == 0 {
+			continue
+		}
+		alias, ok := e.Path[0].(string)
+		if !ok {
+			continue
+		}
+		idx, ok := aliasMap[alias]
+		if !ok || idx < 0 || idx >= len(refs) {
+			continue
+		}
+		owners[refs[idx].Owner] = true
+	}
+	return owners
+}
+
+// ssoRequiredMessage builds an actionable error directing the user to
+// authorize their token for an SSO-protected organization.
+func ssoRequiredMessage(hostname, owner string) string {
+	host := hostname
+	if host == "" {
+		host = "github.com"
+	}
+	return fmt.Sprintf("SSO authorization required: your token is not authorized for the %q organization (SAML enforcement). Authorize it at https://%s/orgs/%s/sso and retry", owner, host, owner)
+}

--- a/internal/ghapi/graphql_action_files_test.go
+++ b/internal/ghapi/graphql_action_files_test.go
@@ -1,0 +1,180 @@
+package ghapi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+func TestBuildActionFileQuery(t *testing.T) {
+	refs := []ActionFileRequest{
+		{Owner: "actions", Repo: "checkout", Ref: "v6"},
+		{Owner: "actions", Repo: "cache", Path: "save", Ref: "v4"},
+	}
+
+	query, vars, aliases := buildActionFileQuery(refs)
+	if len(aliases) != 2 {
+		t.Fatalf("expected two aliases, got %+v", aliases)
+	}
+	for _, want := range []string{
+		`$owner0: String!, $name0: String!, $expr0: String!, $yml0: String!, $yaml0: String!`,
+		`a0: repository(owner: $owner0, name: $name0)`,
+		`object(expression: $expr0)`,
+		`file: file(path: $yml0)`,
+		`a1: repository(owner: $owner1, name: $name1)`,
+		`fileYaml: file(path: $yaml1)`,
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("query missing %q:\n%s", want, query)
+		}
+	}
+	for k, want := range map[string]any{
+		"owner0": "actions", "name0": "checkout", "expr0": "v6^{commit}",
+		"yml0": "action.yml", "yaml0": "action.yaml",
+		"owner1": "actions", "name1": "cache", "expr1": "v4^{commit}",
+		"yml1": "save/action.yml", "yaml1": "save/action.yaml",
+	} {
+		if vars[k] != want {
+			t.Fatalf("vars[%q]=%v, want %v", k, vars[k], want)
+		}
+	}
+}
+
+func TestParseActionFileResponse(t *testing.T) {
+	refs := []ActionFileRequest{
+		{Owner: "actions", Repo: "checkout", Ref: "v6"},
+		{Owner: "actions", Repo: "cache", Path: "save", Ref: "v4"},
+	}
+	aliases := map[string]int{"a0": 0, "a1": 1}
+
+	data := map[string]json.RawMessage{
+		"a0": json.RawMessage(`{"nameWithOwner":"actions/checkout","object":{"oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","file":{"object":{"text":"name: Checkout\nruns:\n  using: node20\n"}}}}`),
+		"a1": json.RawMessage(`{"nameWithOwner":"actions/cache","object":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","fileYaml":{"object":{"text":"name: Cache Save\nruns:\n  using: composite\n  steps:\n    - uses: actions/upload-artifact@v4\n"}}}}`),
+	}
+
+	results := parseActionFileResponse(data, refs, aliases, nil, "")
+	if len(results) != 2 {
+		t.Fatalf("expected two results, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.Err != nil {
+			t.Fatalf("unexpected error for %s/%s: %v", r.Owner, r.Repo, r.Err)
+		}
+	}
+	if results[0].CommitOID != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("expected checkout OID, got %q", results[0].CommitOID)
+	}
+	if !strings.Contains(results[1].ActionYML, "upload-artifact") {
+		t.Fatal("expected yaml content from fileYaml fallback")
+	}
+}
+
+func TestParseActionFileResponse_AnnotatedTagPeeled(t *testing.T) {
+	refs := []ActionFileRequest{
+		{Owner: "nodeselector", Repo: "actions-test-fixtures", Ref: "annotated-v1"},
+	}
+	aliases := map[string]int{"a0": 0}
+	data := map[string]json.RawMessage{
+		"a0": json.RawMessage(`{"nameWithOwner":"nodeselector/actions-test-fixtures","object":{"oid":"ea53476fdc172d8552df5af9658a45a367e4f41d","file":{"object":{"text":"name: Fixture\nruns:\n  using: node20\n"}}}}`),
+	}
+
+	results := parseActionFileResponse(data, refs, aliases, nil, "")
+	if len(results) != 1 {
+		t.Fatalf("expected one result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+	if results[0].Ref != "annotated-v1" {
+		t.Fatalf("expected Ref preserved as %q, got %q", "annotated-v1", results[0].Ref)
+	}
+	if results[0].CommitOID != "ea53476fdc172d8552df5af9658a45a367e4f41d" {
+		t.Fatalf("expected peeled commit oid, got %q", results[0].CommitOID)
+	}
+}
+
+func TestParseActionFileResponse_Errors(t *testing.T) {
+	refs := []ActionFileRequest{
+		{Owner: "actions", Repo: "checkout", Ref: "v6"},
+		{Owner: "actions", Repo: "setup-go", Ref: "v6"},
+		{Owner: "actions", Repo: "cache", Ref: "v4"},
+	}
+	aliases := map[string]int{"a0": 0, "a1": 1, "a2": 2}
+	data := map[string]json.RawMessage{
+		"a0": json.RawMessage(`null`),
+		"a1": json.RawMessage(`{"nameWithOwner":"actions/setup-go","object":{"oid":""}}`),
+	}
+
+	results := parseActionFileResponse(data, refs, aliases, nil, "")
+	if results[0].Err == nil || !strings.Contains(results[0].Err.Error(), "not found or not accessible") {
+		t.Fatalf("expected 'not found' error for checkout, got %v", results[0].Err)
+	}
+	if results[1].Err == nil || !strings.Contains(results[1].Err.Error(), "does not exist") {
+		t.Fatalf("expected 'does not exist' error for setup-go, got %v", results[1].Err)
+	}
+	if results[2].Err == nil || !strings.Contains(results[2].Err.Error(), "not found in response") {
+		t.Fatalf("expected 'not found in response' error for cache, got %v", results[2].Err)
+	}
+}
+
+func TestParseActionFileResponse_SAMLSSO(t *testing.T) {
+	refs := []ActionFileRequest{
+		{Owner: "actions", Repo: "checkout", Ref: "v6"},
+		{Owner: "unknownorg", Repo: "missing", Ref: "v1"},
+	}
+	aliases := map[string]int{"a0": 0, "a1": 1}
+	data := map[string]json.RawMessage{
+		"a0": json.RawMessage(`null`),
+		"a1": json.RawMessage(`null`),
+	}
+	gqlErr := &api.GraphQLError{
+		Errors: []api.GraphQLErrorItem{
+			{
+				Type:       "FORBIDDEN",
+				Message:    "Resource protected by organization SAML enforcement.",
+				Path:       []interface{}{"a0"},
+				Extensions: map[string]interface{}{"saml_failure": true},
+			},
+		},
+	}
+
+	results := parseActionFileResponse(data, refs, aliases, gqlErr, "github.localhost")
+	if results[0].Err == nil || !strings.Contains(results[0].Err.Error(), "SSO authorization required") {
+		t.Fatalf("expected SSO message for checkout, got %v", results[0].Err)
+	}
+	if !strings.Contains(results[0].Err.Error(), "github.localhost/orgs/actions/sso") {
+		t.Fatalf("expected SSO URL, got %v", results[0].Err)
+	}
+	if results[1].Err == nil || !strings.Contains(results[1].Err.Error(), "not found or not accessible") {
+		t.Fatalf("expected generic error for unknownorg, got %v", results[1].Err)
+	}
+	if strings.Contains(results[0].Err.Error(), "not found or not accessible") {
+		t.Fatal("SAML ref should not emit generic not-found")
+	}
+}
+
+func TestActionFileRequest_NWO(t *testing.T) {
+	r := ActionFileRequest{Owner: "actions", Repo: "checkout"}
+	if got := r.NWO(); got != "actions/checkout" {
+		t.Fatalf("expected actions/checkout, got %q", got)
+	}
+}
+
+func TestSSORequiredMessage(t *testing.T) {
+	msg := ssoRequiredMessage("github.com", "myorg")
+	if !strings.Contains(msg, "SSO authorization required") {
+		t.Fatalf("missing SSO prefix: %s", msg)
+	}
+	if !strings.Contains(msg, "github.com/orgs/myorg/sso") {
+		t.Fatalf("missing SSO URL: %s", msg)
+	}
+}
+
+func TestSSORequiredMessage_EmptyHost(t *testing.T) {
+	msg := ssoRequiredMessage("", "myorg")
+	if !strings.Contains(msg, "github.com/orgs/myorg/sso") {
+		t.Fatalf("expected default host, got: %s", msg)
+	}
+}

--- a/internal/ghapi/graphql_action_files_test.go
+++ b/internal/ghapi/graphql_action_files_test.go
@@ -1,8 +1,14 @@
 package ghapi
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cli/go-gh/v2/pkg/api"
@@ -176,5 +182,229 @@ func TestSSORequiredMessage_EmptyHost(t *testing.T) {
 	msg := ssoRequiredMessage("", "myorg")
 	if !strings.Contains(msg, "github.com/orgs/myorg/sso") {
 		t.Fatalf("expected default host, got: %s", msg)
+	}
+}
+
+func TestBatchLevelGraphQLErr(t *testing.T) {
+	tests := []struct {
+		name    string
+		gqlErr  *api.GraphQLError
+		wantErr bool
+	}{
+		{name: "nil", gqlErr: nil, wantErr: false},
+		{
+			name: "cost limit (no path) is batch-level",
+			gqlErr: &api.GraphQLError{Errors: []api.GraphQLErrorItem{
+				{Message: "query has cost too high", Type: "MAX_NODE_LIMIT_EXCEEDED"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "per-alias error (has path) is not batch-level",
+			gqlErr: &api.GraphQLError{Errors: []api.GraphQLErrorItem{
+				{Message: "could not resolve", Path: []interface{}{"a3"}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "no-path saml block is batch-level (splits to attribute SSO)",
+			gqlErr: &api.GraphQLError{Errors: []api.GraphQLErrorItem{
+				{Message: "saml", Extensions: map[string]interface{}{"saml_failure": true}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "per-alias saml block (has path) is not batch-level",
+			gqlErr: &api.GraphQLError{Errors: []api.GraphQLErrorItem{
+				{Message: "saml", Path: []interface{}{"a2"}, Extensions: map[string]interface{}{"saml_failure": true}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "saml block alongside a real cost error still reports batch-level",
+			gqlErr: &api.GraphQLError{Errors: []api.GraphQLErrorItem{
+				{Message: "saml", Extensions: map[string]interface{}{"saml_failure": true}},
+				{Message: "cost too high"},
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := batchLevelGraphQLErr(tc.gqlErr)
+			if (got != nil) != tc.wantErr {
+				t.Fatalf("batchLevelGraphQLErr() = %v, wantErr=%v", got, tc.wantErr)
+			}
+		})
+	}
+}
+
+// splitTransport rejects any batch with more than one alias as a cost-limit
+// failure and resolves single-alias batches successfully, modeling GitHub's
+// per-query cost ceiling so the adaptive split can be observed end-to-end.
+type splitTransport struct {
+	mu        sync.Mutex
+	calls     int
+	multiRejs int
+	oids      map[string]string // "owner/name" -> commit oid
+}
+
+func (s *splitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, _ := io.ReadAll(req.Body)
+	var payload struct {
+		Variables map[string]any `json:"variables"`
+	}
+	_ = json.Unmarshal(body, &payload)
+
+	// Count aliases by ownerN keys present in variables.
+	var idxs []int
+	for i := 0; ; i++ {
+		if _, ok := payload.Variables[fmt.Sprintf("owner%d", i)]; !ok {
+			break
+		}
+		idxs = append(idxs, i)
+	}
+
+	s.mu.Lock()
+	s.calls++
+	if len(idxs) > 1 {
+		s.multiRejs++
+	}
+	s.mu.Unlock()
+
+	if len(idxs) > 1 {
+		return jsonHTTP(map[string]any{
+			"data": nil,
+			"errors": []map[string]any{
+				{"message": "query has cost too high", "type": "MAX_NODE_LIMIT_EXCEEDED"},
+			},
+		})
+	}
+
+	owner, _ := payload.Variables["owner0"].(string)
+	name, _ := payload.Variables["name0"].(string)
+	oid := s.oids[owner+"/"+name]
+	data := map[string]any{
+		"a0": map[string]any{
+			"nameWithOwner": owner + "/" + name,
+			"object": map[string]any{
+				"oid":  oid,
+				"file": map[string]any{"object": map[string]any{"text": "name: x\nruns:\n  using: node20\n"}},
+			},
+		},
+	}
+	return jsonHTTP(map[string]any{"data": data})
+}
+
+func jsonHTTP(v any) (*http.Response, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(b)),
+	}, nil
+}
+
+func TestResolveActionFiles_AdaptiveSplit(t *testing.T) {
+	tr := &splitTransport{oids: map[string]string{
+		"actions/checkout": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"actions/setup-go": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"actions/cache":    "cccccccccccccccccccccccccccccccccccccccc",
+	}}
+	c, err := New("github.com", WithClientTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := []ActionFileRequest{
+		{Owner: "actions", Repo: "checkout", Ref: "v6"},
+		{Owner: "actions", Repo: "setup-go", Ref: "v6"},
+		{Owner: "actions", Repo: "cache", Ref: "v3"},
+	}
+
+	results := c.ResolveActionFiles(context.Background(), refs)
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	wantOID := map[string]string{
+		"checkout": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"setup-go": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"cache":    "cccccccccccccccccccccccccccccccccccccccc",
+	}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Fatalf("result %d (%s) unexpected error: %v", i, r.Repo, r.Err)
+		}
+		if r.CommitOID != wantOID[r.Repo] {
+			t.Fatalf("result %d (%s) oid=%q, want %q", i, r.Repo, r.CommitOID, wantOID[r.Repo])
+		}
+	}
+	// Order must survive the split: input order is checkout, setup-go, cache.
+	if results[0].Repo != "checkout" || results[1].Repo != "setup-go" || results[2].Repo != "cache" {
+		t.Fatalf("result order not preserved across split: %s, %s, %s",
+			results[0].Repo, results[1].Repo, results[2].Repo)
+	}
+	if tr.multiRejs == 0 {
+		t.Fatal("expected at least one multi-alias batch to be rejected (the split trigger)")
+	}
+}
+
+func TestResolveActionFiles_SingleRefBatchErrorSurfaced(t *testing.T) {
+	// A single-ref batch can't be split further, so a batch-level cost error
+	// must surface on the ref rather than being mislabeled "not found".
+	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonHTTP(map[string]any{
+			"data": nil,
+			"errors": []map[string]any{
+				{"message": "query has cost too high", "type": "MAX_NODE_LIMIT_EXCEEDED"},
+			},
+		})
+	})
+	c, err := New("github.com", WithClientTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := c.ResolveActionFiles(context.Background(),
+		[]ActionFileRequest{{Owner: "actions", Repo: "checkout", Ref: "v6"}})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err == nil {
+		t.Fatal("expected an error for the single rejected ref")
+	}
+	if strings.Contains(results[0].Err.Error(), "not found in response") {
+		t.Fatalf("batch-level error was mislabeled as not-found: %v", results[0].Err)
+	}
+	if !strings.Contains(results[0].Err.Error(), "cost too high") {
+		t.Fatalf("expected cost error surfaced, got %v", results[0].Err)
+	}
+}
+
+func TestParseActionFileResponse_NoPathSamlSurfacesSSO(t *testing.T) {
+	// A SAML block with no alias path, on a single-ref batch (the state after
+	// ResolveActionFiles has split down): the missing alias must surface the
+	// actionable SSO message for that owner, not "not found in response".
+	refs := []ActionFileRequest{{Owner: "secureorg", Repo: "private-action", Ref: "v1"}}
+	aliases := map[string]int{"a0": 0}
+	gqlErr := &api.GraphQLError{Errors: []api.GraphQLErrorItem{
+		{Message: "Resource protected by organization SAML enforcement",
+			Extensions: map[string]interface{}{"saml_failure": true}},
+	}}
+	// data has no a0 alias (the whole query was rejected).
+	results := parseActionFileResponse(map[string]json.RawMessage{}, refs, aliases, gqlErr, "github.com")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err == nil {
+		t.Fatal("expected an error for the saml-blocked ref")
+	}
+	msg := results[0].Err.Error()
+	if strings.Contains(msg, "not found in response") {
+		t.Fatalf("no-path saml mislabeled as not-found: %v", msg)
+	}
+	if !strings.Contains(msg, "SSO authorization required") || !strings.Contains(msg, "secureorg") {
+		t.Fatalf("expected actionable SSO message for secureorg, got %v", msg)
 	}
 }

--- a/internal/ghapi/graphql_peel.go
+++ b/internal/ghapi/graphql_peel.go
@@ -1,0 +1,59 @@
+package ghapi
+
+import "context"
+
+// tagObjectPeelQuery resolves both the type of the object at $oid and the
+// commit it peels to in a single round trip. The `^{commit}` suffix follows
+// tag-of-tag chains server-side so depth costs nothing.
+const tagObjectPeelQuery = `query($owner: String!, $name: String!, $oid: GitObjectID!, $expr: String!) {
+  repository(owner: $owner, name: $name) {
+    head: object(oid: $oid) { __typename }
+    peeled: object(expression: $expr) { ... on Commit { oid } }
+  }
+}`
+
+// PeelTagObjectResult holds the outcome of a tag-object peel query.
+type PeelTagObjectResult struct {
+	// Typename is the __typename of the object at the given OID
+	// ("Tag", "Commit", "Blob", "Tree"), or empty if the OID/repo
+	// was not found.
+	Typename string
+
+	// CommitOID is the commit SHA the tag peels to (via ^{commit}).
+	// Empty when the peel fails or the object is not a tag.
+	CommitOID string
+}
+
+// PeelTagObject queries whether sha is an annotated tag object in owner/repo
+// and, if so, returns the commit it dereferences to. Returns a zero result
+// (not an error) when the OID or repo is not accessible — callers decide
+// how to interpret the negative.
+func (c *Client) PeelTagObject(ctx context.Context, owner, repo, sha string) (PeelTagObjectResult, error) {
+	var resp struct {
+		Repository *struct {
+			Head *struct {
+				Typename string `json:"__typename"`
+			} `json:"head"`
+			Peeled *struct {
+				OID string `json:"oid"`
+			} `json:"peeled"`
+		} `json:"repository"`
+	}
+	vars := map[string]any{
+		"owner": owner,
+		"name":  repo,
+		"oid":   sha,
+		"expr":  sha + "^{commit}",
+	}
+	if err := c.graphql.DoWithContext(ctx, tagObjectPeelQuery, vars, &resp); err != nil {
+		return PeelTagObjectResult{}, err
+	}
+	if resp.Repository == nil || resp.Repository.Head == nil {
+		return PeelTagObjectResult{}, nil
+	}
+	result := PeelTagObjectResult{Typename: resp.Repository.Head.Typename}
+	if resp.Repository.Peeled != nil {
+		result.CommitOID = resp.Repository.Peeled.OID
+	}
+	return result, nil
+}

--- a/internal/ghapi/graphql_peel_test.go
+++ b/internal/ghapi/graphql_peel_test.go
@@ -1,0 +1,116 @@
+package ghapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/github/gh-actions-pin/internal/ghapi/httpmock"
+)
+
+func TestPeelTagObject_Tag(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.GraphQL("query"),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"head":   map[string]any{"__typename": "Tag"},
+					"peeled": map[string]any{"oid": "commitabc"},
+				},
+			},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	result, err := c.PeelTagObject(context.Background(), "actions", "checkout", "tagsha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Typename != "Tag" {
+		t.Fatalf("expected Tag, got %q", result.Typename)
+	}
+	if result.CommitOID != "commitabc" {
+		t.Fatalf("expected commitabc, got %q", result.CommitOID)
+	}
+}
+
+func TestPeelTagObject_Commit(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.GraphQL("query"),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"head":   map[string]any{"__typename": "Commit"},
+					"peeled": nil,
+				},
+			},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	result, err := c.PeelTagObject(context.Background(), "actions", "checkout", "commitsha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Typename != "Commit" {
+		t.Fatalf("expected Commit, got %q", result.Typename)
+	}
+	if result.CommitOID != "" {
+		t.Fatalf("expected empty CommitOID for non-tag, got %q", result.CommitOID)
+	}
+}
+
+func TestPeelTagObject_NotFound(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.GraphQL("query"),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"head":   nil,
+					"peeled": nil,
+				},
+			},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	result, err := c.PeelTagObject(context.Background(), "actions", "checkout", "badsha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Typename != "" || result.CommitOID != "" {
+		t.Fatalf("expected zero result for not-found, got %+v", result)
+	}
+}
+
+func TestPeelTagObject_NilRepo(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.GraphQL("query"),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"repository": nil,
+			},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	result, err := c.PeelTagObject(context.Background(), "x", "y", "z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Typename != "" {
+		t.Fatalf("expected zero result for nil repo, got %+v", result)
+	}
+}
+
+func newTestClient(t *testing.T, reg *httpmock.Registry) *Client {
+	t.Helper()
+	c, err := New("github.com", WithClientTransport(reg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}

--- a/internal/ghapi/graphql_reachability.go
+++ b/internal/ghapi/graphql_reachability.go
@@ -1,0 +1,124 @@
+package ghapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+// batchReachabilitySize is the maximum number of branches per GraphQL query.
+const batchReachabilitySize = 50
+
+// BatchBranchContains checks whether sha is reachable from any of the given
+// branches using the GraphQL Ref.compare API. It batches all branches into
+// one or a few GraphQL queries (batchReachabilitySize per query) and returns
+// the first matching branch name in the order provided.
+//
+// Returns:
+//   - matchedBranch: name of the first branch containing sha, or "" if none
+//   - anyChecked: true if at least one branch was successfully checked
+//   - err: non-nil only on transport/auth failures (not per-branch misses)
+func (c *Client) BatchBranchContains(ctx context.Context, owner, repo, sha string, branches []BranchHead) (matchedBranch string, anyChecked bool, err error) {
+	if len(branches) == 0 {
+		return "", false, nil
+	}
+
+	for start := 0; start < len(branches); start += batchReachabilitySize {
+		end := start + batchReachabilitySize
+		if end > len(branches) {
+			end = len(branches)
+		}
+		chunk := branches[start:end]
+
+		matched, checked, qerr := c.batchBranchContainsChunk(ctx, owner, repo, sha, chunk)
+		if checked {
+			anyChecked = true
+		}
+		if matched != "" {
+			return matched, true, nil
+		}
+		if qerr != nil {
+			err = qerr
+		}
+	}
+	return "", anyChecked, err
+}
+
+func (c *Client) batchBranchContainsChunk(ctx context.Context, owner, repo, sha string, branches []BranchHead) (matched string, anyChecked bool, err error) {
+	query, vars := buildBranchCompareQuery(owner, repo, sha, branches)
+
+	var data map[string]json.RawMessage
+	gqlErr := c.graphql.DoWithContext(ctx, query, vars, &data)
+	if gqlErr != nil {
+		var httpErr *api.HTTPError
+		if errors.As(gqlErr, &httpErr) {
+			return "", false, gqlErr
+		}
+		if data == nil {
+			return "", false, gqlErr
+		}
+	}
+
+	repoRaw, ok := data["repo"]
+	if !ok {
+		return "", false, gqlErr
+	}
+
+	var repoData map[string]json.RawMessage
+	if err := json.Unmarshal(repoRaw, &repoData); err != nil {
+		return "", false, fmt.Errorf("parsing batch reachability response: %w", err)
+	}
+
+	for i, b := range branches {
+		alias := fmt.Sprintf("b%d", i)
+		raw, ok := repoData[alias]
+		if !ok || string(raw) == "null" {
+			continue
+		}
+
+		var refData struct {
+			Compare *struct {
+				Status string `json:"status"`
+			} `json:"compare"`
+		}
+		if err := json.Unmarshal(raw, &refData); err != nil || refData.Compare == nil {
+			continue
+		}
+
+		anyChecked = true
+		status := strings.ToUpper(refData.Compare.Status)
+		if status == "BEHIND" || status == "IDENTICAL" {
+			return b.Name, true, nil
+		}
+	}
+
+	return "", anyChecked, nil
+}
+
+func buildBranchCompareQuery(owner, repo, sha string, branches []BranchHead) (string, map[string]any) {
+	vars := make(map[string]any, len(branches)+3)
+	vars["owner"] = owner
+	vars["name"] = repo
+	vars["sha"] = sha
+
+	var decl strings.Builder
+	var body strings.Builder
+
+	decl.WriteString("query($owner: String!, $name: String!, $sha: String!")
+	body.WriteString(") { repo: repository(owner: $owner, name: $name) {")
+
+	for i, b := range branches {
+		refVar := fmt.Sprintf("ref%d", i)
+		vars[refVar] = "refs/heads/" + b.Name
+
+		fmt.Fprintf(&decl, ", $%s: String!", refVar)
+		fmt.Fprintf(&body, " b%d: ref(qualifiedName: $%s) { compare(headRef: $sha) { status } }", i, refVar)
+	}
+
+	body.WriteString(" } }")
+	return decl.String() + body.String(), vars
+}

--- a/internal/ghapi/graphql_reachability_test.go
+++ b/internal/ghapi/graphql_reachability_test.go
@@ -1,0 +1,43 @@
+package ghapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildBranchCompareQuery(t *testing.T) {
+	branches := []BranchHead{
+		{Name: "main", SHA: "aaa"},
+		{Name: "release/v4", SHA: "bbb"},
+	}
+
+	query, vars := buildBranchCompareQuery("o", "r", "targetsha", branches)
+
+	for _, want := range []string{
+		"$owner: String!", "$name: String!", "$sha: String!",
+		"$ref0: String!", "$ref1: String!",
+		"b0: ref(qualifiedName: $ref0)",
+		"b1: ref(qualifiedName: $ref1)",
+		"compare(headRef: $sha)",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("query missing %q:\n%s", want, query)
+		}
+	}
+
+	if vars["owner"] != "o" || vars["name"] != "r" || vars["sha"] != "targetsha" {
+		t.Fatalf("unexpected base vars: %+v", vars)
+	}
+	if vars["ref0"] != "refs/heads/main" {
+		t.Fatalf("expected refs/heads/main, got %v", vars["ref0"])
+	}
+	if vars["ref1"] != "refs/heads/release/v4" {
+		t.Fatalf("expected refs/heads/release/v4, got %v", vars["ref1"])
+	}
+}
+
+func TestBatchReachabilitySize(t *testing.T) {
+	if batchReachabilitySize != 50 {
+		t.Fatalf("expected 50, got %d", batchReachabilitySize)
+	}
+}

--- a/internal/ghapi/httpmock/githubfixtures.go
+++ b/internal/ghapi/httpmock/githubfixtures.go
@@ -1,0 +1,61 @@
+// Package httpmock provides HTTP test fakes for the ghapi client.
+package httpmock
+
+// This file mirrors cli/cli's pkg/httpmock/legacy.go: a small set of
+// cross-cutting GitHub REST response shapes used by tests across multiple
+// packages. Keep the surface narrow — only fixtures that are duplicated in
+// two or more test packages belong here. Per-test bespoke shapes should stay
+// inline at the call site.
+
+// BranchListResponse builds a REST list-branches response body. pairs are
+// (name, sha) alternating, e.g. BranchListResponse("main", "abc", "dev", "def").
+// All entries are marked protected:true so tests model trusted-upstream
+// branches by default; use BranchListResponseProtected to mix protected and
+// unprotected entries.
+func BranchListResponse(pairs ...string) any {
+	out := make([]map[string]any, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, map[string]any{
+			"name":      pairs[i],
+			"commit":    map[string]any{"sha": pairs[i+1]},
+			"protected": true,
+		})
+	}
+	return out
+}
+
+// BranchListResponseProtected builds a REST list-branches response body
+// where each entry is a (name, sha, protected) triple.
+func BranchListResponseProtected(triples ...any) any {
+	out := make([]map[string]any, 0, len(triples)/3)
+	for i := 0; i+2 < len(triples); i += 3 {
+		out = append(out, map[string]any{
+			"name":      triples[i],
+			"commit":    map[string]any{"sha": triples[i+1]},
+			"protected": triples[i+2],
+		})
+	}
+	return out
+}
+
+// TagListResponse builds a REST list-tags response body. pairs are
+// (name, sha) alternating.
+func TagListResponse(pairs ...string) any {
+	out := make([]map[string]any, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, map[string]any{
+			"name":   pairs[i],
+			"commit": map[string]any{"sha": pairs[i+1]},
+		})
+	}
+	return out
+}
+
+// CompareAncestorResponse builds a REST compare response indicating the
+// requested sha is an ancestor of the head, with the given merge-base sha.
+func CompareAncestorResponse(mergeBaseSHA string) any {
+	return map[string]any{
+		"status":            "ahead",
+		"merge_base_commit": map[string]any{"sha": mergeBaseSHA},
+	}
+}

--- a/internal/ghapi/httpmock/httpmock.go
+++ b/internal/ghapi/httpmock/httpmock.go
@@ -1,0 +1,291 @@
+package httpmock
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Matcher determines whether a stub matches an outbound request.
+type Matcher func(req *http.Request) bool
+
+// Responder builds an HTTP response for a matched request.
+type Responder func(req *http.Request) (*http.Response, error)
+
+type stub struct {
+	stack     string
+	matched   bool
+	matcher   Matcher
+	responder Responder
+}
+
+// Registry records requests and serves stubbed responses. It mirrors the
+// cli/cli pkg/httpmock usage pattern for deterministic API tests.
+type Registry struct {
+	mu       sync.Mutex
+	stubs    []*stub
+	Requests []*http.Request
+}
+
+// Register adds a matcher/response pair to the registry.
+func (r *Registry) Register(m Matcher, resp Responder) {
+	r.stubs = append(r.stubs, &stub{
+		stack:     string(debug.Stack()),
+		matcher:   m,
+		responder: resp,
+	})
+}
+
+// Verify fails the test if any registered stubs were never exercised.
+func (r *Registry) Verify(t *testing.T) {
+	t.Helper()
+
+	var unmatched []string
+	for _, s := range r.stubs {
+		if !s.matched {
+			unmatched = append(unmatched, s.stack)
+		}
+	}
+	if len(unmatched) == 0 {
+		return
+	}
+
+	var b strings.Builder
+	for i, stack := range unmatched {
+		fmt.Fprintf(&b, "Stub %d:\n\t%s", i+1, stack)
+		if i < len(unmatched)-1 {
+			b.WriteString("\n")
+		}
+	}
+	t.Fatalf("%d HTTP stubs unmatched:\n%s", len(unmatched), b.String())
+}
+
+// RoundTrip satisfies http.RoundTripper.
+func (r *Registry) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, s := range r.stubs {
+		if s.matched || !s.matcher(req) {
+			continue
+		}
+		s.matched = true
+		r.Requests = append(r.Requests, req)
+		return s.responder(req)
+	}
+
+	return nil, fmt.Errorf("no registered HTTP stubs matched %v", req.URL)
+}
+
+// GraphQL matches a POST GraphQL request whose query matches q.
+func GraphQL(q string) Matcher {
+	re := regexp.MustCompile(q)
+
+	return func(req *http.Request) bool {
+		if !strings.EqualFold(req.Method, http.MethodPost) {
+			return false
+		}
+		if req.URL.Path != "/graphql" && req.URL.Path != "/api/graphql" {
+			return false
+		}
+
+		var body struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = decodeJSONBody(req, &body)
+
+		// Match against the query string. Older callers wrote regexes
+		// over inlined `repository(owner: "actions", ...)` literals;
+		// queries that use GraphQL variables also expose those values
+		// in the variables map, so we synthesize a deterministic
+		// "varKey=varValue" haystack and let the regex search both.
+		if re.MatchString(body.Query) {
+			return true
+		}
+		return re.MatchString(varsHaystack(body.Variables))
+	}
+}
+
+// GraphQLForRepo matches any GraphQL request whose query or variables
+// reference the given repository owner/name. This is the preferred matcher
+// for queries that pass owner/name through GraphQL `$variables` rather
+// than interpolating them as string literals.
+func GraphQLForRepo(owner, repo string) Matcher {
+	return func(req *http.Request) bool {
+		if !strings.EqualFold(req.Method, http.MethodPost) {
+			return false
+		}
+		if req.URL.Path != "/graphql" && req.URL.Path != "/api/graphql" {
+			return false
+		}
+
+		var body struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = decodeJSONBody(req, &body)
+
+		// Inline literal form: e.g. `owner: "actions", name: "checkout"`.
+		inline := fmt.Sprintf(`owner: %q, name: %q`, owner, repo)
+		if strings.Contains(body.Query, inline) {
+			return true
+		}
+		// Variable form: pair an owner var with the matching name var
+		// (owner0/name0, owner1/name1, ...). This avoids a false match
+		// when one repo's owner happens to equal another repo's name.
+		for k, v := range body.Variables {
+			if !strings.HasPrefix(k, "owner") {
+				continue
+			}
+			if vs, _ := v.(string); vs != owner {
+				continue
+			}
+			suffix := strings.TrimPrefix(k, "owner")
+			if name, ok := body.Variables["name"+suffix].(string); ok && name == repo {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func varsHaystack(vars map[string]any) string {
+	if len(vars) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&sb, "%s=%v\n", k, vars[k])
+	}
+	return sb.String()
+}
+
+// JSONResponse turns a value into a 200 JSON response.
+func JSONResponse(body any) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		b, _ := json.Marshal(body)
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			Body:    io.NopCloser(bytes.NewBuffer(b)),
+			Request: req,
+			Status:  "200 OK",
+		}
+		return resp, nil
+	}
+}
+
+// GraphQLQuery inspects the outbound GraphQL request before returning a body.
+func GraphQLQuery(body string, cb func(query string, variables map[string]any)) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := decodeJSONBody(req, &payload); err != nil {
+			return nil, err
+		}
+		cb(payload.Query, payload.Variables)
+
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			Body:    io.NopCloser(bytes.NewBufferString(body)),
+			Request: req,
+			Status:  "200 OK",
+		}
+		return resp, nil
+	}
+}
+
+// REST matches a request by method and URL path pattern (regex).
+func REST(method, pathPattern string) Matcher {
+	re := regexp.MustCompile(pathPattern)
+
+	return func(req *http.Request) bool {
+		if !strings.EqualFold(req.Method, method) {
+			return false
+		}
+		return re.MatchString(req.URL.Path)
+	}
+}
+
+// RESTWithQuery is like REST but also requires querySubstring to appear in the
+// request's raw query string. Use this to distinguish calls that share a URL
+// path but differ by query parameter (e.g. branches?protected=true vs
+// branches?per_page=100).
+func RESTWithQuery(method, pathPattern, querySubstring string) Matcher {
+	re := regexp.MustCompile(pathPattern)
+
+	return func(req *http.Request) bool {
+		if !strings.EqualFold(req.Method, method) {
+			return false
+		}
+		return re.MatchString(req.URL.Path) && strings.Contains(req.URL.RawQuery, querySubstring)
+	}
+}
+
+// StatusResponse returns a response with the given status code and empty body.
+func StatusResponse(code int) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: code,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBuffer(nil)),
+			Request:    req,
+			Status:     fmt.Sprintf("%d", code),
+		}, nil
+	}
+}
+
+// StatusResponseWithHeaders is StatusResponse with response headers — used
+// by tests that exercise rate-limit fallbacks keyed off Retry-After or
+// X-RateLimit-Reset / X-RateLimit-Remaining.
+func StatusResponseWithHeaders(code int, headers map[string]string) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		h := http.Header{}
+		for k, v := range headers {
+			h.Set(k, v)
+		}
+		return &http.Response{
+			StatusCode: code,
+			Header:     h,
+			Body:       io.NopCloser(bytes.NewBuffer(nil)),
+			Request:    req,
+			Status:     fmt.Sprintf("%d", code),
+		}, nil
+	}
+}
+
+func decodeJSONBody(req *http.Request, dest any) error {
+	b, err := readBody(req)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, dest)
+}
+
+func readBody(req *http.Request) ([]byte, error) {
+	bodyCopy := &bytes.Buffer{}
+	r := io.TeeReader(req.Body, bodyCopy)
+	req.Body = io.NopCloser(bodyCopy)
+	return io.ReadAll(r)
+}

--- a/internal/ghapi/httpmock/httpmock_test.go
+++ b/internal/ghapi/httpmock/httpmock_test.go
@@ -1,0 +1,59 @@
+package httpmock
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestGraphQLAndRegistry(t *testing.T) {
+	reg := &Registry{}
+	reg.Register(
+		GraphQL(`query Example\b`),
+		JSONResponse(map[string]any{"data": map[string]any{"ok": true}}),
+	)
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.github.com/graphql", io.NopCloser(strings.NewReader(`{"query":"query Example { viewer { login } }"}`)))
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+
+	resp, err := reg.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("roundtrip failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	reg.Verify(t)
+}
+
+func TestGraphQLQueryResponder(t *testing.T) {
+	reg := &Registry{}
+	called := false
+	reg.Register(
+		GraphQL(`query Example\b`),
+		GraphQLQuery(`{"data":{"viewer":{"login":"mona"}}}`, func(query string, variables map[string]any) {
+			called = true
+			if query == "" {
+				t.Fatal("expected query to be passed to callback")
+			}
+		}),
+	)
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.github.com/graphql", io.NopCloser(strings.NewReader(`{"query":"query Example { viewer { login } }","variables":{"x":1}}`)))
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+
+	_, err = reg.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("roundtrip failed: %v", err)
+	}
+	if !called {
+		t.Fatal("expected GraphQLQuery callback to run")
+	}
+	reg.Verify(t)
+}

--- a/internal/ghapi/repos.go
+++ b/internal/ghapi/repos.go
@@ -1,0 +1,372 @@
+package ghapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+// BranchHead holds a branch name, the SHA of its HEAD commit, and whether
+// the branch has branch-protection rules enabled in the upstream repo.
+type BranchHead struct {
+	Name      string
+	SHA       string
+	Protected bool
+}
+
+// TagEntry holds a tag name and the commit SHA it points at.
+type TagEntry struct {
+	Name string
+	SHA  string
+}
+
+// ListBranches returns all branches with their HEAD SHAs for a repo.
+// Paginates up to 3 pages (300 branches). Results are cached per owner/repo
+// and coalesced via singleflight.
+func (c *Client) ListBranches(ctx context.Context, owner, repo string) ([]BranchHead, error) {
+	key := ForRepo(owner, repo)
+	if cached, ok := c.branchListCache.Get(key); ok {
+		return cached, nil
+	}
+	sfKey := owner + "/" + repo
+	v, err, _ := c.branchListSF.Do(sfKey, func() (any, error) {
+		if cached, ok := c.branchListCache.Get(key); ok {
+			return cached, nil
+		}
+		var all []BranchHead
+		for page := 1; page <= 3; page++ {
+			path := fmt.Sprintf("repos/%s/%s/branches?per_page=100&page=%d",
+				url.PathEscape(owner), url.PathEscape(repo), page)
+			var resp []struct {
+				Name   string `json:"name"`
+				Commit struct {
+					SHA string `json:"sha"`
+				} `json:"commit"`
+				Protected bool `json:"protected"`
+			}
+			if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+				return nil, fmt.Errorf("listing branches for %s/%s: %w", owner, repo, err)
+			}
+			for _, b := range resp {
+				all = append(all, BranchHead{Name: b.Name, SHA: b.Commit.SHA, Protected: b.Protected})
+			}
+			if len(resp) < 100 {
+				break
+			}
+		}
+		c.branchListCache.Put(key, all)
+		return all, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.([]BranchHead), nil
+}
+
+// ListTags returns all tags with their commit SHAs for a repo (first page,
+// up to 100). Results are cached per owner/repo and coalesced via singleflight.
+func (c *Client) ListTags(ctx context.Context, owner, repo string) ([]TagEntry, error) {
+	key := ForRepo(owner, repo)
+	if cached, ok := c.tagListCache.Get(key); ok {
+		return cached, nil
+	}
+	sfKey := owner + "/" + repo
+	type result struct {
+		tags []TagEntry
+		err  error
+	}
+	v, _, _ := c.tagListSF.Do(sfKey, func() (any, error) {
+		if cached, ok := c.tagListCache.Get(key); ok {
+			return result{tags: cached}, nil
+		}
+		path := fmt.Sprintf("repos/%s/%s/tags?per_page=100",
+			url.PathEscape(owner), url.PathEscape(repo))
+		var resp []struct {
+			Name   string `json:"name"`
+			Commit struct {
+				SHA string `json:"sha"`
+			} `json:"commit"`
+		}
+		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+			return result{err: fmt.Errorf("listing tags for %s/%s: %w", owner, repo, err)}, nil
+		}
+		tags := make([]TagEntry, 0, len(resp))
+		for _, t := range resp {
+			tags = append(tags, TagEntry{Name: t.Name, SHA: t.Commit.SHA})
+		}
+		c.tagListCache.Put(key, tags)
+		return result{tags: tags}, nil
+	})
+	res := v.(result)
+	return res.tags, res.err
+}
+
+// GetDefaultBranch returns the repo's default branch name (e.g. "main").
+// On lookup failure an empty string is cached so subsequent callers don't
+// retry. Results are coalesced via singleflight.
+func (c *Client) GetDefaultBranch(ctx context.Context, owner, repo string) string {
+	key := ForRepo(owner, repo)
+	if name, ok := c.defaultBranchCache.Get(key); ok {
+		return name
+	}
+	sfKey := owner + "/" + repo
+	v, _, _ := c.defaultBranchSF.Do(sfKey, func() (any, error) {
+		if name, ok := c.defaultBranchCache.Get(key); ok {
+			return name, nil
+		}
+		var resp struct {
+			DefaultBranch string `json:"default_branch"`
+		}
+		path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
+		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+			c.defaultBranchCache.Put(key, "")
+			return "", nil
+		}
+		c.defaultBranchCache.Put(key, resp.DefaultBranch)
+		return resp.DefaultBranch, nil
+	})
+	return v.(string)
+}
+
+// GetBranchHead resolves a single branch's HEAD commit directly via the
+// git/ref endpoint. Unlike ListBranches this is not subject to the paginated
+// 300-branch cap. Results (including 404s) are cached. Returns ok=false on
+// any error.
+func (c *Client) GetBranchHead(ctx context.Context, owner, repo, name string) (BranchHead, bool) {
+	if name == "" {
+		return BranchHead{}, false
+	}
+	key := ForNWOName(owner, repo, name)
+	if bh, ok := c.namedBranchCache.Get(key); ok {
+		return bh, bh.Name != ""
+	}
+	path := fmt.Sprintf("repos/%s/%s/git/ref/heads/%s",
+		url.PathEscape(owner), url.PathEscape(repo), escapeBranchPath(name))
+	var resp struct {
+		Ref    string `json:"ref"`
+		Object struct {
+			SHA  string `json:"sha"`
+			Type string `json:"type"`
+		} `json:"object"`
+	}
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		var httpErr *api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			c.namedBranchCache.Put(key, BranchHead{}) // negative cache
+		}
+		return BranchHead{}, false
+	}
+	// A prefix (non-exact) match returns an array, decoding to an empty
+	// object here; treat that as "not found" rather than guessing.
+	if resp.Object.SHA == "" {
+		return BranchHead{}, false
+	}
+	bh := BranchHead{Name: name, SHA: resp.Object.SHA}
+	c.namedBranchCache.Put(key, bh)
+	return bh, true
+}
+
+// ListProtectedBranches returns the repo's protected branches. Best-effort:
+// any error yields whatever was collected so far (possibly empty). Results
+// are cached per owner/repo and coalesced via singleflight.
+func (c *Client) ListProtectedBranches(ctx context.Context, owner, repo string) []BranchHead {
+	key := ForRepo(owner, repo)
+	if cached, ok := c.protectedBranchCache.Get(key); ok {
+		return cached
+	}
+	sfKey := owner + "/" + repo
+	v, _, _ := c.protectedBranchSF.Do(sfKey, func() (any, error) {
+		if cached, ok := c.protectedBranchCache.Get(key); ok {
+			return cached, nil
+		}
+		var all []BranchHead
+		for page := 1; page <= 3; page++ {
+			path := fmt.Sprintf("repos/%s/%s/branches?protected=true&per_page=100&page=%d",
+				url.PathEscape(owner), url.PathEscape(repo), page)
+			var resp []struct {
+				Name   string `json:"name"`
+				Commit struct {
+					SHA string `json:"sha"`
+				} `json:"commit"`
+			}
+			if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+				break // best-effort
+			}
+			for _, b := range resp {
+				all = append(all, BranchHead{Name: b.Name, SHA: b.Commit.SHA, Protected: true})
+			}
+			if len(resp) < 100 {
+				break
+			}
+		}
+		c.protectedBranchCache.Put(key, all)
+		return all, nil
+	})
+	if v == nil {
+		return nil
+	}
+	return v.([]BranchHead)
+}
+
+// MatchingHeadRefs returns branches whose names start with prefix via the
+// git/matching-refs endpoint. Best-effort: any error yields nil.
+func (c *Client) MatchingHeadRefs(ctx context.Context, owner, repo, prefix string) []BranchHead {
+	path := fmt.Sprintf("repos/%s/%s/git/matching-refs/heads/%s",
+		url.PathEscape(owner), url.PathEscape(repo), escapeBranchPath(prefix))
+	var resp []struct {
+		Ref    string `json:"ref"`
+		Object struct {
+			SHA  string `json:"sha"`
+			Type string `json:"type"`
+		} `json:"object"`
+	}
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil
+	}
+	var out []BranchHead
+	for _, ref := range resp {
+		name := strings.TrimPrefix(ref.Ref, "refs/heads/")
+		if name == ref.Ref || name == "" || ref.Object.SHA == "" {
+			continue
+		}
+		out = append(out, BranchHead{Name: name, SHA: ref.Object.SHA})
+	}
+	return out
+}
+
+// escapeBranchPath percent-escapes each slash-delimited segment of a ref name
+// while preserving the slashes themselves, so names like "releases/v4" form a
+// valid git/ref path.
+func escapeBranchPath(name string) string {
+	parts := strings.Split(name, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// compareResponse is the subset of the GitHub Compare API response we need.
+type compareResponse struct {
+	Status          string `json:"status"`
+	MergeBaseCommit struct {
+		SHA string `json:"sha"`
+	} `json:"merge_base_commit"`
+}
+
+// CompareCommits reports whether sha is on the lineage of branchHeadSHA
+// using the Compare API. A 404 or 422 response (unrelated histories or
+// missing commit) is treated as a non-error false return. Results are
+// memoized for the lifetime of the Client.
+func (c *Client) CompareCommits(ctx context.Context, owner, repo, sha, branchHeadSHA string) (bool, error) {
+	if strings.EqualFold(sha, branchHeadSHA) {
+		return true, nil
+	}
+	key := ForCompare(owner, repo, sha, branchHeadSHA)
+	if v, ok := c.compareCache.Get(key); ok {
+		return v, nil
+	}
+	path := fmt.Sprintf("repos/%s/%s/compare/%s...%s",
+		url.PathEscape(owner), url.PathEscape(repo),
+		url.PathEscape(sha), url.PathEscape(branchHeadSHA))
+	var resp compareResponse
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		var httpErr *api.HTTPError
+		if errors.As(err, &httpErr) &&
+			(httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusUnprocessableEntity) {
+			c.compareCache.Put(key, false)
+			return false, nil
+		}
+		return false, err
+	}
+	contains := strings.EqualFold(resp.MergeBaseCommit.SHA, sha)
+	c.compareCache.Put(key, contains)
+	return contains, nil
+}
+
+// CompareRefs returns the Compare API status and merge-base SHA for
+// base...head. Unlike CompareCommits it surfaces the raw verdict and the
+// underlying error (including *api.HTTPError) so callers can distinguish
+// ancestry, forgery, and inconclusive results. Not cached: ancestry checks
+// key on distinct base/head pairs that rarely repeat within a run.
+func (c *Client) CompareRefs(ctx context.Context, owner, repo, base, head string) (status, mergeBaseSHA string, err error) {
+	path := fmt.Sprintf("repos/%s/%s/compare/%s...%s",
+		url.PathEscape(owner), url.PathEscape(repo),
+		url.PathEscape(base), url.PathEscape(head))
+	var resp compareResponse
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return "", "", err
+	}
+	return resp.Status, resp.MergeBaseCommit.SHA, nil
+}
+
+// RepoIDs returns the numeric owner ID and repo ID for a NWO, querying
+// the GitHub REST API on cache miss.
+func (c *Client) RepoIDs(ctx context.Context, owner, repo string) (int64, int64, error) {
+	key := ForRepo(owner, repo)
+	if ids, ok := c.repoIDsCache.Get(key); ok {
+		return ids[0], ids[1], nil
+	}
+	var resp struct {
+		ID    int64 `json:"id"`
+		Owner struct {
+			ID int64 `json:"id"`
+		} `json:"owner"`
+	}
+	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return 0, 0, fmt.Errorf("fetching %s: %w", path, err)
+	}
+	if resp.ID == 0 || resp.Owner.ID == 0 {
+		return 0, 0, fmt.Errorf("%s returned zero IDs (owner=%d repo=%d)", path, resp.Owner.ID, resp.ID)
+	}
+	c.repoIDsCache.Put(key, [2]int64{resp.Owner.ID, resp.ID})
+	return resp.Owner.ID, resp.ID, nil
+}
+
+// OrderedBranches returns branches in tiered order so the most trust-bearing
+// candidates are compared first:
+//
+//  1. hintBranch (previously recorded in lockfile for this commit)
+//  2. hintRef (ref the user wrote in the workflow)
+//  3. defaultBranch (e.g. main / master)
+//  4. protected branches, lex-sorted within tier
+//  5. unprotected branches, lex-sorted within tier
+func OrderedBranches(branches []BranchHead, hintBranch, hintRef, defaultBranch string) []BranchHead {
+	priority := make(map[string]bool)
+	var result []BranchHead
+	for _, name := range []string{hintBranch, hintRef, defaultBranch} {
+		if name == "" || priority[name] {
+			continue
+		}
+		for _, b := range branches {
+			if b.Name == name {
+				result = append(result, b)
+				priority[b.Name] = true
+				break
+			}
+		}
+	}
+	protected := make([]BranchHead, 0, len(branches))
+	unprotected := make([]BranchHead, 0, len(branches))
+	for _, b := range branches {
+		if priority[b.Name] {
+			continue
+		}
+		if b.Protected {
+			protected = append(protected, b)
+		} else {
+			unprotected = append(unprotected, b)
+		}
+	}
+	sort.Slice(protected, func(i, j int) bool { return protected[i].Name < protected[j].Name })
+	sort.Slice(unprotected, func(i, j int) bool { return unprotected[i].Name < unprotected[j].Name })
+	result = append(result, protected...)
+	result = append(result, unprotected...)
+	return result
+}

--- a/internal/ghapi/repos.go
+++ b/internal/ghapi/repos.go
@@ -107,37 +107,65 @@ func (c *Client) ListTags(ctx context.Context, owner, repo string) ([]TagEntry, 
 	return res.tags, res.err
 }
 
-// GetDefaultBranch returns the repo's default branch name (e.g. "main").
-// On lookup failure an empty string is cached so subsequent callers don't
-// retry. Results are coalesced via singleflight.
-func (c *Client) GetDefaultBranch(ctx context.Context, owner, repo string) string {
+// repoMeta is the slice of repos/{owner}/{repo} the resolver needs: the
+// default branch plus the numeric owner and repo IDs.
+type repoMeta struct {
+	DefaultBranch string
+	OwnerID       int64
+	RepoID        int64
+}
+
+// repoMetadata fetches repos/{owner}/{repo} at most once per run, coalescing
+// concurrent callers via singleflight and caching the result. Both
+// GetDefaultBranch and RepoIDs derive from it, so a repo costs one round-trip
+// instead of one per consumer. The request runs under a cancel-free context:
+// callers fan out under scan/errgroup contexts that cancel on first
+// match/error, and a coalesced caller's cancellation must not abort the shared
+// fetch for the others waiting on it.
+func (c *Client) repoMetadata(ctx context.Context, owner, repo string) (repoMeta, error) {
 	key := ForRepo(owner, repo)
-	if name, ok := c.defaultBranchCache.Get(key); ok {
-		return name
+	if m, ok := c.repoMetaCache.Get(key); ok {
+		return m, nil
 	}
-	sfKey := key.String()
-	v, _, _ := c.defaultBranchSF.Do(sfKey, func() (any, error) {
-		if name, ok := c.defaultBranchCache.Get(key); ok {
-			return name, nil
+	v, err, _ := c.repoMetaSF.Do(key.String(), func() (any, error) {
+		if m, ok := c.repoMetaCache.Get(key); ok {
+			return m, nil
 		}
 		var resp struct {
 			DefaultBranch string `json:"default_branch"`
+			ID            int64  `json:"id"`
+			Owner         struct {
+				ID int64 `json:"id"`
+			} `json:"owner"`
 		}
 		path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
-		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-			c.defaultBranchCache.Put(key, "")
-			return "", nil
+		if err := c.rest.DoWithContext(context.WithoutCancel(ctx), http.MethodGet, path, nil, &resp); err != nil {
+			return repoMeta{}, fmt.Errorf("fetching %s: %w", path, err)
 		}
-		c.defaultBranchCache.Put(key, resp.DefaultBranch)
-		return resp.DefaultBranch, nil
+		m := repoMeta{DefaultBranch: resp.DefaultBranch, OwnerID: resp.Owner.ID, RepoID: resp.ID}
+		c.repoMetaCache.Put(key, m)
+		return m, nil
 	})
-	return v.(string)
+	if err != nil {
+		return repoMeta{}, err
+	}
+	return v.(repoMeta), nil
+}
+
+// GetDefaultBranch returns the repo's default branch name (e.g. "main"), or
+// "" if the lookup fails. Backed by the shared repoMetadata fetch.
+func (c *Client) GetDefaultBranch(ctx context.Context, owner, repo string) string {
+	m, err := c.repoMetadata(ctx, owner, repo)
+	if err != nil {
+		return ""
+	}
+	return m.DefaultBranch
 }
 
 // GetBranchHead resolves a single branch's HEAD commit directly via the
 // git/ref endpoint. Unlike ListBranches this is not subject to the paginated
-// 300-branch cap. Results (including 404s) are cached. Returns ok=false on
-// any error.
+// 300-branch cap. Results (including 404s) are cached and concurrent lookups
+// are coalesced via singleflight. Returns ok=false on any error.
 func (c *Client) GetBranchHead(ctx context.Context, owner, repo, name string) (BranchHead, bool) {
 	if name == "" {
 		return BranchHead{}, false
@@ -146,30 +174,37 @@ func (c *Client) GetBranchHead(ctx context.Context, owner, repo, name string) (B
 	if bh, ok := c.namedBranchCache.Get(key); ok {
 		return bh, bh.Name != ""
 	}
-	path := fmt.Sprintf("repos/%s/%s/git/ref/heads/%s",
-		url.PathEscape(owner), url.PathEscape(repo), escapeBranchPath(name))
-	var resp struct {
-		Ref    string `json:"ref"`
-		Object struct {
-			SHA  string `json:"sha"`
-			Type string `json:"type"`
-		} `json:"object"`
-	}
-	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		var httpErr *api.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			c.namedBranchCache.Put(key, BranchHead{}) // negative cache
+	v, _, _ := c.namedBranchSF.Do(key.String(), func() (any, error) {
+		if bh, ok := c.namedBranchCache.Get(key); ok {
+			return bh, nil
 		}
-		return BranchHead{}, false
-	}
-	// A prefix (non-exact) match returns an array, decoding to an empty
-	// object here; treat that as "not found" rather than guessing.
-	if resp.Object.SHA == "" {
-		return BranchHead{}, false
-	}
-	bh := BranchHead{Name: name, SHA: resp.Object.SHA}
-	c.namedBranchCache.Put(key, bh)
-	return bh, true
+		path := fmt.Sprintf("repos/%s/%s/git/ref/heads/%s",
+			url.PathEscape(owner), url.PathEscape(repo), escapeBranchPath(name))
+		var resp struct {
+			Ref    string `json:"ref"`
+			Object struct {
+				SHA  string `json:"sha"`
+				Type string `json:"type"`
+			} `json:"object"`
+		}
+		if err := c.rest.DoWithContext(context.WithoutCancel(ctx), http.MethodGet, path, nil, &resp); err != nil {
+			var httpErr *api.HTTPError
+			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+				c.namedBranchCache.Put(key, BranchHead{}) // negative cache
+			}
+			return BranchHead{}, nil
+		}
+		// A prefix (non-exact) match returns an array, decoding to an empty
+		// object here; treat that as "not found" rather than guessing.
+		if resp.Object.SHA == "" {
+			return BranchHead{}, nil
+		}
+		bh := BranchHead{Name: name, SHA: resp.Object.SHA}
+		c.namedBranchCache.Put(key, bh)
+		return bh, nil
+	})
+	bh := v.(BranchHead)
+	return bh, bh.Name != ""
 }
 
 // ListProtectedBranches returns the repo's protected branches. Best-effort:
@@ -262,7 +297,11 @@ type compareResponse struct {
 // CompareCommits reports whether sha is on the lineage of branchHeadSHA
 // using the Compare API. A 404 or 422 response (unrelated histories or
 // missing commit) is treated as a non-error false return. Results are
-// memoized for the lifetime of the Client.
+// memoized for the lifetime of the Client and concurrent identical
+// comparisons are coalesced via singleflight. The request runs under a
+// cancel-free context so that one fanned-out caller's cancellation (the
+// reachability scan cancels siblings on first match) cannot abort the shared
+// comparison the others are waiting on.
 func (c *Client) CompareCommits(ctx context.Context, owner, repo, sha, branchHeadSHA string) (bool, error) {
 	if strings.EqualFold(sha, branchHeadSHA) {
 		return true, nil
@@ -271,22 +310,31 @@ func (c *Client) CompareCommits(ctx context.Context, owner, repo, sha, branchHea
 	if v, ok := c.compareCache.Get(key); ok {
 		return v, nil
 	}
-	path := fmt.Sprintf("repos/%s/%s/compare/%s...%s",
-		url.PathEscape(owner), url.PathEscape(repo),
-		url.PathEscape(sha), url.PathEscape(branchHeadSHA))
-	var resp compareResponse
-	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		var httpErr *api.HTTPError
-		if errors.As(err, &httpErr) &&
-			(httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusUnprocessableEntity) {
-			c.compareCache.Put(key, false)
-			return false, nil
+	v, err, _ := c.compareSF.Do(key.String(), func() (any, error) {
+		if v, ok := c.compareCache.Get(key); ok {
+			return v, nil
 		}
+		path := fmt.Sprintf("repos/%s/%s/compare/%s...%s",
+			url.PathEscape(owner), url.PathEscape(repo),
+			url.PathEscape(sha), url.PathEscape(branchHeadSHA))
+		var resp compareResponse
+		if err := c.rest.DoWithContext(context.WithoutCancel(ctx), http.MethodGet, path, nil, &resp); err != nil {
+			var httpErr *api.HTTPError
+			if errors.As(err, &httpErr) &&
+				(httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusUnprocessableEntity) {
+				c.compareCache.Put(key, false)
+				return false, nil
+			}
+			return false, err
+		}
+		contains := strings.EqualFold(resp.MergeBaseCommit.SHA, sha)
+		c.compareCache.Put(key, contains)
+		return contains, nil
+	})
+	if err != nil {
 		return false, err
 	}
-	contains := strings.EqualFold(resp.MergeBaseCommit.SHA, sha)
-	c.compareCache.Put(key, contains)
-	return contains, nil
+	return v.(bool), nil
 }
 
 // CompareRefs returns the Compare API status and merge-base SHA for
@@ -305,28 +353,19 @@ func (c *Client) CompareRefs(ctx context.Context, owner, repo, base, head string
 	return resp.Status, resp.MergeBaseCommit.SHA, nil
 }
 
-// RepoIDs returns the numeric owner ID and repo ID for a NWO, querying
-// the GitHub REST API on cache miss.
+// RepoIDs returns the numeric owner ID and repo ID for a NWO. Backed by the
+// shared repoMetadata fetch, so it shares a single repos/{owner}/{repo}
+// round-trip with GetDefaultBranch.
 func (c *Client) RepoIDs(ctx context.Context, owner, repo string) (int64, int64, error) {
-	key := ForRepo(owner, repo)
-	if ids, ok := c.repoIDsCache.Get(key); ok {
-		return ids[0], ids[1], nil
+	m, err := c.repoMetadata(ctx, owner, repo)
+	if err != nil {
+		return 0, 0, err
 	}
-	var resp struct {
-		ID    int64 `json:"id"`
-		Owner struct {
-			ID int64 `json:"id"`
-		} `json:"owner"`
+	if m.OwnerID == 0 || m.RepoID == 0 {
+		return 0, 0, fmt.Errorf("repos/%s/%s returned zero IDs (owner=%d repo=%d)",
+			owner, repo, m.OwnerID, m.RepoID)
 	}
-	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
-	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return 0, 0, fmt.Errorf("fetching %s: %w", path, err)
-	}
-	if resp.ID == 0 || resp.Owner.ID == 0 {
-		return 0, 0, fmt.Errorf("%s returned zero IDs (owner=%d repo=%d)", path, resp.Owner.ID, resp.ID)
-	}
-	c.repoIDsCache.Put(key, [2]int64{resp.Owner.ID, resp.ID})
-	return resp.Owner.ID, resp.ID, nil
+	return m.OwnerID, m.RepoID, nil
 }
 
 // OrderedBranches returns branches in tiered order so the most trust-bearing

--- a/internal/ghapi/repos.go
+++ b/internal/ghapi/repos.go
@@ -107,17 +107,20 @@ func (c *Client) ListTags(ctx context.Context, owner, repo string) ([]TagEntry, 
 	return res.tags, res.err
 }
 
-// repoMeta is the slice of repos/{owner}/{repo} the resolver needs: the
-// default branch plus the numeric owner and repo IDs.
+// repoMeta is the subset of repos/{owner}/{repo} the tool needs: the default
+// branch, the numeric owner and repo IDs (lockfile write), and the visibility
+// and last-push time (tag freshness/immutability checks).
 type repoMeta struct {
 	DefaultBranch string
 	OwnerID       int64
 	RepoID        int64
+	Visibility    string
+	PushedAt      string
 }
 
 // repoMetadata fetches repos/{owner}/{repo} at most once per run, coalescing
-// concurrent callers via singleflight and caching the result. Both
-// GetDefaultBranch and RepoIDs derive from it, so a repo costs one round-trip
+// concurrent callers via singleflight and caching the result. GetDefaultBranch,
+// RepoIDs, and RepoMetadata all derive from it, so a repo costs one round-trip
 // instead of one per consumer. The request runs under a cancel-free context:
 // callers fan out under scan/errgroup contexts that cancel on first
 // match/error, and a coalesced caller's cancellation must not abort the shared
@@ -133,6 +136,8 @@ func (c *Client) repoMetadata(ctx context.Context, owner, repo string) (repoMeta
 		}
 		var resp struct {
 			DefaultBranch string `json:"default_branch"`
+			Visibility    string `json:"visibility"`
+			PushedAt      string `json:"pushed_at"`
 			ID            int64  `json:"id"`
 			Owner         struct {
 				ID int64 `json:"id"`
@@ -142,7 +147,13 @@ func (c *Client) repoMetadata(ctx context.Context, owner, repo string) (repoMeta
 		if err := c.rest.DoWithContext(context.WithoutCancel(ctx), http.MethodGet, path, nil, &resp); err != nil {
 			return repoMeta{}, fmt.Errorf("fetching %s: %w", path, err)
 		}
-		m := repoMeta{DefaultBranch: resp.DefaultBranch, OwnerID: resp.Owner.ID, RepoID: resp.ID}
+		m := repoMeta{
+			DefaultBranch: resp.DefaultBranch,
+			OwnerID:       resp.Owner.ID,
+			RepoID:        resp.ID,
+			Visibility:    resp.Visibility,
+			PushedAt:      resp.PushedAt,
+		}
 		c.repoMetaCache.Put(key, m)
 		return m, nil
 	})

--- a/internal/ghapi/repos.go
+++ b/internal/ghapi/repos.go
@@ -34,7 +34,7 @@ func (c *Client) ListBranches(ctx context.Context, owner, repo string) ([]Branch
 	if cached, ok := c.branchListCache.Get(key); ok {
 		return cached, nil
 	}
-	sfKey := owner + "/" + repo
+	sfKey := key.String()
 	v, err, _ := c.branchListSF.Do(sfKey, func() (any, error) {
 		if cached, ok := c.branchListCache.Get(key); ok {
 			return cached, nil
@@ -76,7 +76,7 @@ func (c *Client) ListTags(ctx context.Context, owner, repo string) ([]TagEntry, 
 	if cached, ok := c.tagListCache.Get(key); ok {
 		return cached, nil
 	}
-	sfKey := owner + "/" + repo
+	sfKey := key.String()
 	type result struct {
 		tags []TagEntry
 		err  error
@@ -115,7 +115,7 @@ func (c *Client) GetDefaultBranch(ctx context.Context, owner, repo string) strin
 	if name, ok := c.defaultBranchCache.Get(key); ok {
 		return name
 	}
-	sfKey := owner + "/" + repo
+	sfKey := key.String()
 	v, _, _ := c.defaultBranchSF.Do(sfKey, func() (any, error) {
 		if name, ok := c.defaultBranchCache.Get(key); ok {
 			return name, nil
@@ -180,7 +180,7 @@ func (c *Client) ListProtectedBranches(ctx context.Context, owner, repo string) 
 	if cached, ok := c.protectedBranchCache.Get(key); ok {
 		return cached
 	}
-	sfKey := owner + "/" + repo
+	sfKey := key.String()
 	v, _, _ := c.protectedBranchSF.Do(sfKey, func() (any, error) {
 		if cached, ok := c.protectedBranchCache.Get(key); ok {
 			return cached, nil

--- a/internal/ghapi/repos_dedup_test.go
+++ b/internal/ghapi/repos_dedup_test.go
@@ -1,0 +1,206 @@
+package ghapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/github/gh-actions-pin/internal/ghapi/httpmock"
+)
+
+// countingTransport is a RoundTripper that records how many times each URL
+// path is requested and serves a canned response per endpoint shape. Unlike
+// httpmock.Registry (whose stubs match once), it answers repeated requests so
+// a missing-singleflight stampede shows up as a count > 1.
+type countingTransport struct {
+	mu     sync.Mutex
+	counts map[string]int
+	delay  time.Duration // widen the cache-miss window so concurrent callers overlap
+}
+
+func newCountingTransport(delay time.Duration) *countingTransport {
+	return &countingTransport{counts: map[string]int{}, delay: delay}
+}
+
+func (t *countingTransport) count(substr string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	total := 0
+	for p, n := range t.counts {
+		if strings.Contains(p, substr) {
+			total += n
+		}
+	}
+	return total
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	t.counts[req.URL.Path]++
+	t.mu.Unlock()
+
+	if t.delay > 0 {
+		time.Sleep(t.delay)
+	}
+
+	p := req.URL.Path
+	switch {
+	case strings.Contains(p, "/compare/"):
+		return httpmock.JSONResponse(map[string]any{
+			"status":            "behind",
+			"merge_base_commit": map[string]string{"sha": "old"},
+		})(req)
+	case strings.Contains(p, "/git/ref/heads/"):
+		return httpmock.JSONResponse(map[string]any{
+			"ref":    "refs/heads/main",
+			"object": map[string]string{"sha": "headsha", "type": "commit"},
+		})(req)
+	default: // repos/{owner}/{repo}
+		return httpmock.JSONResponse(map[string]any{
+			"default_branch": "main",
+			"id":             int64(20),
+			"owner":          map[string]any{"id": int64(10)},
+		})(req)
+	}
+}
+
+func newCountingClient(t *testing.T, tr http.RoundTripper) *Client {
+	t.Helper()
+	c, err := New("github.com", WithClientTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// runConcurrent fans out fn across n goroutines that start together.
+func runConcurrent(n int, fn func()) {
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	done.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer done.Done()
+			start.Wait()
+			fn()
+		}()
+	}
+	start.Done()
+	done.Wait()
+}
+
+func TestCompareCommits_CoalescesConcurrent(t *testing.T) {
+	tr := newCountingTransport(2 * time.Millisecond)
+	c := newCountingClient(t, tr)
+
+	runConcurrent(50, func() {
+		got, err := c.CompareCommits(context.Background(), "o", "r", "old", "new")
+		if err != nil || !got {
+			t.Errorf("CompareCommits = (%v, %v), want (true, nil)", got, err)
+		}
+	})
+
+	if n := tr.count("/compare/"); n != 1 {
+		t.Fatalf("expected 1 compare request, got %d", n)
+	}
+}
+
+func TestGetBranchHead_CoalescesConcurrent(t *testing.T) {
+	tr := newCountingTransport(2 * time.Millisecond)
+	c := newCountingClient(t, tr)
+
+	runConcurrent(50, func() {
+		bh, ok := c.GetBranchHead(context.Background(), "o", "r", "main")
+		if !ok || bh.SHA != "headsha" {
+			t.Errorf("GetBranchHead = (%+v, %v), want sha=headsha ok=true", bh, ok)
+		}
+	})
+
+	if n := tr.count("/git/ref/heads/"); n != 1 {
+		t.Fatalf("expected 1 git/ref request, got %d", n)
+	}
+}
+
+func TestRepoIDs_CoalescesConcurrent(t *testing.T) {
+	tr := newCountingTransport(2 * time.Millisecond)
+	c := newCountingClient(t, tr)
+
+	runConcurrent(50, func() {
+		owner, repo, err := c.RepoIDs(context.Background(), "o", "r")
+		if err != nil || owner != 10 || repo != 20 {
+			t.Errorf("RepoIDs = (%d, %d, %v), want (10, 20, nil)", owner, repo, err)
+		}
+	})
+
+	if n := tr.count("repos/o/r"); n != 1 {
+		t.Fatalf("expected 1 repo request, got %d", n)
+	}
+}
+
+// RepoIDs and GetDefaultBranch both derive from repos/{owner}/{repo}; they
+// must share a single round-trip rather than fetching it twice.
+func TestRepoMetadata_SharedAcrossConsumers(t *testing.T) {
+	tr := newCountingTransport(2 * time.Millisecond)
+	c := newCountingClient(t, tr)
+
+	runConcurrent(50, func() {
+		if got := c.GetDefaultBranch(context.Background(), "o", "r"); got != "main" {
+			t.Errorf("GetDefaultBranch = %q, want main", got)
+		}
+		if owner, repo, err := c.RepoIDs(context.Background(), "o", "r"); err != nil || owner != 10 || repo != 20 {
+			t.Errorf("RepoIDs = (%d, %d, %v)", owner, repo, err)
+		}
+	})
+
+	if n := tr.count("repos/o/r"); n != 1 {
+		t.Fatalf("expected 1 shared repo request, got %d", n)
+	}
+}
+
+// A coalesced caller fans out under a scan/errgroup context that cancels on
+// first match or error. The shared request must not inherit that cancellation,
+// otherwise one caller's cancel would poison the result for everyone waiting on
+// it. These assert a pre-canceled caller still gets the real answer.
+
+func TestCompareCommits_IgnoresCallerCancel(t *testing.T) {
+	tr := newCountingTransport(0)
+	c := newCountingClient(t, tr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := c.CompareCommits(ctx, "o", "r", "old", "new")
+	if err != nil || !got {
+		t.Fatalf("CompareCommits with canceled ctx = (%v, %v), want (true, nil)", got, err)
+	}
+}
+
+func TestGetBranchHead_IgnoresCallerCancel(t *testing.T) {
+	tr := newCountingTransport(0)
+	c := newCountingClient(t, tr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	bh, ok := c.GetBranchHead(ctx, "o", "r", "main")
+	if !ok || bh.SHA != "headsha" {
+		t.Fatalf("GetBranchHead with canceled ctx = (%+v, %v), want sha=headsha ok=true", bh, ok)
+	}
+}
+
+func TestRepoIDs_IgnoresCallerCancel(t *testing.T) {
+	tr := newCountingTransport(0)
+	c := newCountingClient(t, tr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	owner, repo, err := c.RepoIDs(ctx, "o", "r")
+	if err != nil || owner != 10 || repo != 20 {
+		t.Fatalf("RepoIDs with canceled ctx = (%d, %d, %v), want (10, 20, nil)", owner, repo, err)
+	}
+}

--- a/internal/ghapi/repos_test.go
+++ b/internal/ghapi/repos_test.go
@@ -1,0 +1,297 @@
+package ghapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/github/gh-actions-pin/internal/ghapi/httpmock"
+)
+
+func TestOrderedBranches(t *testing.T) {
+	branches := []BranchHead{
+		{Name: "dev", SHA: "1", Protected: false},
+		{Name: "main", SHA: "2", Protected: true},
+		{Name: "release/v4", SHA: "3", Protected: true},
+		{Name: "alpha", SHA: "4", Protected: false},
+		{Name: "staging", SHA: "5", Protected: true},
+	}
+
+	ordered := OrderedBranches(branches, "release/v4", "v4", "main")
+
+	want := []string{"release/v4", "main", "staging", "alpha", "dev"}
+	if len(ordered) != len(want) {
+		t.Fatalf("expected %d branches, got %d", len(want), len(ordered))
+	}
+	for i, name := range want {
+		if ordered[i].Name != name {
+			t.Errorf("position %d: expected %q, got %q", i, name, ordered[i].Name)
+		}
+	}
+}
+
+func TestOrderedBranches_EmptyHints(t *testing.T) {
+	branches := []BranchHead{
+		{Name: "b", SHA: "1"},
+		{Name: "a", SHA: "2"},
+	}
+	ordered := OrderedBranches(branches, "", "", "")
+	if len(ordered) != 2 {
+		t.Fatalf("expected 2, got %d", len(ordered))
+	}
+	if ordered[0].Name != "a" {
+		t.Errorf("expected lex-sorted, got %q first", ordered[0].Name)
+	}
+}
+
+func TestEscapeBranchPath(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"main", "main"},
+		{"release/v4", "release/v4"},
+		{"feat/hello world", "feat/hello%20world"},
+	}
+	for _, tt := range tests {
+		got := escapeBranchPath(tt.in)
+		if got != tt.want {
+			t.Errorf("escapeBranchPath(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCompareCommits_SameSHA(t *testing.T) {
+	c := &Client{}
+	ok, err := c.CompareCommits(context.Background(), "o", "r", "abc", "abc")
+	if err != nil || !ok {
+		t.Fatalf("expected true/nil for same SHA, got %v/%v", ok, err)
+	}
+}
+
+func TestCompareCommits_Ancestor(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r/compare/old...new"),
+		httpmock.JSONResponse(map[string]any{
+			"status":            "behind",
+			"merge_base_commit": map[string]string{"sha": "old"},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	ok, err := c.CompareCommits(context.Background(), "o", "r", "old", "new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected true for ancestor")
+	}
+}
+
+func TestCompareCommits_NotAncestor(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r/compare/old...new"),
+		httpmock.JSONResponse(map[string]any{
+			"status":            "diverged",
+			"merge_base_commit": map[string]string{"sha": "other"},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	ok, err := c.CompareCommits(context.Background(), "o", "r", "old", "new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("expected false for non-ancestor")
+	}
+}
+
+func TestCompareCommits_404(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r/compare/old...new"),
+		httpmock.StatusResponse(http.StatusNotFound),
+	)
+
+	c := newTestClient(t, reg)
+	ok, err := c.CompareCommits(context.Background(), "o", "r", "old", "new")
+	if err != nil {
+		t.Fatalf("expected nil error for 404, got %v", err)
+	}
+	if ok {
+		t.Fatal("expected false for 404")
+	}
+}
+
+func TestCompareCommits_Cache(t *testing.T) {
+	calls := 0
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r/compare/old...new"),
+		func(req *http.Request) (*http.Response, error) {
+			calls++
+			return httpmock.JSONResponse(map[string]any{
+				"status":            "behind",
+				"merge_base_commit": map[string]string{"sha": "old"},
+			})(req)
+		},
+	)
+
+	c := newTestClient(t, reg)
+	_, _ = c.CompareCommits(context.Background(), "o", "r", "old", "new")
+	_, _ = c.CompareCommits(context.Background(), "o", "r", "old", "new")
+	if calls != 1 {
+		t.Fatalf("expected 1 call (second should cache), got %d", calls)
+	}
+}
+
+func TestGetDefaultBranch(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r"),
+		httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
+	)
+
+	c := newTestClient(t, reg)
+	got := c.GetDefaultBranch(context.Background(), "o", "r")
+	if got != "main" {
+		t.Fatalf("expected main, got %q", got)
+	}
+}
+
+func TestListBranches(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r/branches"),
+		httpmock.JSONResponse([]map[string]any{
+			{"name": "main", "commit": map[string]string{"sha": "aaa"}, "protected": true},
+			{"name": "dev", "commit": map[string]string{"sha": "bbb"}, "protected": false},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	branches, err := c.ListBranches(context.Background(), "o", "r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("expected 2 branches, got %d", len(branches))
+	}
+	if branches[0].Name != "main" || !branches[0].Protected {
+		t.Fatalf("unexpected first branch: %+v", branches[0])
+	}
+}
+
+func TestRepoIDs(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r"),
+		httpmock.JSONResponse(map[string]any{
+			"id":    42,
+			"owner": map[string]any{"id": 7},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	ownerID, repoID, err := c.RepoIDs(context.Background(), "o", "r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ownerID != 7 || repoID != 42 {
+		t.Fatalf("expected owner=7 repo=42, got owner=%d repo=%d", ownerID, repoID)
+	}
+}
+
+func TestRepoIDs_ZeroIDs(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r"),
+		httpmock.JSONResponse(map[string]any{
+			"id":    0,
+			"owner": map[string]any{"id": 0},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	_, _, err := c.RepoIDs(context.Background(), "o", "r")
+	if err == nil {
+		t.Fatal("expected error for zero IDs")
+	}
+}
+
+func TestListTags(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r/tags"),
+		httpmock.JSONResponse([]map[string]any{
+			{"name": "v1.0.0", "commit": map[string]string{"sha": "aaa"}},
+			{"name": "v2.0.0", "commit": map[string]string{"sha": "bbb"}},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	tags, err := c.ListTags(context.Background(), "o", "r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(tags))
+	}
+	if tags[0].Name != "v1.0.0" {
+		t.Fatalf("unexpected first tag: %+v", tags[0])
+	}
+}
+
+func TestGetBranchHead(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r/git/ref/heads/main"),
+		httpmock.JSONResponse(map[string]any{
+			"ref":    "refs/heads/main",
+			"object": map[string]any{"sha": "abc123", "type": "commit"},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	bh, ok := c.GetBranchHead(context.Background(), "o", "r", "main")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if bh.Name != "main" || bh.SHA != "abc123" {
+		t.Fatalf("unexpected result: %+v", bh)
+	}
+}
+
+func TestGetBranchHead_Empty(t *testing.T) {
+	c := &Client{}
+	_, ok := c.GetBranchHead(context.Background(), "o", "r", "")
+	if ok {
+		t.Fatal("expected ok=false for empty name")
+	}
+}
+
+func TestMatchingHeadRefs(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "repos/o/r/git/matching-refs/heads/release/"),
+		httpmock.JSONResponse([]map[string]any{
+			{"ref": "refs/heads/release/v3", "object": map[string]any{"sha": "aaa", "type": "commit"}},
+			{"ref": "refs/heads/release/v4", "object": map[string]any{"sha": "bbb", "type": "commit"}},
+		}),
+	)
+
+	c := newTestClient(t, reg)
+	branches := c.MatchingHeadRefs(context.Background(), "o", "r", "release/")
+	if len(branches) != 2 {
+		t.Fatalf("expected 2 branches, got %d", len(branches))
+	}
+	if branches[0].Name != "release/v3" {
+		t.Fatalf("unexpected first branch: %+v", branches[0])
+	}
+}
+
+// Suppress unused import warning.
+var _ = fmt.Sprintf

--- a/internal/ghapi/repos_test.go
+++ b/internal/ghapi/repos_test.go
@@ -2,7 +2,6 @@ package ghapi
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -292,6 +291,3 @@ func TestMatchingHeadRefs(t *testing.T) {
 		t.Fatalf("unexpected first branch: %+v", branches[0])
 	}
 }
-
-// Suppress unused import warning.
-var _ = fmt.Sprintf

--- a/internal/ghapi/tagsource.go
+++ b/internal/ghapi/tagsource.go
@@ -1,0 +1,144 @@
+package ghapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// RepoTag is a tag name paired with the commit SHA it resolves to, as
+// returned by the repos/tags endpoint (annotated tags dereferenced).
+type RepoTag struct {
+	Name string
+	SHA  string
+}
+
+// RepoTags lists a repository's tags (up to 100), dereferencing annotated
+// tags to their target commit SHA.
+func (c *Client) RepoTags(ctx context.Context, owner, repo string) ([]RepoTag, error) {
+	path := fmt.Sprintf("repos/%s/%s/tags?per_page=100",
+		url.PathEscape(owner), url.PathEscape(repo))
+
+	var apiTags []struct {
+		Name   string `json:"name"`
+		Commit struct {
+			SHA string `json:"sha"`
+		} `json:"commit"`
+	}
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &apiTags); err != nil {
+		return nil, fmt.Errorf("fetching tags for %s/%s: %w", owner, repo, err)
+	}
+
+	out := make([]RepoTag, 0, len(apiTags))
+	for _, t := range apiTags {
+		out = append(out, RepoTag{Name: t.Name, SHA: t.Commit.SHA})
+	}
+	return out, nil
+}
+
+// TagObjectRef is a tag ref paired with the SHA and type of the object it
+// points at: the tag object SHA for annotated tags, the commit SHA for
+// lightweight tags. Name has the refs/tags/ prefix stripped.
+type TagObjectRef struct {
+	Name       string
+	ObjectSHA  string
+	ObjectType string
+}
+
+// MatchingTagRefs lists raw tag refs (up to 100) without dereferencing
+// annotated tag objects, so callers can recover the tag object SHA that
+// immutable release pins resolve to.
+func (c *Client) MatchingTagRefs(ctx context.Context, owner, repo string) ([]TagObjectRef, error) {
+	path := fmt.Sprintf("repos/%s/%s/git/matching-refs/tags?per_page=100",
+		url.PathEscape(owner), url.PathEscape(repo))
+
+	var refs []struct {
+		Ref    string `json:"ref"`
+		Object struct {
+			SHA  string `json:"sha"`
+			Type string `json:"type"`
+		} `json:"object"`
+	}
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &refs); err != nil {
+		return nil, fmt.Errorf("fetching tag refs for %s/%s: %w", owner, repo, err)
+	}
+
+	out := make([]TagObjectRef, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, TagObjectRef{
+			Name:       strings.TrimPrefix(r.Ref, "refs/tags/"),
+			ObjectSHA:  r.Object.SHA,
+			ObjectType: r.Object.Type,
+		})
+	}
+	return out, nil
+}
+
+// RepoRelease holds release metadata for a tag.
+type RepoRelease struct {
+	TagName     string
+	PublishedAt string // ISO 8601 date
+	Immutable   bool
+}
+
+// Releases lists a repository's most recent releases (up to 30).
+func (c *Client) Releases(ctx context.Context, owner, repo string) ([]RepoRelease, error) {
+	path := fmt.Sprintf("repos/%s/%s/releases?per_page=30",
+		url.PathEscape(owner), url.PathEscape(repo))
+
+	var releases []struct {
+		TagName     string `json:"tag_name"`
+		PublishedAt string `json:"published_at"`
+		Immutable   bool   `json:"immutable"`
+	}
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &releases); err != nil {
+		return nil, err
+	}
+
+	out := make([]RepoRelease, 0, len(releases))
+	for _, rel := range releases {
+		out = append(out, RepoRelease(rel))
+	}
+	return out, nil
+}
+
+// RepoMetadata holds repository-level metadata relevant for pinning decisions.
+type RepoMetadata struct {
+	DefaultBranch string
+	Visibility    string // "public", "private", or "internal"
+	PushedAt      string // ISO 8601 timestamp of last push
+}
+
+// RepoMetadata fetches a repository's default branch, visibility, and last
+// push time.
+func (c *Client) RepoMetadata(ctx context.Context, owner, repo string) (RepoMetadata, error) {
+	path := fmt.Sprintf("repos/%s/%s",
+		url.PathEscape(owner), url.PathEscape(repo))
+
+	var result struct {
+		DefaultBranch string `json:"default_branch"`
+		Visibility    string `json:"visibility"`
+		PushedAt      string `json:"pushed_at"`
+	}
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return RepoMetadata{}, err
+	}
+	return RepoMetadata(result), nil
+}
+
+// CommitSHA resolves a ref (branch, tag, or SHA) to its commit SHA via the
+// repos/commits endpoint.
+func (c *Client) CommitSHA(ctx context.Context, owner, repo, ref string) (string, error) {
+	path := fmt.Sprintf("repos/%s/%s/commits/%s",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(ref))
+
+	var result struct {
+		SHA string `json:"sha"`
+	}
+	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return "", err
+	}
+	return result.SHA, nil
+}

--- a/internal/ghapi/tagsource.go
+++ b/internal/ghapi/tagsource.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 )
 
 // RepoTag is a tag name paired with the commit SHA it resolves to, as
@@ -34,44 +33,6 @@ func (c *Client) RepoTags(ctx context.Context, owner, repo string) ([]RepoTag, e
 	out := make([]RepoTag, 0, len(apiTags))
 	for _, t := range apiTags {
 		out = append(out, RepoTag{Name: t.Name, SHA: t.Commit.SHA})
-	}
-	return out, nil
-}
-
-// TagObjectRef is a tag ref paired with the SHA and type of the object it
-// points at: the tag object SHA for annotated tags, the commit SHA for
-// lightweight tags. Name has the refs/tags/ prefix stripped.
-type TagObjectRef struct {
-	Name       string
-	ObjectSHA  string
-	ObjectType string
-}
-
-// MatchingTagRefs lists raw tag refs (up to 100) without dereferencing
-// annotated tag objects, so callers can recover the tag object SHA that
-// immutable release pins resolve to.
-func (c *Client) MatchingTagRefs(ctx context.Context, owner, repo string) ([]TagObjectRef, error) {
-	path := fmt.Sprintf("repos/%s/%s/git/matching-refs/tags?per_page=100",
-		url.PathEscape(owner), url.PathEscape(repo))
-
-	var refs []struct {
-		Ref    string `json:"ref"`
-		Object struct {
-			SHA  string `json:"sha"`
-			Type string `json:"type"`
-		} `json:"object"`
-	}
-	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &refs); err != nil {
-		return nil, fmt.Errorf("fetching tag refs for %s/%s: %w", owner, repo, err)
-	}
-
-	out := make([]TagObjectRef, 0, len(refs))
-	for _, r := range refs {
-		out = append(out, TagObjectRef{
-			Name:       strings.TrimPrefix(r.Ref, "refs/tags/"),
-			ObjectSHA:  r.Object.SHA,
-			ObjectType: r.Object.Type,
-		})
 	}
 	return out, nil
 }

--- a/internal/ghapi/tagsource.go
+++ b/internal/ghapi/tagsource.go
@@ -14,25 +14,17 @@ type RepoTag struct {
 	SHA  string
 }
 
-// RepoTags lists a repository's tags (up to 100), dereferencing annotated
-// tags to their target commit SHA.
+// RepoTags lists a repository's tags (up to 100) with the commit SHA each
+// resolves to. Delegates to ListTags so it shares the cached, singleflight-
+// coalesced tag fetch rather than issuing a second identical request.
 func (c *Client) RepoTags(ctx context.Context, owner, repo string) ([]RepoTag, error) {
-	path := fmt.Sprintf("repos/%s/%s/tags?per_page=100",
-		url.PathEscape(owner), url.PathEscape(repo))
-
-	var apiTags []struct {
-		Name   string `json:"name"`
-		Commit struct {
-			SHA string `json:"sha"`
-		} `json:"commit"`
-	}
-	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &apiTags); err != nil {
+	entries, err := c.ListTags(ctx, owner, repo)
+	if err != nil {
 		return nil, fmt.Errorf("fetching tags for %s/%s: %w", owner, repo, err)
 	}
-
-	out := make([]RepoTag, 0, len(apiTags))
-	for _, t := range apiTags {
-		out = append(out, RepoTag{Name: t.Name, SHA: t.Commit.SHA})
+	out := make([]RepoTag, 0, len(entries))
+	for _, t := range entries {
+		out = append(out, RepoTag{Name: t.Name, SHA: t.SHA})
 	}
 	return out, nil
 }
@@ -73,20 +65,19 @@ type RepoMetadata struct {
 }
 
 // RepoMetadata fetches a repository's default branch, visibility, and last
-// push time.
+// push time. Delegates to the shared repoMetadata fetch so it shares the
+// cached, singleflight-coalesced repos/{owner}/{repo} round-trip with
+// GetDefaultBranch and RepoIDs.
 func (c *Client) RepoMetadata(ctx context.Context, owner, repo string) (RepoMetadata, error) {
-	path := fmt.Sprintf("repos/%s/%s",
-		url.PathEscape(owner), url.PathEscape(repo))
-
-	var result struct {
-		DefaultBranch string `json:"default_branch"`
-		Visibility    string `json:"visibility"`
-		PushedAt      string `json:"pushed_at"`
-	}
-	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &result); err != nil {
+	m, err := c.repoMetadata(ctx, owner, repo)
+	if err != nil {
 		return RepoMetadata{}, fmt.Errorf("fetching metadata for %s/%s: %w", owner, repo, err)
 	}
-	return RepoMetadata(result), nil
+	return RepoMetadata{
+		DefaultBranch: m.DefaultBranch,
+		Visibility:    m.Visibility,
+		PushedAt:      m.PushedAt,
+	}, nil
 }
 
 // CommitSHA resolves a ref (branch, tag, or SHA) to its commit SHA via the

--- a/internal/ghapi/tagsource.go
+++ b/internal/ghapi/tagsource.go
@@ -94,7 +94,7 @@ func (c *Client) Releases(ctx context.Context, owner, repo string) ([]RepoReleas
 		Immutable   bool   `json:"immutable"`
 	}
 	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &releases); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fetching releases for %s/%s: %w", owner, repo, err)
 	}
 
 	out := make([]RepoRelease, 0, len(releases))
@@ -123,7 +123,7 @@ func (c *Client) RepoMetadata(ctx context.Context, owner, repo string) (RepoMeta
 		PushedAt      string `json:"pushed_at"`
 	}
 	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &result); err != nil {
-		return RepoMetadata{}, err
+		return RepoMetadata{}, fmt.Errorf("fetching metadata for %s/%s: %w", owner, repo, err)
 	}
 	return RepoMetadata(result), nil
 }
@@ -138,7 +138,7 @@ func (c *Client) CommitSHA(ctx context.Context, owner, repo, ref string) (string
 		SHA string `json:"sha"`
 	}
 	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &result); err != nil {
-		return "", err
+		return "", fmt.Errorf("resolving %s/%s@%s: %w", owner, repo, ref, err)
 	}
 	return result.SHA, nil
 }

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -428,7 +428,7 @@ func TestWriteDependenciesGroupedByParent(t *testing.T) {
 
 	parentMap := map[string][]string{
 		"actions/cache/save@v4": {"actions/setup-go@v5"},
-		"other/dep@v1":         {"actions/checkout@v4"},
+		"other/dep@v1":          {"actions/checkout@v4"},
 	}
 
 	output, err := f.WriteDependencies(deps, parentMap)


### PR DESCRIPTION
**Layer 1/7 — foundation.**

Introduce `internal/ghapi`, a single client that owns REST + GraphQL transport, caching, retry, and batched GraphQL queries. Later layers route all GitHub access through it instead of holding their own handles.

---
Part of a stacked series for the pre-release hardening of `gh actions-pin`. Review bottom-up; each PR is based on the one below it so the diff shows only that layer.