### PR TITLE
Dedup investigation alerts and improve pin summary UX

### DIFF
--- a/cmd/gh-actions-pin/format/terminal.go
+++ b/cmd/gh-actions-pin/format/terminal.go
@@ -143,6 +143,7 @@ func renderFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 			out.Bold("→"), nwo, f.RecommendedTag, sha)
 	}
 	if f.Category == checks.ImpostorCommit {
+		out.Detail("  %s %s", out.Yellow("!"), pipeline.ImpostorCommitContext)
 		out.Detail("  %s %s", out.Bold("→"), pipeline.PublisherEscalationCopy)
 		out.Detail("  see: %s", out.DocLink(pipeline.PublisherTagReleasesDocURL))
 	}

--- a/cmd/gh-actions-pin/format/terminal.go
+++ b/cmd/gh-actions-pin/format/terminal.go
@@ -143,7 +143,7 @@ func renderFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 			out.Bold("→"), nwo, f.RecommendedTag, sha)
 	}
 	if f.Category == checks.ImpostorCommit {
-		out.Detail("  %s", pipeline.PublisherEscalationCopy)
+		out.Detail("  %s %s", out.Bold("→"), pipeline.PublisherEscalationCopy)
 		out.Detail("  see: %s", out.DocLink(pipeline.PublisherTagReleasesDocURL))
 	}
 	if f.DocURL != "" {

--- a/cmd/gh-actions-pin/pin_summary.go
+++ b/cmd/gh-actions-pin/pin_summary.go
@@ -181,6 +181,7 @@ func renderInvestigationAlerts(console *ui.UI, investigated []pin.Entry, r *reso
 				console.TermBold("→"), console.TermYellow(g.NWO+"@"+g.Suggestion))
 		}
 		if g.Issue == string(checks.ImpostorCommit) {
+			console.TermDetail("    %s %s", console.TermYellow("!"), pipeline.ImpostorCommitContext)
 			console.TermDetail("    %s %s", console.TermBold("→"), pipeline.PublisherEscalationCopy)
 			console.TermDetail("    see: %s", console.TermLink(console.TermDim("Using tags for release management"), pipeline.PublisherTagReleasesDocURL))
 		}

--- a/cmd/gh-actions-pin/pin_summary.go
+++ b/cmd/gh-actions-pin/pin_summary.go
@@ -167,9 +167,25 @@ func renderInvestigationAlerts(console *ui.UI, investigated []pin.Entry, r *reso
 	}
 
 	console.TermBlank()
-	console.TermError("%d %s %s maintainer action — pinned commit is not reachable from any branch",
-		len(groups), ui.Pluralize(len(groups), "action", "actions"),
-		ui.Pluralize(len(groups), "requires", "require"))
+
+	// Use a specific header when all entries are impostor-commit;
+	// fall back to a generic header when other issue types are mixed in.
+	allImpostor := true
+	for _, g := range groups {
+		if g.Issue != string(checks.ImpostorCommit) {
+			allImpostor = false
+			break
+		}
+	}
+	if allImpostor {
+		console.TermError("%d %s %s maintainer action — pinned commit is not reachable from any branch",
+			len(groups), ui.Pluralize(len(groups), "action", "actions"),
+			ui.Pluralize(len(groups), "requires", "require"))
+	} else {
+		console.TermError("%d %s %s investigation — do not auto-pin",
+			len(groups), ui.Pluralize(len(groups), "action", "actions"),
+			ui.Pluralize(len(groups), "requires", "require"))
+	}
 	for _, g := range groups {
 		dep := g.NWO + "@" + g.Ref
 		console.TermDetail("  %s", console.TermLink(console.TermYellow(dep), format.DepReleaseURL(dep, r.IsKnownTagObject)))

--- a/cmd/gh-actions-pin/pin_summary.go
+++ b/cmd/gh-actions-pin/pin_summary.go
@@ -103,16 +103,16 @@ func renderPinnedEntries(console *ui.UI, pinned []pin.Entry) {
 			label = fmt.Sprintf("%s (%s)", label, short)
 		}
 		console.TermDetail("  %s", console.TermYellow(label))
-		if g.AutoFixedRef != "" {
-			short := g.AutoFixedRef
-			if len(short) > 12 {
-				short = short[:12]
-			}
-			console.TermDetail("    ↳ pinned commit %s was unreachable; re-pinned to latest release %s",
-				console.TermDim(short), console.TermBold(g.Ref))
-		}
 		for _, wf := range g.workflows {
 			console.TermDetail("    └─ %s", console.TermDim(wf))
+		}
+		if g.AutoFixedRef != "" {
+			prev := g.AutoFixedRef
+			if len(prev) > 7 {
+				prev = prev[:7]
+			}
+			console.TermDetail("    %s re-pinned from unreachable %s to %s",
+				console.TermYellow("!"), console.TermDim(prev), console.TermBold(g.Ref))
 		}
 	}
 }
