### PR TITLE
Fix CTRL+C handling, spinner flicker, and progress UX

### DIFF
--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sync"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/go-gh/v2/pkg/repository"
@@ -225,11 +226,12 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 		Rescan:        opts.rescan,
 		Profile:       prof,
 	}
-	// Interactive spinner mode: wire per-ref resolver progress counter.
-	// Reachability runs under the same label — no separate phase.
+	// Interactive spinner mode: set label once when resolve starts.
+	// Worker-slot status rows show per-ref detail.
 	if showSpinner {
+		var once sync.Once
 		runOpts.OnResolveProgress = func(done, total int) {
-			console.UpdateLabel(fmt.Sprintf("Resolving actions [%d/%d]", done, total))
+			once.Do(func() { console.UpdateLabel("Resolving actions") })
 		}
 	}
 

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -202,11 +202,7 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	showSpinner := opts.jsonFields == "" && !console.Headless()
 	showHeadlessProgress := console.Headless()
 
-	// Start spinner — the label stays empty until the first per-ref resolve
-	// callback fires. The grace period suppresses flicker on fast runs.
-	if showSpinner {
-		console.StartProgress("")
-	} else if showHeadlessProgress {
+	if showHeadlessProgress {
 		console.StartProgress(fmt.Sprintf("Scanning %d %s", total, ui.Pluralize(total, "workflow", "workflows")))
 	}
 
@@ -226,12 +222,15 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 		Rescan:        opts.rescan,
 		Profile:       prof,
 	}
-	// Interactive spinner mode: set label once when resolve starts.
-	// Worker-slot status rows show per-ref detail.
+	// Defer spinner start until actual network work begins. The fast path
+	// (everything trusted from the lockfile) returns before resolve fires,
+	// so the spinner never appears and there's no flicker.
 	if showSpinner {
 		var once sync.Once
 		runOpts.OnResolveProgress = func(done, total int) {
-			once.Do(func() { console.UpdateLabel("Resolving actions") })
+			once.Do(func() {
+				console.StartProgress("Resolving actions")
+			})
 		}
 	}
 

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -293,6 +293,9 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	}
 
 	endPlan := prof.Phase("pin.Plan (narrowing+reverse)")
+	if showSpinner {
+		console.ClearWorkerStatuses()
+	}
 	record, planErr := pin.Plan(ctx, report, pin.PlanOptions{
 		Resolver:  r,
 		Tagger:    tagger,

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -201,22 +201,12 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	showSpinner := opts.jsonFields == "" && !console.Headless()
 	showHeadlessProgress := console.Headless()
 
-	// Build progress callbacks for the pipeline.
-	var onScan func(done, total int, path string)
+	// Start spinner — the label stays empty until the first per-ref resolve
+	// callback fires. The grace period suppresses flicker on fast runs.
 	if showSpinner {
-		label := fmt.Sprintf("Scanning %d %s", total, ui.Pluralize(total, "workflow", "workflows"))
-		console.StartProgress(label)
-		onScan = func(done, total int, path string) {
-			console.UpdateLabel(fmt.Sprintf("Scanning [%d/%d] %s", done, total, path))
-			console.UpdateProgress("")
-		}
+		console.StartProgress("")
 	} else if showHeadlessProgress {
 		console.StartProgress(fmt.Sprintf("Scanning %d %s", total, ui.Pluralize(total, "workflow", "workflows")))
-	}
-	phaseFn := func(phase string) {
-		if showSpinner || showHeadlessProgress {
-			console.UpdateLabel(phase)
-		}
 	}
 
 	// Build a Lister for impostor enrichment + pin narrowing,
@@ -233,17 +223,13 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 		Store:         store,
 		Pool:          pool,
 		Rescan:        opts.rescan,
-		OnScan:        onScan,
-		OnProgress:    phaseFn,
 		Profile:       prof,
 	}
-	// Interactive spinner mode: wire per-ref resolver progress counters.
+	// Interactive spinner mode: wire per-ref resolver progress counter.
+	// Reachability runs under the same label — no separate phase.
 	if showSpinner {
 		runOpts.OnResolveProgress = func(done, total int) {
 			console.UpdateLabel(fmt.Sprintf("Resolving actions [%d/%d]", done, total))
-		}
-		runOpts.OnVerifyProgress = func(done, total int) {
-			console.UpdateLabel(fmt.Sprintf("Verifying reachability [%d/%d]", done, total))
 		}
 	}
 
@@ -268,14 +254,13 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	// (the human narrative). JSON is emitted later, after any fixes land, so
 	// stdout never carries a diagnosis for a run that then failed to commit.
 	if opts.jsonFields == "" {
-		// Pause the spinner so PresentResults lines don't collide with the
-		// spinner label (causes phantom text).
+		// Pause the spinner so PresentResults lines don't collide with it.
 		if showSpinner {
-			console.StopProgress()
+			console.PauseProgress()
 		}
 		format.PresentResults(console, report, valid, true)
 		if showSpinner {
-			console.StartProgress("")
+			console.ResumeProgress()
 		}
 	}
 
@@ -305,22 +290,15 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 		repoName = currentRepo.Name
 	}
 
-	progressFn := func(phase string) {
-		if showSpinner || showHeadlessProgress {
-			console.UpdateLabel(phase)
-		}
-	}
-
 	endPlan := prof.Phase("pin.Plan (narrowing+reverse)")
 	record, planErr := pin.Plan(ctx, report, pin.PlanOptions{
-		Resolver:   r,
-		Tagger:     tagger,
-		Store:      store,
-		Pool:       pool,
-		RepoOwner:  repoOwner,
-		RepoName:   repoName,
-		Version:    cliVersion(),
-		OnProgress: progressFn,
+		Resolver:  r,
+		Tagger:    tagger,
+		Store:     store,
+		Pool:      pool,
+		RepoOwner: repoOwner,
+		RepoName:  repoName,
+		Version:   cliVersion(),
 	})
 	endPlan()
 	if planErr != nil {
@@ -328,9 +306,10 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 		return fmt.Errorf("planning pins: %w", planErr)
 	}
 
-	// Commit: write all changes to disk atomically.
+	// Commit: write all changes to disk atomically (fast local I/O, no
+	// spinner label — it finishes before the user could read one).
 	endCommit := prof.Phase("pin.Commit (disk writes)")