@@ -139,23 +139,50 @@ func renderFullScanWarnings(console *ui.UI, pinned []pin.Entry) {
 
 // renderInvestigationAlerts prints error-level alerts for entries that
 // require manual investigation (impostor commits, forgery, etc.).
+// Entries sharing the same NWO@Ref are grouped so the action line
+// appears once with all affected workflows listed underneath.
 func renderInvestigationAlerts(console *ui.UI, investigated []pin.Entry, r *resolve.Resolver) {
-	console.TermBlank()
-	console.TermError("%d %s %s investigation — do not auto-fix",
-		len(investigated), ui.Pluralize(len(investigated), "action", "actions"),
-		ui.Pluralize(len(investigated), "requires", "require"))
+	type investigateGroup struct {
+		pin.Entry
+		workflows []string
+	}
+	seen := map[string]int{} // NWO@Ref → index
+	var groups []investigateGroup
+	var groupWFs []map[string]bool
 	for _, e := range investigated {
-		dep := e.NWO + "@" + e.Ref
-		console.TermDetail("  %s", console.TermLink(console.TermYellow(dep), format.DepReleaseURL(dep, r.IsKnownTagObject)))
+		key := e.NWO + "@" + e.Ref
+		idx, ok := seen[key]
+		if !ok {
+			idx = len(groups)
+			seen[key] = idx
+			groups = append(groups, investigateGroup{Entry: e})
+			groupWFs = append(groupWFs, map[string]bool{})
+		}
 		for _, wf := range e.Workflows {
+			if !groupWFs[idx][wf] {
+				groupWFs[idx][wf] = true
+				groups[idx].workflows = append(groups[idx].workflows, wf)
+			}
+		}
+	}
+
+	console.TermBlank()
+	console.TermError("%d %s %s maintainer action — pinned commit is not reachable from any branch",
+		len(groups), ui.Pluralize(len(groups), "action", "actions"),
+		ui.Pluralize(len(groups), "requires", "require"))
+	for _, g := range groups {
+		dep := g.NWO + "@" + g.Ref
+		console.TermDetail("  %s", console.TermLink(console.TermYellow(dep), format.DepReleaseURL(dep, r.IsKnownTagObject)))
+		for _, wf := range g.workflows {
 			console.TermDetail("    └─ %s", console.TermDim(wf))
 		}
-		if e.Suggestion != "" {
+		if g.Suggestion != "" {
 			console.TermDetail("    %s Suggested re-pin: %s",
-				console.TermBold("→"), console.TermYellow(e.NWO+"@"+e.Suggestion))
+				console.TermBold("→"), console.TermYellow(g.NWO+"@"+g.Suggestion))
 		}
-		if e.Issue == string(checks.ImpostorCommit) {
-			console.TermDetail("    %s", pipeline.PublisherEscalationCopy)
+		if g.Issue == string(checks.ImpostorCommit) {
+			console.TermDetail("    %s %s", console.TermBold("→"), pipeline.PublisherEscalationCopy)
+			console.TermDetail("    see: %s", console.TermLink(console.TermDim("Using tags for release management"), pipeline.PublisherTagReleasesDocURL))
 		}
 	}
 }

--- a/cmd/gh-actions-pin/pin_summary_test.go
+++ b/cmd/gh-actions-pin/pin_summary_test.go
@@ -152,6 +152,11 @@ func TestRenderInvestigationAlerts_ImpostorCommitEscalation(t *testing.T) {
 	renderInvestigationAlerts(console, entries, r)
 	out := buf.String()
 
+	// Impostor context line.
+	if !strings.Contains(out, "indistinguishable from impostor") {
+		t.Errorf("expected impostor commit context line, got:\n%s", out)
+	}
+
 	// Actionable copy with → arrow.
 	if !strings.Contains(out, "→") {
 		t.Errorf("expected → action arrow, got:\n%s", out)

--- a/cmd/gh-actions-pin/pin_summary_test.go
+++ b/cmd/gh-actions-pin/pin_summary_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/github/gh-actions-pin/internal/pin"
+	"github.com/github/gh-actions-pin/internal/resolve"
 	"github.com/github/gh-actions-pin/internal/ui"
 )
 
@@ -32,5 +33,168 @@ func TestRenderPinnedEntries_WorkflowSharedAcrossActions(t *testing.T) {
 	}
 	if !strings.Contains(out, "Pinned 2 actions across 2 workflows") {
 		t.Fatalf("expected header counting 2 actions across 2 workflows, got:\n%s", out)
+	}
+}
+
+func TestRenderInvestigationAlerts_DeduplicatesByNWORef(t *testing.T) {
+	entries := []pin.Entry{
+		{
+			NWO:       "JasonEtco/create-an-issue",
+			Ref:       "9e6213aec58987fa7d2f4deb8b256b99e63107a2",
+			Issue:     "impostor-commit",
+			Workflows: []string{".github/workflows/rotation-a.yml"},
+		},
+		{
+			NWO:       "JasonEtco/create-an-issue",
+			Ref:       "9e6213aec58987fa7d2f4deb8b256b99e63107a2",
+			Issue:     "impostor-commit",
+			Workflows: []string{".github/workflows/rotation-b.yml"},
+		},
+	}
+
+	var buf bytes.Buffer
+	console := ui.NewPlain(&buf)
+	r := &resolve.Resolver{}
+	renderInvestigationAlerts(console, entries, r)
+	out := buf.String()
+
+	// Header should count 1 unique action, not 2 raw entries.
+	if !strings.Contains(out, "1 action requires maintainer action") {
+		t.Errorf("expected '1 action requires maintainer action', got:\n%s", out)
+	}
+
+	// The NWO@Ref line should appear exactly once.
+	if got := strings.Count(out, "JasonEtco/create-an-issue@9e6213"); got != 1 {
+		t.Errorf("expected NWO@Ref listed once, got %d\noutput:\n%s", got, out)
+	}
+
+	// Both workflows should be listed.
+	if !strings.Contains(out, "rotation-a.yml") || !strings.Contains(out, "rotation-b.yml") {
+		t.Errorf("expected both workflows listed, got:\n%s", out)
+	}
+}
+
+func TestRenderInvestigationAlerts_DistinctActionsStaySeparate(t *testing.T) {
+	entries := []pin.Entry{
+		{
+			NWO:       "octo/action-a",
+			Ref:       "aaaa",
+			Issue:     "impostor-commit",
+			Workflows: []string{"ci.yml"},
+		},
+		{
+			NWO:       "octo/action-b",
+			Ref:       "bbbb",
+			Issue:     "impostor-commit",
+			Workflows: []string{"ci.yml"},
+		},
+	}
+
+	var buf bytes.Buffer
+	console := ui.NewPlain(&buf)
+	r := &resolve.Resolver{}
+	renderInvestigationAlerts(console, entries, r)
+	out := buf.String()
+
+	if !strings.Contains(out, "2 actions require maintainer action") {
+		t.Errorf("expected '2 actions require maintainer action', got:\n%s", out)
+	}
+	if !strings.Contains(out, "octo/action-a@aaaa") || !strings.Contains(out, "octo/action-b@bbbb") {
+		t.Errorf("expected both distinct actions listed, got:\n%s", out)
+	}
+}
+
+func TestRenderInvestigationAlerts_WorkflowDedup(t *testing.T) {
+	// Same workflow appears in multiple entries for the same action —
+	// should only be listed once after grouping.
+	entries := []pin.Entry{
+		{
+			NWO:       "octo/action",
+			Ref:       "v1",
+			Issue:     "impostor-commit",
+			Workflows: []string{"ci.yml", "deploy.yml"},
+		},
+		{
+			NWO:       "octo/action",
+			Ref:       "v1",
+			Issue:     "impostor-commit",
+			Workflows: []string{"ci.yml"},
+		},
+	}
+
+	var buf bytes.Buffer
+	console := ui.NewPlain(&buf)
+	r := &resolve.Resolver{}
+	renderInvestigationAlerts(console, entries, r)
+	out := buf.String()
+
+	if got := strings.Count(out, "ci.yml"); got != 1 {
+		t.Errorf("expected ci.yml listed once (deduped), got %d\noutput:\n%s", got, out)
+	}
+	if got := strings.Count(out, "deploy.yml"); got != 1 {
+		t.Errorf("expected deploy.yml listed once, got %d\noutput:\n%s", got, out)
+	}
+}
+
+func TestRenderInvestigationAlerts_ImpostorCommitEscalation(t *testing.T) {
+	entries := []pin.Entry{
+		{
+			NWO:       "octo/action",
+			Ref:       "abc123abc123abc123abc123abc123abc123abcd",
+			Issue:     "impostor-commit",
+			Workflows: []string{"ci.yml"},
+		},
+	}
+
+	var buf bytes.Buffer
+	console := ui.NewPlain(&buf)
+	r := &resolve.Resolver{}
+	renderInvestigationAlerts(console, entries, r)
+	out := buf.String()
+
+	// Actionable copy with → arrow.
+	if !strings.Contains(out, "→") {
+		t.Errorf("expected → action arrow, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Ask the action maintainer") {
+		t.Errorf("expected actionable escalation copy, got:\n%s", out)
+	}
+
+	// Doc link present — plain UI renders the display text, not the URL.
+	if !strings.Contains(out, "Using tags for release management") {
+		t.Errorf("expected doc link for tag release management, got:\n%s", out)
+	}
+}
+
+func TestRenderPinnedEntries_AutoFixNoteAfterWorkflows(t *testing.T) {
+	pinned := []pin.Entry{
+		{
+			NWO:          "slackapi/slack-github-action",
+			Ref:          "v3.0.3",
+			SHA:          "45a88b9000000000000000000000000000000000",
+			AutoFixedRef: "6c661ce5880400000000000000000000000000000",
+			Direct:       true,
+			Workflows:    []string{"retry.yml", "deploy.yml"},
+		},
+	}
+
+	var buf bytes.Buffer
+	console := ui.NewPlain(&buf)
+	renderPinnedEntries(console, pinned)
+	out := buf.String()
+
+	// The auto-fix note should appear after the workflow list.
+	wfPos := strings.LastIndex(out, "deploy.yml")
+	notePos := strings.Index(out, "re-pinned from unreachable")
+	if wfPos == -1 || notePos == -1 {
+		t.Fatalf("expected both workflow and auto-fix note in output:\n%s", out)
+	}
+	if notePos < wfPos {
+		t.Errorf("auto-fix note should appear after workflow list, not before\noutput:\n%s", out)
+	}
+
+	// Yellow ! icon on the auto-fix line.
+	if !strings.Contains(out, "! re-pinned") {
+		t.Errorf("expected '!' icon on auto-fix line, got:\n%s", out)
 	}
 }

--- a/cmd/gh-actions-pin/pin_summary_test.go
+++ b/cmd/gh-actions-pin/pin_summary_test.go
@@ -152,6 +152,11 @@ func TestRenderInvestigationAlerts_ImpostorCommitEscalation(t *testing.T) {
 	renderInvestigationAlerts(console, entries, r)
 	out := buf.String()
 
+	// All-impostor header.
+	if !strings.Contains(out, "requires maintainer action") {
+		t.Errorf("expected maintainer action header for all-impostor entries, got:\n%s", out)
+	}
+
 	// Impostor context line.
 	if !strings.Contains(out, "indistinguishable from impostor") {
 		t.Errorf("expected impostor commit context line, got:\n%s", out)
@@ -168,6 +173,37 @@ func TestRenderInvestigationAlerts_ImpostorCommitEscalation(t *testing.T) {
 	// Doc link present — plain UI renders the display text, not the URL.
 	if !strings.Contains(out, "Using tags for release management") {
 		t.Errorf("expected doc link for tag release management, got:\n%s", out)
+	}
+}
+
+func TestRenderInvestigationAlerts_MixedIssuesFallbackHeader(t *testing.T) {
+	entries := []pin.Entry{
+		{
+			NWO:       "octo/action",
+			Ref:       "abc123abc123abc123abc123abc123abc123abcd",
+			Issue:     "impostor-commit",
+			Workflows: []string{"ci.yml"},
+		},
+		{
+			NWO:       "other/dep",
+			Ref:       "v2",
+			Issue:     "ref-moved",
+			Workflows: []string{"deploy.yml"},
+		},
+	}
+
+	var buf bytes.Buffer
+	console := ui.NewPlain(&buf)
+	r := &resolve.Resolver{}
+	renderInvestigationAlerts(console, entries, r)
+	out := buf.String()
+
+	// Mixed issues should use the generic header, not the impostor-specific one.
+	if strings.Contains(out, "requires maintainer action") {
+		t.Errorf("expected generic header for mixed issues, got:\n%s", out)
+	}
+	if !strings.Contains(out, "investigation") {
+		t.Errorf("expected investigation header for mixed issues, got:\n%s", out)
 	}
 }
 

--- a/internal/pipeline/doc_urls.go
+++ b/internal/pipeline/doc_urls.go
@@ -28,6 +28,10 @@ const PublisherTagReleasesDocURL = "https://docs.github.com/en/actions/how-tos/c
 // a branch.
 const PublisherEscalationCopy = "Ask the action maintainer to tag releases from a branch"
 
+// ImpostorCommitContext explains why off-branch commits are dangerous.
+// Shown just before the escalation copy so users understand the risk.
+const ImpostorCommitContext = "Off-branch commits are indistinguishable from impostor commits"
+
 // docURLs maps every Category that can appear on a checks.Finding to its
 // documentation URL. Categories representing "no issue" (Valid, RunOnly)
 // have no URL — they aren't rendered as findings.

--- a/internal/pipeline/doc_urls.go
+++ b/internal/pipeline/doc_urls.go
@@ -23,10 +23,10 @@ const securityHardeningBase = "https://docs.github.com/en/actions/security-for-g
 const PublisherTagReleasesDocURL = "https://docs.github.com/en/actions/how-tos/create-and-publish-actions/manage-custom-actions#using-tags-for-release-management"
 
 // PublisherEscalationCopy is the standardized one-liner shown in any block
-// where a SHA fell off-branch on the publisher side. Phrased as a direct
-// instruction to maintainers so users have a copy-paste sentence to drop
-// into an issue or release-process discussion when escalating.
-const PublisherEscalationCopy = "Actions publishers should ensure released actions are reachable from a branch. Otherwise, they are indistinguishable from impostor commits"
+// where a SHA fell off-branch on the publisher side. Phrased as direct
+// guidance so users know what to do next: ask the maintainer to tag from
+// a branch.
+const PublisherEscalationCopy = "Ask the action maintainer to tag releases from a branch"
 
 // docURLs maps every Category that can appear on a checks.Finding to its
 // documentation URL. Categories representing "no issue" (Valid, RunOnly)


### PR DESCRIPTION
The pin summary output had two UX problems: duplicate entries for the same action across workflows, and messaging that described tool behavior ("do not auto-fix") instead of the actual problem.

## Changes

**Dedup investigation alerts by NWO@Ref.** When the same action appears in multiple workflow files, it was printed as separate entries with repeated context. Now groups by action (matching `renderPinnedEntries` and `renderUnresolvedWarnings`), listing all affected workflows under one heading.

**Reorder auto-fix note after workflow tree.** The "re-pinned from unreachable..." line was interrupting the tree structure between the action header and workflow list. Moved it after the workflow list per primer CLI guidelines (context headers up top, tree uninterrupted, supplementary info after).

**Actionable impostor-commit escalation copy.** Changed from passive "Actions publishers should ensure released actions are reachable from a branch" to direct "Ask the action maintainer to tag releases from a branch" with a `->` action arrow and doc link to the GitHub tag release management guide.

**Better header framing.** "do not auto-fix" implied a tooling limitation. Changed to "requires maintainer action -- pinned commit is not reachable from any branch" which describes the actual problem and what to do about it.

**Icon consistency.** Yellow `!` for auto-fix notes (something was off, we handled it). Bold `->` for actionable next steps (ask the maintainer). Consistent with cli/cli primer conventions.

**Added doc URL to pin flow.** The `check` flow included the tag-release-management doc link but the `pin` flow was missing it.

## Before/After

Before:
```
X 2 actions require investigation -- do not auto-fix
  JasonEtco/create-an-issue@9e6213ae...
    L .github/workflows/rotation-a.yml
    Actions publishers should ensure released actions...
  JasonEtco/create-an-issue@9e6213ae...
    L .github/workflows/rotation-b.yml
    Actions publishers should ensure released actions...
```

After:
```
X 1 action requires maintainer action -- pinned commit is not reachable from any branch
  JasonEtco/create-an-issue@9e6213ae...
    L .github/workflows/rotation-a.yml
    L .github/workflows/rotation-b.yml
    -> Ask the action maintainer to tag releases from a branch
    see: Using tags for release management
```

## Tests

Five new test cases in `pin_summary_test.go`:
- Dedup by NWO@Ref (same action, multiple workflows)
- Distinct actions stay separate
- Workflow dedup within same action
- Impostor commit escalation copy and doc link
- Auto-fix note ordering (after workflow tree, not before)