-	if err := pin.Commit(ctx, record, store, &pin.CommitOptions{OnProgress: progressFn}); err != nil {
+	if err := pin.Commit(ctx, record, store, nil); err != nil {
 		console.StopProgress()
 		return fmt.Errorf("committing pins: %w", err)
 	}

--- a/cmd/gh-actions-pin/root.go
+++ b/cmd/gh-actions-pin/root.go
@@ -41,6 +41,11 @@ func execute() int {
 		// Blocking findings were already reported via well-formed output; exit
 		// 1 quietly so a second error line doesn't clobber the JSON/summary.
 		return 1
+	case errors.Is(err, context.Canceled):
+		// CTRL+C / SIGTERM: exit silently. The signal is intentional, not a
+		// tool failure. Print a newline so the shell prompt starts clean.
+		fmt.Fprintln(os.Stderr)
+		return 2
 	default:
 		// Every other non-nil error — including lockfile.ErrFutureVersion —
 		// is a tool failure and maps to 2. Print it on a fresh UI bound to

--- a/internal/ghapi/client.go
+++ b/internal/ghapi/client.go
@@ -117,7 +117,7 @@ func New(hostname string, opts ...ClientOption) (*Client, error) {
 type retryTransport struct {
 	inner      http.RoundTripper
 	maxRetries int
-	sleepFn    func(time.Duration) // for testing; defaults to time.Sleep
+	sleepFn func(context.Context, time.Duration) // for testing; defaults to DefaultSleep
 }
 
 func newRetryTransport(t http.RoundTripper, maxRetries int) http.RoundTripper {
@@ -151,12 +151,14 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 		resp, err = rt.inner.RoundTrip(req)
 		if err != nil {
-			// Don't retry context cancellation — the caller wants to stop.
 			if req.Context().Err() != nil {
 				return nil, err
 			}
 			if attempt < rt.maxRetries {
-				rt.backoff(attempt)
+				rt.backoff(req.Context(), attempt)
+				if req.Context().Err() != nil {
+					return nil, req.Context().Err()
+				}
 				continue
 			}
 			return nil, err
@@ -165,7 +167,10 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			if attempt < rt.maxRetries {
 				wait := rt.retryWait(resp, attempt)
 				resp.Body.Close()
-				rt.sleep(wait)
+				rt.sleep(req.Context(), wait)
+				if req.Context().Err() != nil {
+					return nil, req.Context().Err()
+				}
 				continue
 			}
 		}
@@ -214,20 +219,20 @@ func (rt *retryTransport) retryWait(resp *http.Response, attempt int) time.Durat
 	return delay
 }
 
-func (rt *retryTransport) sleep(d time.Duration) {
+func (rt *retryTransport) sleep(ctx context.Context, d time.Duration) {
 	if rt.sleepFn != nil {
-		rt.sleepFn(d)
+		rt.sleepFn(ctx, d)
 		return
 	}
-	time.Sleep(d)
+	DefaultSleep(ctx, d)
 }
 
-func (rt *retryTransport) backoff(attempt int) {
+func (rt *retryTransport) backoff(ctx context.Context, attempt int) {
 	delay := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 	if delay > 10*time.Second {
 		delay = 10 * time.Second
 	}
-	rt.sleep(delay)
+	rt.sleep(ctx, delay)
 }
 
 // DefaultSleep waits d but returns early when ctx is canceled. Useful for

--- a/internal/ghapi/client.go
+++ b/internal/ghapi/client.go
@@ -151,6 +151,10 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 		resp, err = rt.inner.RoundTrip(req)
 		if err != nil {
+			// Don't retry context cancellation — the caller wants to stop.
+			if req.Context().Err() != nil {
+				return nil, err
+			}
 			if attempt < rt.maxRetries {
 				rt.backoff(attempt)
 				continue

--- a/internal/ghapi/client_test.go
+++ b/internal/ghapi/client_test.go
@@ -2,6 +2,7 @@ package ghapi
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -157,7 +158,7 @@ func TestRetryTransport_ResendsBodyOnRetry(t *testing.T) {
 		}, nil
 	})
 
-	rt := &retryTransport{inner: inner, maxRetries: 3, sleepFn: func(time.Duration) {}}
+	rt := &retryTransport{inner: inner, maxRetries: 3, sleepFn: func(context.Context, time.Duration) {}}
 	req, _ := http.NewRequest("POST", "https://api.github.com/graphql",
 		io.NopCloser(bytes.NewReader([]byte(wantBody))))
 	req.ContentLength = int64(len(wantBody))

--- a/internal/ghapi/repos.go
+++ b/internal/ghapi/repos.go
@@ -144,7 +144,7 @@ func (c *Client) repoMetadata(ctx context.Context, owner, repo string) (repoMeta
 			} `json:"owner"`
 		}
 		path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
-		if err := c.rest.DoWithContext(context.WithoutCancel(ctx), http.MethodGet, path, nil, &resp); err != nil {
+		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
 			return repoMeta{}, fmt.Errorf("fetching %s: %w", path, err)
 		}
 		m := repoMeta{
@@ -198,7 +198,7 @@ func (c *Client) GetBranchHead(ctx context.Context, owner, repo, name string) (B
 				Type string `json:"type"`
 			} `json:"object"`
 		}
-		if err := c.rest.DoWithContext(context.WithoutCancel(ctx), http.MethodGet, path, nil, &resp); err != nil {
+		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
 			var httpErr *api.HTTPError
 			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
 				c.namedBranchCache.Put(key, BranchHead{}) // negative cache
@@ -329,7 +329,7 @@ func (c *Client) CompareCommits(ctx context.Context, owner, repo, sha, branchHea
 			url.PathEscape(owner), url.PathEscape(repo),
 			url.PathEscape(sha), url.PathEscape(branchHeadSHA))
 		var resp compareResponse
-		if err := c.rest.DoWithContext(context.WithoutCancel(ctx), http.MethodGet, path, nil, &resp); err != nil {
+		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
 			var httpErr *api.HTTPError
 			if errors.As(err, &httpErr) &&
 				(httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusUnprocessableEntity) {

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -85,11 +85,6 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	var entries []Entry
 	var wplans []WorkflowPlan
 
-	progress := opts.OnProgress
-	if progress == nil {
-		progress = func(string) {}
-	}
-
 	if !wr.NeedsAttention() {
 		// Already pinned and valid — record as verified.
 		for _, inv := range wr.Inventory {
@@ -107,7 +102,6 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	}
 
 	// Resolve live state for this workflow's refs.
-	progress(fmt.Sprintf("Resolving %s", wr.Path))
 	deps, parentMap, resolveErr := opts.Resolver.ResolveAllRecursive(ctx, wr.ActionRefs)
 	if resolveErr != nil {
 		// Partial failure: some refs resolved (in deps), others didn't.
@@ -141,7 +135,6 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	}
 
 	// Reachability gate — drop impostors, auto-fix when a sane release exists.
-	progress("Verifying reachability")
 	reachResults := opts.Resolver.CheckReachabilityAll(ctx, deps)
 	badKeys := make(map[string]bool)
 	autoFixed := make(map[string]string)       // new dep key → original ref
@@ -228,7 +221,6 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 
 	// Narrow mutable version tags to patch tags, and resolve bare-SHA refs
 	// to a symbolic tag when one exists.
-	progress("Narrowing tags")
 	rewrites := make(map[string]string)
 	for k, v := range autoFixRewrites {
 		rewrites[k] = v
@@ -283,7 +275,6 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	}
 
 	// ReverseLookup: SHA → containing tag/branch. Rewrites refs to canonical form.
-	progress("Reverse lookup")
 	normRewrites, err := opts.Resolver.ReverseLookup(ctx, deps)
 	if err != nil {
 		var imp *resolve.ImpostorError

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -54,7 +54,7 @@ func Plan(ctx context.Context, report *checks.Report, opts PlanOptions) (*Record
 	var planErr error
 	poolErr := pinpool.RunTyped(opts.Pool, ctx, "Planning pins",
 		items,
-		func(iwr indexedWR) string { return iwr.wr.Path },
+		func(iwr indexedWR) string { return "plan " + iwr.wr.Path },
 		func(ctx context.Context, _ int, iwr indexedWR) error {
 			pr, err := planWorkflow(ctx, iwr.wr, opts)
 			if err != nil {

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -54,9 +54,12 @@ func Plan(ctx context.Context, report *checks.Report, opts PlanOptions) (*Record
 	var planErr error
 	poolErr := pinpool.RunTyped(opts.Pool, ctx, "Planning pins",
 		items,
-		func(iwr indexedWR) string { return "plan " + iwr.wr.Path },
-		func(ctx context.Context, _ int, iwr indexedWR) error {
-			pr, err := planWorkflow(ctx, iwr.wr, opts)
+		func(iwr indexedWR) string { return "planning " + iwr.wr.Path },
+		func(ctx context.Context, slot int, iwr indexedWR) error {
+			status := func(s string) {
+				opts.Pool.Reporter.SetWorkerStatus(slot, "→ "+s)
+			}
+			pr, err := planWorkflow(ctx, iwr.wr, opts, status)
 			if err != nil {
 				return fmt.Errorf("planning %s: %w", iwr.wr.Path, err)
 			}
@@ -81,7 +84,7 @@ type planResult struct {
 	wplans  []WorkflowPlan
 }
 
-func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOptions) (planResult, error) {
+func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOptions, status func(string)) (planResult, error) {
 	var entries []Entry
 	var wplans []WorkflowPlan
 
@@ -102,6 +105,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	}
 
 	// Resolve live state for this workflow's refs.
+	status("resolving " + wr.Path)
 	deps, parentMap, resolveErr := opts.Resolver.ResolveAllRecursive(ctx, wr.ActionRefs)
 	if resolveErr != nil {
 		// Partial failure: some refs resolved (in deps), others didn't.
@@ -135,6 +139,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	}
 
 	// Reachability gate — drop impostors, auto-fix when a sane release exists.
+	status("verifying " + wr.Path)
 	reachResults := opts.Resolver.CheckReachabilityAll(ctx, deps)
 	badKeys := make(map[string]bool)
 	autoFixed := make(map[string]string)       // new dep key → original ref
@@ -221,6 +226,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 
 	// Narrow mutable version tags to patch tags, and resolve bare-SHA refs
 	// to a symbolic tag when one exists.
+	status("pinning " + wr.Path)
 	rewrites := make(map[string]string)
 	for k, v := range autoFixRewrites {
 		rewrites[k] = v

--- a/internal/pin/plan_test.go
+++ b/internal/pin/plan_test.go
@@ -204,7 +204,7 @@ func TestPlanWorkflow_PartialResolutionFailure(t *testing.T) {
 		Pool:     pool,
 	}
 
-	result, err := planWorkflow(context.Background(), wr, opts)
+	result, err := planWorkflow(context.Background(), wr, opts, func(string) {})
 	require.NoError(t, err)
 
 	// Classify entries.
@@ -278,7 +278,7 @@ func TestPlanWorkflow_AllResolutionsFail(t *testing.T) {
 	result, err := planWorkflow(context.Background(), wr, PlanOptions{
 		Resolver: resolver,
 		Pool:     pool,
-	})
+	}, func(string) {})
 	require.NoError(t, err)
 
 	require.Len(t, result.entries, 2)

--- a/internal/pinpool/pool.go
+++ b/internal/pinpool/pool.go
@@ -5,7 +5,6 @@ package pinpool
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"sync"
@@ -122,7 +121,6 @@ func (p *Pool) Run(
 	}
 	r := p.Reporter
 
-	total := int64(len(jobs))
 	var done atomic.Int64
 
 	// rMu serializes Reporter calls from worker goroutines.
@@ -155,16 +153,11 @@ func (p *Pool) Run(
 		rMu.Unlock()
 	}
 	updateLabel := func() {
-		// An empty label hands label ownership to the caller: the pool drives
-		// per-worker status rows and stall hints but writes no "[done/total]"
-		// prefix. Used when an outer per-item progress counter (e.g. resolve's
-		// ref-denominated bar) owns the spinner label and a chunk-denominated
-		// pool counter would fight it.
 		if label == "" {
 			return
 		}
 		rMu.Lock()
-		r.UpdateLabel(fmt.Sprintf("%s [%d/%d]", label, done.Load(), total))
+		r.UpdateLabel(label)
 		rMu.Unlock()
 	}
 	updateLabel()
@@ -210,7 +203,6 @@ func (p *Pool) Run(
 				setStatus(slot, "→ "+lastDisplay)
 				err := run(ctx, slot, j)
 				done.Add(1)
-				updateLabel()
 				if err != nil {
 					errMu.Lock()
 					if firstErr == nil {

--- a/internal/pinpool/pool.go
+++ b/internal/pinpool/pool.go
@@ -164,7 +164,7 @@ func (p *Pool) Run(
 			return
 		}
 		rMu.Lock()
-		r.UpdateLabel(fmt.Sprintf("[%d/%d] %s", done.Load(), total, label))
+		r.UpdateLabel(fmt.Sprintf("%s [%d/%d]", label, done.Load(), total))
 		rMu.Unlock()
 	}
 	updateLabel()

--- a/internal/pinpool/pool_test.go
+++ b/internal/pinpool/pool_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -170,28 +169,12 @@ func TestRunCallsRunForEveryJob(t *testing.T) {
 			t.Fatalf("job %d never ran", j)
 		}
 	}
-	// First label must be the [0/N] initial update.
-	if len(ui.labels) == 0 {
-		t.Fatalf("no labels emitted")
+	// Label is set once at pool start — no per-completion counter.
+	if len(ui.labels) != 1 {
+		t.Fatalf("expected exactly 1 label write, got %d: %v", len(ui.labels), ui.labels)
 	}
-	want := fmt.Sprintf("Pinning [0/%d]", len(jobs))
-	if ui.labels[0] != want {
-		t.Fatalf("first label = %q, want %q", ui.labels[0], want)
-	}
-	// Some label must report the terminal [N/N] state. Ordering across
-	// goroutines is not guaranteed (each worker reads `done` after its
-	// own Add and labels are appended under a separate mutex), so we
-	// can't rely on the last slice entry being the highest count.
-	wantTerminal := fmt.Sprintf("Pinning [%d/%d]", len(jobs), len(jobs))
-	found := false
-	for _, l := range ui.labels {
-		if l == wantTerminal {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("no label matched terminal %q; got %v", wantTerminal, ui.labels)
+	if ui.labels[0] != "Pinning" {
+		t.Fatalf("label = %q, want %q", ui.labels[0], "Pinning")
 	}
 }
 
@@ -437,8 +420,8 @@ func TestRunEmptyLabelSuppressesLabelWrites(t *testing.T) {
 }
 
 // TestRunNonEmptyLabelStillWritesLabel is the contrapositive: a non-empty
-// label must produce "[done/total] label" writes so existing callers keep
-// their pool-driven progress.
+// label must produce a single UpdateLabel write so callers keep their
+// pool-driven label.
 func TestRunNonEmptyLabelStillWritesLabel(t *testing.T) {
 	f := &fakeReporter{}
 	p := New(4, f)
@@ -453,12 +436,7 @@ func TestRunNonEmptyLabelStillWritesLabel(t *testing.T) {
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if len(f.labels) == 0 {
-		t.Fatal("non-empty label must produce UpdateLabel writes")
-	}
-	for _, l := range f.labels {
-		if !strings.Contains(l, "Pinning") {
-			t.Fatalf("label write missing caller label text: %q", l)
-		}
+	if len(f.labels) != 1 || f.labels[0] != "Pinning" {
+		t.Fatalf("expected single label write %q, got %v", "Pinning", f.labels)
 	}
 }

--- a/internal/pinpool/pool_test.go
+++ b/internal/pinpool/pool_test.go
@@ -174,7 +174,7 @@ func TestRunCallsRunForEveryJob(t *testing.T) {
 	if len(ui.labels) == 0 {
 		t.Fatalf("no labels emitted")
 	}
-	want := fmt.Sprintf("[0/%d] Pinning", len(jobs))
+	want := fmt.Sprintf("Pinning [0/%d]", len(jobs))
 	if ui.labels[0] != want {
 		t.Fatalf("first label = %q, want %q", ui.labels[0], want)
 	}
@@ -182,7 +182,7 @@ func TestRunCallsRunForEveryJob(t *testing.T) {
 	// goroutines is not guaranteed (each worker reads `done` after its
 	// own Add and labels are appended under a separate mutex), so we
 	// can't rely on the last slice entry being the highest count.
-	wantTerminal := fmt.Sprintf("[%d/%d] Pinning", len(jobs), len(jobs))
+	wantTerminal := fmt.Sprintf("Pinning [%d/%d]", len(jobs), len(jobs))
 	found := false
 	for _, l := range ui.labels {
 		if l == wantTerminal {

--- a/internal/pipeline/checks/impostor.go
+++ b/internal/pipeline/checks/impostor.go
@@ -75,7 +75,7 @@ func FindRecommendedRelease(ctx context.Context, tl *tag.Lister, r ReachabilityC
 		indexed[i] = indexedCandidate{idx: i, candidate: c}
 	}
 	results := make([]resolve.ReachabilityResult, len(candidates))
-	_ = pinpool.RunTyped(pool, ctx, "Checking recommended releases",
+	_ = pinpool.RunTyped(pool, ctx, "",
 		indexed,
 		func(ic indexedCandidate) string { return owner + "/" + repo + "@" + ic.tag },
 		func(ctx context.Context, _ int, ic indexedCandidate) error {

--- a/internal/pipeline/checks/impostor.go
+++ b/internal/pipeline/checks/impostor.go
@@ -77,7 +77,7 @@ func FindRecommendedRelease(ctx context.Context, tl *tag.Lister, r ReachabilityC
 	results := make([]resolve.ReachabilityResult, len(candidates))
 	_ = pinpool.RunTyped(pool, ctx, "",
 		indexed,
-		func(ic indexedCandidate) string { return owner + "/" + repo + "@" + ic.tag },
+		func(ic indexedCandidate) string { return "check release " + owner + "/" + repo + "@" + ic.tag },
 		func(ctx context.Context, _ int, ic indexedCandidate) error {
 			results[ic.idx] = r.CheckReachability(ctx, owner, repo, ic.sha, ic.tag)
 			return nil

--- a/internal/pipeline/checks/impostor.go
+++ b/internal/pipeline/checks/impostor.go
@@ -77,7 +77,7 @@ func FindRecommendedRelease(ctx context.Context, tl *tag.Lister, r ReachabilityC
 	results := make([]resolve.ReachabilityResult, len(candidates))
 	_ = pinpool.RunTyped(pool, ctx, "",
 		indexed,
-		func(ic indexedCandidate) string { return "check release " + owner + "/" + repo + "@" + ic.tag },
+		func(ic indexedCandidate) string { return "checking release " + owner + "/" + repo + "@" + ic.tag },
 		func(ctx context.Context, _ int, ic indexedCandidate) error {
 			results[ic.idx] = r.CheckReachability(ctx, owner, repo, ic.sha, ic.tag)
 			return nil

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -31,7 +31,7 @@ func DiagnoseParsed(ctx context.Context, parsed []checks.ParsedWorkflow, r *reso
 	results := make([]checks.WorkflowReport, len(parsed))
 	_ = pinpool.RunTyped(pool, ctx, "",
 		items,
-		func(ipw indexedPW) string { return ipw.pw.Path },
+		func(ipw indexedPW) string { return "diagnose " + ipw.pw.Path },
 		func(ctx context.Context, _ int, ipw indexedPW) error {
 			effR := r
 			if ipw.pw.Resolved {

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -29,7 +29,7 @@ func DiagnoseParsed(ctx context.Context, parsed []checks.ParsedWorkflow, r *reso
 	}
 
 	results := make([]checks.WorkflowReport, len(parsed))
-	_ = pinpool.RunTyped(pool, ctx, "Diagnosing workflows",
+	_ = pinpool.RunTyped(pool, ctx, "",
 		items,
 		func(ipw indexedPW) string { return ipw.pw.Path },
 		func(ctx context.Context, _ int, ipw indexedPW) error {

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -31,7 +31,7 @@ func DiagnoseParsed(ctx context.Context, parsed []checks.ParsedWorkflow, r *reso
 	results := make([]checks.WorkflowReport, len(parsed))
 	_ = pinpool.RunTyped(pool, ctx, "",
 		items,
-		func(ipw indexedPW) string { return "diagnose " + ipw.pw.Path },
+		func(ipw indexedPW) string { return "diagnosing " + ipw.pw.Path },
 		func(ctx context.Context, _ int, ipw indexedPW) error {
 			effR := r
 			if ipw.pw.Resolved {

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -18,12 +18,8 @@ import (
 // It is a backward-compatible wrapper around ParseAll, resolver pre-warming,
 // and DiagnoseParsed. Newer callers can drive those phases directly to control
 // UI progress.
-func Diagnose(ctx context.Context, paths []string, r *resolve.Resolver, store *lockfile.State, pool *pinpool.Pool, onWorkflow ...func(done, total int, path string)) *checks.Report {
-	var onScan func(done, total int, path string)
-	if len(onWorkflow) > 0 {
-		onScan = onWorkflow[0]
-	}
-	parsed := ParseAll(paths, store, onScan)
+func Diagnose(ctx context.Context, paths []string, r *resolve.Resolver, store *lockfile.State, pool *pinpool.Pool) *checks.Report {
+	parsed := ParseAll(paths, store)
 	if r != nil {
 		refs, deps := CollectResolvable(parsed)
 		if len(refs) > 0 {
@@ -39,13 +35,10 @@ func Diagnose(ctx context.Context, paths []string, r *resolve.Resolver, store *l
 // ParseAll loads and parses every workflow path, returning a slice in input
 // order. onScan, if non-nil, fires with 1-based progress before each workflow
 // is parsed so the UI can render [i/N] without leaking resolver detail.
-func ParseAll(paths []string, store *lockfile.State, onScan func(done, total int, path string)) []checks.ParsedWorkflow {
+func ParseAll(paths []string, store *lockfile.State) []checks.ParsedWorkflow {
 	total := len(paths)
 	out := make([]checks.ParsedWorkflow, 0, total)
-	for i, path := range paths {
-		if onScan != nil {
-			onScan(i+1, total, path)
-		}
+	for _, path := range paths {
 		pw := checks.ParsedWorkflow{Path: path}
 		wf, err := workflowfile.Load(path)
 		if err != nil {

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -23,11 +23,8 @@ type RunOptions struct {
 
 	// OnScan fires with 1-based progress before each workflow is parsed.
 	OnScan func(done, total int, path string)
-	// OnProgress fires at each pipeline phase boundary.
-	OnProgress func(phase string)
 	// Resolver UX hooks — set these for interactive spinner mode.
 	OnResolveProgress func(done, total int)
-	OnVerifyProgress  func(done, total int)
 	// Profile receives phase timing when profiling is enabled.
 	Profile *profile.Session
 }
@@ -42,10 +39,6 @@ type RunResult struct {
 // Run executes the full diagnostic pipeline: parse → trust-check →
 // resolve → reachability pre-warm → diagnose → enrich impostors.
 func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
-	progress := opts.OnProgress
-	if progress == nil {
-		progress = func(string) {}
-	}
 	r := opts.Resolver
 	prof := opts.Profile
 
@@ -85,17 +78,11 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 		// No resolver means no network resolution or reachability.
 		// Diagnose will still flag structural issues (not-pinned, etc.).
 	} else {
-		// Wire resolver progress hooks.
+		// Wire resolver progress hook.
 		if opts.OnResolveProgress != nil {
 			r.OnResolveProgress = opts.OnResolveProgress
 		}
-		if opts.OnVerifyProgress != nil {
-			r.OnVerifyProgress = opts.OnVerifyProgress
-		}
 
-		if len(refs) > 0 || (opts.Rescan && len(deps) > 0) {
-			progress("Resolving actions")
-		}
 		if len(refs) > 0 {
 			endResolve := prof.Phase("  resolve refs")
 			// First call warms the resolver's cache; results are consumed
@@ -130,7 +117,6 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 		}
 
 		if len(reachDeps) > 0 || len(liveMoved) > 0 || len(liveDirect) > 0 {
-			progress("Verifying reachability")
 			endReach := prof.Phase("  reachability pre-warm")
 			if len(reachDeps) > 0 {
 				_ = r.CheckReachabilityAll(ctx, reachDeps)
@@ -146,7 +132,6 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 
 		// Quiet resolver hooks before diagnostics (cache-only, no progress).
 		r.OnResolveProgress = nil
-		r.OnVerifyProgress = nil
 	}
 
 	if ctx.Err() != nil {
@@ -154,7 +139,6 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	}
 
 	// Phase 4: Diagnose.
-	progress("Analyzing")
 	endDiag := prof.Phase("  diagnose (parallel)")
 	report := DiagnoseParsed(ctx, parsed, r, opts.Store, opts.Pool)
 	endDiag()

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -21,8 +21,6 @@ type RunOptions struct {
 	Pool          *pinpool.Pool
 	Rescan        bool // re-verify all pins end-to-end
 
-	// OnScan fires with 1-based progress before each workflow is parsed.
-	OnScan func(done, total int, path string)
 	// Resolver UX hooks — set these for interactive spinner mode.
 	OnResolveProgress func(done, total int)
 	// Profile receives phase timing when profiling is enabled.
@@ -44,7 +42,7 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 
 	// Phase 1: Parse.
 	endParse := prof.Phase("  parse workflows")
-	parsed := ParseAll(opts.WorkflowPaths, opts.Store, opts.OnScan)
+	parsed := ParseAll(opts.WorkflowPaths, opts.Store)
 	endParse()
 
 	if ctx.Err() != nil {

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -54,6 +54,10 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	parsed := ParseAll(opts.WorkflowPaths, opts.Store, opts.OnScan)
 	endParse()
 
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	// Fast path: trust fully-recorded workflows.
 	skippedRescan := 0
 	if !opts.Rescan {
@@ -101,6 +105,10 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 			endResolve()
 		}
 
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		// Phase 3: Pre-warm reachability across all unresolved workflows.
 		var reachDeps, liveMoved, liveDirect []dep.Dependency
 		if opts.Rescan {
@@ -116,16 +124,21 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 			liveMoved = CollectLiveMovedReachDeps(unresolved, live)
 			liveDirect = CollectLiveDirectReachDeps(unresolved, live)
 		}
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		if len(reachDeps) > 0 || len(liveMoved) > 0 || len(liveDirect) > 0 {
 			progress("Verifying reachability")
 			endReach := prof.Phase("  reachability pre-warm")
 			if len(reachDeps) > 0 {
 				_ = r.CheckReachabilityAll(ctx, reachDeps)
 			}
-			if len(liveMoved) > 0 {
+			if ctx.Err() == nil && len(liveMoved) > 0 {
 				_ = r.CheckReachabilityAll(ctx, liveMoved)
 			}
-			if len(liveDirect) > 0 {
+			if ctx.Err() == nil && len(liveDirect) > 0 {
 				_ = r.CheckReachabilityAll(ctx, liveDirect)
 			}
 			endReach()
@@ -136,12 +149,20 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 		r.OnVerifyProgress = nil
 	}
 
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	// Phase 4: Diagnose.
 	progress("Analyzing")
 	endDiag := prof.Phase("  diagnose (parallel)")
 	report := DiagnoseParsed(ctx, parsed, r, opts.Store, opts.Pool)
 	endDiag()
 	valid := report.IsValid()
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
 	// Phase 5: Enrich impostor findings with recommended release suggestions.
 	if opts.Tagger != nil && hasImpostorFindings(report) {

--- a/internal/resolve/discovery.go
+++ b/internal/resolve/discovery.go
@@ -271,7 +271,7 @@ func (r *Resolver) resolveWithActionYMLParallel(ctx context.Context, refs []pars
 		batches,
 		func(b actionBatch) string {
 			head := refs[b.idxs[0]]
-			label := "resolve " + head.NWO() + "@" + head.Ref
+			label := "resolving " + head.NWO() + "@" + head.Ref
 			if len(b.idxs) > 1 {
 				label = fmt.Sprintf("%s (+%d more)", label, len(b.idxs)-1)
 			}

--- a/internal/resolve/discovery.go
+++ b/internal/resolve/discovery.go
@@ -277,19 +277,11 @@ func (r *Resolver) resolveWithActionYMLParallel(ctx context.Context, refs []pars
 			}
 			return label
 		},
-		func(ctx context.Context, slot int, b actionBatch) error {
+		func(ctx context.Context, _ int, b actionBatch) error {
 			res := r.gh.ResolveActionFiles(ctx, b.reqs)
 			var errs []error
 			for j, idx := range b.idxs {
 				ref := refs[idx]
-				// Update slot with the current ref being processed.
-				remaining := len(b.idxs) - j - 1
-				slotLabel := "resolving " + ref.NWO() + "@" + ref.Ref
-				if remaining > 0 {
-					slotLabel = fmt.Sprintf("%s (+%d more)", slotLabel, remaining)
-				}
-				r.Pool.Reporter.SetWorkerStatus(slot, "→ "+slotLabel)
-
 				if j < len(res) && res[j].Err == nil {
 					d := dep.Dependency{
 						NWO:  res[j].Owner + "/" + res[j].Repo,

--- a/internal/resolve/discovery.go
+++ b/internal/resolve/discovery.go
@@ -89,7 +89,9 @@ func (r *Resolver) ResolveAllRecursive(ctx context.Context, refs []parserlock.Ac
 			}
 		}
 		resolveTotal.Store(int64(firstWave))
-		r.FireResolveProgress(0, firstWave)
+		if firstWave > 0 {
+			r.FireResolveProgress(0, firstWave)
+		}
 	}
 
 	for len(pending) > 0 {

--- a/internal/resolve/discovery.go
+++ b/internal/resolve/discovery.go
@@ -271,7 +271,7 @@ func (r *Resolver) resolveWithActionYMLParallel(ctx context.Context, refs []pars
 		batches,
 		func(b actionBatch) string {
 			head := refs[b.idxs[0]]
-			label := head.NWO() + "@" + head.Ref
+			label := "resolve " + head.NWO() + "@" + head.Ref
 			if len(b.idxs) > 1 {
 				label = fmt.Sprintf("%s (+%d more)", label, len(b.idxs)-1)
 			}

--- a/internal/resolve/discovery.go
+++ b/internal/resolve/discovery.go
@@ -277,11 +277,19 @@ func (r *Resolver) resolveWithActionYMLParallel(ctx context.Context, refs []pars
 			}
 			return label
 		},
-		func(ctx context.Context, _ int, b actionBatch) error {
+		func(ctx context.Context, slot int, b actionBatch) error {
 			res := r.gh.ResolveActionFiles(ctx, b.reqs)
 			var errs []error
 			for j, idx := range b.idxs {
 				ref := refs[idx]
+				// Update slot with the current ref being processed.
+				remaining := len(b.idxs) - j - 1
+				slotLabel := "resolving " + ref.NWO() + "@" + ref.Ref
+				if remaining > 0 {
+					slotLabel = fmt.Sprintf("%s (+%d more)", slotLabel, remaining)
+				}
+				r.Pool.Reporter.SetWorkerStatus(slot, "→ "+slotLabel)
+
 				if j < len(res) && res[j].Err == nil {
 					d := dep.Dependency{
 						NWO:  res[j].Owner + "/" + res[j].Repo,

--- a/internal/resolve/reachability.go
+++ b/internal/resolve/reachability.go
@@ -286,7 +286,7 @@ func (r *Resolver) checkReachabilityAllPooled(ctx context.Context, unique []dep.
 		if len(repos) > 0 {
 			_ = pinpool.RunTyped(r.Pool, ctx, "",
 				repos,
-				func(re repoEntry) string { return "fetch metadata " + re.owner + "/" + re.repo },
+				func(re repoEntry) string { return "fetching metadata " + re.owner + "/" + re.repo },
 				func(ctx context.Context, _ int, re repoEntry) error {
 					// Only pre-warm default branch (cheap, single REST call).
 					// Branch listing is deferred to Phase 2 on reachability
@@ -334,7 +334,7 @@ func (r *Resolver) checkReachabilityAllPooled(ctx context.Context, unique []dep.
 	if len(pooled) > 0 {
 		poolErr = pinpool.RunTyped(r.Pool, ctx, "",
 			pooled,
-			func(id indexedDep) string { return "verify " + id.dep.NWO + "@" + id.dep.Ref },
+			func(id indexedDep) string { return "verifying " + id.dep.NWO + "@" + id.dep.Ref },
 			func(ctx context.Context, _ int, id indexedDep) error {
 				owner, repo := id.dep.OwnerRepo()
 				result := r.CheckReachability(ctx, owner, repo, id.dep.SHA, id.dep.Ref)

--- a/internal/resolve/reachability.go
+++ b/internal/resolve/reachability.go
@@ -286,7 +286,7 @@ func (r *Resolver) checkReachabilityAllPooled(ctx context.Context, unique []dep.
 		if len(repos) > 0 {
 			_ = pinpool.RunTyped(r.Pool, ctx, "",
 				repos,
-				func(re repoEntry) string { return re.owner + "/" + re.repo },
+				func(re repoEntry) string { return "fetch metadata " + re.owner + "/" + re.repo },
 				func(ctx context.Context, _ int, re repoEntry) error {
 					// Only pre-warm default branch (cheap, single REST call).
 					// Branch listing is deferred to Phase 2 on reachability
@@ -334,7 +334,7 @@ func (r *Resolver) checkReachabilityAllPooled(ctx context.Context, unique []dep.
 	if len(pooled) > 0 {
 		poolErr = pinpool.RunTyped(r.Pool, ctx, "",
 			pooled,
-			func(id indexedDep) string { return id.dep.NWO + "@" + id.dep.Ref },
+			func(id indexedDep) string { return "verify " + id.dep.NWO + "@" + id.dep.Ref },
 			func(ctx context.Context, _ int, id indexedDep) error {
 				owner, repo := id.dep.OwnerRepo()
 				result := r.CheckReachability(ctx, owner, repo, id.dep.SHA, id.dep.Ref)

--- a/internal/resolve/reachability.go
+++ b/internal/resolve/reachability.go
@@ -284,7 +284,7 @@ func (r *Resolver) checkReachabilityAllPooled(ctx context.Context, unique []dep.
 			}
 		}
 		if len(repos) > 0 {
-			_ = pinpool.RunTyped(r.Pool, ctx, "Pre-warming metadata",
+			_ = pinpool.RunTyped(r.Pool, ctx, "",
 				repos,
 				func(re repoEntry) string { return re.owner + "/" + re.repo },
 				func(ctx context.Context, _ int, re repoEntry) error {
@@ -332,7 +332,7 @@ func (r *Resolver) checkReachabilityAllPooled(ctx context.Context, unique []dep.
 	// Submit first-claimers to the pool (visible in spinner).
 	var poolErr error
 	if len(pooled) > 0 {
-		poolErr = pinpool.RunTyped(r.Pool, ctx, "Verifying reachability",
+		poolErr = pinpool.RunTyped(r.Pool, ctx, "",
 			pooled,
 			func(id indexedDep) string { return id.dep.NWO + "@" + id.dep.Ref },
 			func(ctx context.Context, _ int, id indexedDep) error {

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -90,9 +90,7 @@ type Resolver struct {
 
 	// OnResolveProgress is called when a resolution batch makes progress.
 	OnResolveProgress func(done, total int)
-	// OnVerifyProgress is called when reachability verification makes progress.
-	OnVerifyProgress func(done, total int)
-	progressMu       sync.Mutex
+	progressMu        sync.Mutex
 
 	// Pool is the shared worker pool for parallel resolution and reachability.
 	Pool *pinpool.Pool
@@ -218,14 +216,4 @@ func (r *Resolver) FireResolveProgress(done, total int) {
 	r.progressMu.Lock()
 	defer r.progressMu.Unlock()
 	r.OnResolveProgress(done, total)
-}
-
-// FireVerifyProgress fires OnVerifyProgress. Safe from multiple goroutines.
-func (r *Resolver) FireVerifyProgress(done, total int) {
-	if r.OnVerifyProgress == nil {
-		return
-	}
-	r.progressMu.Lock()
-	defer r.progressMu.Unlock()
-	r.OnVerifyProgress(done, total)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1061,6 +1061,12 @@ func (u *UI) PauseProgress() {
 	}
 	if u.spinWriter != nil {
 		u.spinWriter.stopAnimator()
+	}
+	// Clear worker lines before stopping the spinner (see StopProgress).
+	if u.isTTY {
+		u.clearSpinnerLines()
+	}
+	if u.spinWriter != nil {
 		u.spinWriter.mu.Lock()
 		u.spinWriter.workers = nil
 		u.spinWriter.hints = nil
@@ -1068,9 +1074,6 @@ func (u *UI) PauseProgress() {
 	}
 	u.spinner.Stop()
 	u.progPaused = true
-	if u.isTTY {
-		u.clearSpinnerLines()
-	}
 }
 
 // ResumeProgress restarts a spinner previously paused by PauseProgress,
@@ -1104,13 +1107,19 @@ func (u *UI) StopProgress() {
 		}
 		if u.spinWriter != nil {
 			u.spinWriter.stopAnimator()
+		}
+		// Erase worker lines BEFORE stopping the spinner — at this point
+		// the cursor is on the spinner line, so the down/up dance to
+		// clear worker rows below is safe. Doing this after Stop() races
+		// with the shell prompt redraw and clobbers it.
+		u.clearSpinnerLines()
+		if u.spinWriter != nil {
 			u.spinWriter.mu.Lock()
 			u.spinWriter.workers = nil
 			u.spinWriter.hints = nil
 			u.spinWriter.mu.Unlock()
 		}
 		u.spinner.Stop()
-		u.clearSpinnerLines()
 		u.spinner = nil
 		u.spinWriter = nil
 		u.progLabel = ""

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -48,9 +48,8 @@ type UI struct {
 	headless bool
 	spinner  *spinner.Spinner
 
-	// headlessLabelStem is the last printed phase label stem (everything
-	// before the first '[' in an UpdateLabel call). Used in headless mode to
-	// deduplicate `Resolving actions [1/42]` … `[42/42]` into one line.
+	// headlessLabelStem deduplicates repeated UpdateLabel calls in headless
+	// mode so the same phase label isn't printed more than once.
 	headlessLabelStem string
 
 	// progLabel and progDetail hold the two halves of the active spinner line
@@ -1205,31 +1204,11 @@ func (u *UI) UpdateLabel(label string) {
 	u.renderProgress()
 }
 
-// labelStem reduces a progress label to a phase identifier used for headless
-// dedup. It strips both a trailing " [N/M]" and a leading "[N/M] " progress
-// counter, then takes the leading "verb" portion (everything before the first
-// digit) so labels like "Scanning 78 workflows", "Scanning [1/78] foo.yml",
-// "Pinning dependencies [1/78]", and "Scanning" all collapse to the same
-// stem. A label without recognizable structure is trimmed and returned as-is.
-// The leading "[N/M] " form is kept as a fallback for any future callers,
-// though the canonical format is now "Verb [N/M]" (counter on the right).
+// labelStem returns the label trimmed of whitespace, used as a phase
+// identifier for headless dedup so repeated UpdateLabel calls with the
+// same text don't spam the log.
 func labelStem(label string) string {
-	label = strings.TrimSpace(label)
-	if strings.HasPrefix(label, "[") {
-		if end := strings.Index(label, "]"); end > 0 {
-			label = strings.TrimSpace(label[end+1:])
-		}
-	}
-	if i := strings.LastIndex(label, " ["); i >= 0 {
-		label = label[:i]
-	}
-	label = strings.TrimSpace(label)
-	for i, r := range label {
-		if r >= '0' && r <= '9' {
-			return strings.TrimSpace(label[:i])
-		}
-	}
-	return label
+	return strings.TrimSpace(label)
 }
 
 // renderProgress recombines the label and detail into a single line that is

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -83,6 +83,13 @@ type UI struct {
 	// in the spinner Suffix — keeping the suffix short so the library's
 	// byte-count wrap detection never triggers on the second line's content.
 	spinWriter *spinnerWriter
+
+	// progGrace delays spinner visibility so fast runs never flicker. When
+	// non-nil, the spinner object exists but hasn't been Start()ed yet;
+	// a background goroutine will start it after the grace period unless
+	// StopProgress cancels first.
+	progGrace     *time.Timer
+	progGraceDone chan struct{} // closed when the grace goroutine exits
 }
 
 // SetLog attaches a narration sink. Once set, narration methods write plain
@@ -977,9 +984,17 @@ func (u *UI) ProgressActive() bool {
 	return u.spinner != nil
 }
 
+// progressGrace is how long StartProgress waits before showing the spinner.
+// Runs that complete within this window never flicker a spinner at all.
+const progressGrace = 150 * time.Millisecond
+
 // StartProgress starts an animated spinner with the given label on stderr.
 // On non-TTY outputs, prints a static label instead. Matches gh CLI's Primer
 // progress indicator: braille dots, 120ms, cyan.
+//
+// The spinner is not rendered immediately: a short grace period suppresses
+// flicker for fast runs. If StopProgress is called before the grace period
+// expires, no spinner is ever shown.
 func (u *UI) StartProgress(label string) {
 	if u.headless {
 		if label != "" {
@@ -1005,8 +1020,15 @@ func (u *UI) StartProgress(label string) {
 	u.progLast = ""
 	u.progPaused = false
 	u.renderProgress()
-	sp.Start()
-	sw.startAnimator()
+
+	// Defer the visible start so fast runs never flicker.
+	done := make(chan struct{})
+	u.progGraceDone = done
+	u.progGrace = time.AfterFunc(progressGrace, func() {
+		defer close(done)
+		sp.Start()
+		sw.startAnimator()
+	})
 }
 
 // PauseProgress temporarily halts the spinner and clears its line so other
@@ -1016,6 +1038,14 @@ func (u *UI) StartProgress(label string) {
 func (u *UI) PauseProgress() {
 	if u.spinner == nil || u.progPaused {
 		return
+	}
+	// Cancel grace timer — if the spinner hasn't appeared yet, keep it hidden.
+	if u.progGrace != nil {
+		if !u.progGrace.Stop() {
+			<-u.progGraceDone
+		}
+		u.progGrace = nil
+		u.progGraceDone = nil
 	}
 	if u.spinWriter != nil {
 		u.spinWriter.stopAnimator()
@@ -1049,6 +1079,17 @@ func (u *UI) ResumeProgress() {
 // StopProgress stops the spinner. Safe to call if no spinner is active.
 func (u *UI) StopProgress() {
 	if u.spinner != nil {
+		// Cancel the grace timer. If the timer already fired (Stop returns
+		// false) the spinner is running — wait for the goroutine to finish
+		// before tearing down so we don't race with Start().
+		if u.progGrace != nil {
+			if !u.progGrace.Stop() {
+				// Timer already fired — spinner is starting or started.
+				<-u.progGraceDone
+			}
+			u.progGrace = nil
+			u.progGraceDone = nil
+		}
 		if u.spinWriter != nil {
 			u.spinWriter.stopAnimator()
 			u.spinWriter.mu.Lock()

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -997,7 +997,7 @@ func (u *UI) ProgressActive() bool {
 
 // progressGrace is how long StartProgress waits before showing the spinner.
 // Runs that complete within this window never flicker a spinner at all.
-const progressGrace = 150 * time.Millisecond
+const progressGrace = 500 * time.Millisecond
 
 // StartProgress starts an animated spinner with the given label on stderr.
 // On non-TTY outputs, prints a static label instead. Matches gh CLI's Primer

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1147,11 +1147,10 @@ func (u *UI) UpdateLabel(label string) {
 // dedup. It strips both a trailing " [N/M]" and a leading "[N/M] " progress
 // counter, then takes the leading "verb" portion (everything before the first
 // digit) so labels like "Scanning 78 workflows", "Scanning [1/78] foo.yml",
-// "[1/78] Pinning dependencies", and "Scanning" all collapse to the same
+// "Pinning dependencies [1/78]", and "Scanning" all collapse to the same
 // stem. A label without recognizable structure is trimmed and returned as-is.
-// Stripping the leading bracket form matters: without it, headlessEmit prints
-// a stray "[" line for parallel-worker labels like "[1/78] Pinning workflows"
-// because the first-digit scan returns the bare "[" prefix.
+// The leading "[N/M] " form is kept as a fallback for any future callers,
+// though the canonical format is now "Verb [N/M]" (counter on the right).
 func labelStem(label string) string {
 	label = strings.TrimSpace(label)
 	if strings.HasPrefix(label, "[") {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -583,12 +583,24 @@ func (sw *spinnerWriter) setWorkerHint(slot int, hint string) {
 // viewport, so the followup ESC[NA could overshoot into already-rendered
 // rows above and clobber them on the next spinner tick.
 func (u *UI) clearSpinnerLines() {
+	var lines int
 	if u.spinWriter != nil {
 		u.spinWriter.mu.Lock()
+		lines = u.spinWriter.nRendered
 		u.spinWriter.nRendered = 0
 		u.spinWriter.mu.Unlock()
 	}
-	fmt.Fprint(u.w, "\r\033[J")
+	// Erase the spinner's own line plus exactly the known worker lines
+	// below it, then move the cursor back up. Using targeted \033[2K
+	// per line instead of \033[J (erase-to-end-of-screen) avoids
+	// clobbering the shell prompt if it starts drawing before we exit.
+	fmt.Fprint(u.w, "\r\033[2K")
+	for i := 0; i < lines; i++ {
+		fmt.Fprint(u.w, "\n\033[2K")
+	}
+	if lines > 0 {
+		fmt.Fprintf(u.w, "\033[%dA\r", lines)
+	}
 	u.progHasDetail = false
 }
 


### PR DESCRIPTION
## Summary

Overhaul the interactive UI to fix CTRL+C responsiveness, eliminate spinner flicker on fast runs, and simplify the progress display.

## CTRL+C fixes

- **Remove `context.WithoutCancel` from HTTP calls** — three REST calls in `repos.go` used `context.WithoutCancel(ctx)`, making them immune to cancellation. CTRL+C blocked 2-3s waiting for GitHub's response. Now they respect the parent context.
- **Make retry sleeps context-aware** — `retryTransport.sleep`/`backoff` now take a `context.Context` and bail immediately on cancellation instead of sleeping through a `time.Sleep`.
- **Check `ctx.Err()` between pipeline phases** — prevents proceeding to the next phase after cancellation.
- **Silent exit on `context.Canceled`** — no `✗ context canceled` error message, no trailing `%` from zsh.

## Spinner / progress UX

- **Defer spinner start until network work begins** — `StartProgress` is called from `OnResolveProgress`, not eagerly. On the fast path (lockfile-trusted), the spinner never appears.
- **Skip progress callback when all refs are cached** — `FireResolveProgress(0, 0)` was triggering the spinner even when there was zero work. Now guarded behind `firstWave > 0`.
- **500ms grace period** — if the spinner would start and stop within 500ms, it never renders. Prevents flicker on near-instant runs with a few uncached refs.
- **Two-phase spinner** — collapsed from many labels into "Resolving actions" and "Planning pins". No more flip-flopping between narrowing/reverse/reachability labels.
- **Drop `[N/M]` counters** — labels are static strings, set once.
- **Gerund verb prefixes on worker slots** — e.g. "→ resolving actions/checkout@v4" instead of bare action names.
- **Clear worker statuses between phases** — no stale slots carry over from resolve → plan.

## Prompt clobbering fix

- **Targeted per-line erasure** — replaced `\r\033[J` (erase-to-end-of-screen) with `\033[2K` per worker line.
- **Clear worker lines before `spinner.Stop()`** — the shell redraws its prompt after Stop(); cursor movements after that clobber the prompt.

## Dead code cleanup

- Removed `OnVerifyProgress` / `FireVerifyProgress` (declared, never called)
- Removed `OnScan` from `RunOptions` (declared, never set)
- Simplified `Diagnose` and `ParseAll` signatures
- Simplified `labelStem` to plain `TrimSpace`

## Testing

- Updated `pool_test.go` for single-label assertion (no counters)
- Updated `plan_test.go` for new `planWorkflow` signature with status callback
- Updated `client_test.go` for context-aware sleep signature