### PR TITLE
perf: per-dep lockfile trust skips network for recorded deps

### DIFF
--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/github/gh-actions-pin/internal/profile"
 )
 
 // ActionFileRequest identifies a GitHub Action ref to resolve via GraphQL.
@@ -97,7 +98,7 @@ func (c *Client) resolveActionFilesOnce(ctx context.Context, refs []ActionFileRe
 	query, vars, aliasMap := buildActionFileQuery(refs)
 
 	var data map[string]json.RawMessage
-	err := c.graphql.DoWithContext(ctx, query, vars, &data)
+	err := c.graphql.DoWithContext(profile.WithGraphQLLabel(ctx, "resolve"), query, vars, &data)
 	var gqlErr *api.GraphQLError
 	if err != nil {
 		if !errors.As(err, &gqlErr) {

--- a/internal/ghapi/graphql_peel.go
+++ b/internal/ghapi/graphql_peel.go
@@ -1,6 +1,10 @@
 package ghapi
 
-import "context"
+import (
+	"context"
+
+	"github.com/github/gh-actions-pin/internal/profile"
+)
 
 // tagObjectPeelQuery resolves both the type of the object at $oid and the
 // commit it peels to in a single round trip. The `^{commit}` suffix follows
@@ -45,7 +49,7 @@ func (c *Client) PeelTagObject(ctx context.Context, owner, repo, sha string) (Pe
 		"oid":   sha,
 		"expr":  sha + "^{commit}",
 	}
-	if err := c.graphql.DoWithContext(ctx, tagObjectPeelQuery, vars, &resp); err != nil {
+	if err := c.graphql.DoWithContext(profile.WithGraphQLLabel(ctx, "peel"), tagObjectPeelQuery, vars, &resp); err != nil {
 		return PeelTagObjectResult{}, err
 	}
 	if resp.Repository == nil || resp.Repository.Head == nil {

--- a/internal/ghapi/graphql_reachability.go
+++ b/internal/ghapi/graphql_reachability.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/github/gh-actions-pin/internal/profile"
 )
 
 // batchReachabilitySize is the maximum number of branches per GraphQL query.
@@ -52,7 +53,7 @@ func (c *Client) batchBranchContainsChunk(ctx context.Context, owner, repo, sha 
 	query, vars := buildBranchCompareQuery(owner, repo, sha, branches)
 
 	var data map[string]json.RawMessage
-	gqlErr := c.graphql.DoWithContext(ctx, query, vars, &data)
+	gqlErr := c.graphql.DoWithContext(profile.WithGraphQLLabel(ctx, "reachability"), query, vars, &data)
 	if gqlErr != nil {
 		var httpErr *api.HTTPError
 		if errors.As(gqlErr, &httpErr) {

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -345,7 +345,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	// Build entries for all pinned deps (skip any already emitted from inventory).
 	directKeys := directTracker.Keys(deps)
 	for _, dep := range deps {
-		nwoSHA := strings.ToLower(dep.NWO) + ":" + dep.SHA
+		nwoSHA := strings.ToLower(dep.NWO) + ":" + strings.ToLower(dep.SHA)
 		if inventorySHA[nwoSHA] {
 			continue // already emitted as Verified from inventory
 		}
@@ -448,11 +448,11 @@ func partitionByInventory(inventory []checks.InventoryEntry, refs []parserlock.A
 	shaSeen = make(map[string]bool, len(inventory))
 	for _, inv := range inventory {
 		nwo := strings.ToLower(inv.Dep.NWO)
-		byKey[nwo+"@"+strings.ToLower(inv.Dep.Ref)] = true
-		shaSeen[nwo+":"+inv.Dep.SHA] = true
+		byKey[nwo+"@"+inv.Dep.Ref] = true
+		shaSeen[nwo+":"+strings.ToLower(inv.Dep.SHA)] = true
 	}
 	for _, ref := range refs {
-		key := strings.ToLower(ref.Owner+"/"+ref.Repo) + "@" + strings.ToLower(ref.Ref)
+		key := strings.ToLower(ref.Owner+"/"+ref.Repo) + "@" + ref.Ref
 		if !byKey[key] {
 			unrecorded = append(unrecorded, ref)
 		}

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -89,24 +89,21 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	var wplans []WorkflowPlan
 
 	if !wr.NeedsAttention() {
-		// Already pinned and valid — record as verified.
-		for _, inv := range wr.Inventory {
-			entries = append(entries, Entry{
-				NWO:        inv.Dep.NWO,
-				Ref:        inv.Dep.Ref,
-				SHA:        inv.Dep.SHA,
-				Resolution: Verified,
-				Workflows:  []string{wr.Path},
-				Direct:     inv.Direct,
-				RequiredBy: inv.Parents,
-			})
-		}
+		entries = verifiedEntries(wr.Inventory, wr.Path)
 		return planResult{entries: entries, wplans: wplans}, nil
 	}
 
-	// Resolve live state for this workflow's refs.
+	// Per-dep trust: recorded deps skip the network path.
+	unrecordedRefs, inventorySHA := partitionByInventory(wr.Inventory, wr.ActionRefs)
+	entries = verifiedEntries(wr.Inventory, wr.Path)
+
+	if len(unrecordedRefs) == 0 {
+		return planResult{entries: entries, wplans: wplans}, nil
+	}
+
+	// Resolve live state for unrecorded refs only.
 	status("resolving " + wr.Path)
-	deps, parentMap, resolveErr := opts.Resolver.ResolveAllRecursive(ctx, wr.ActionRefs)
+	deps, parentMap, resolveErr := opts.Resolver.ResolveAllRecursive(ctx, unrecordedRefs)
 	if resolveErr != nil {
 		// Partial failure: some refs resolved (in deps), others didn't.
 		// Build a set of resolved NWO@Ref keys so we can continue with
@@ -115,13 +112,20 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 		for _, d := range deps {
 			resolved[strings.ToLower(d.NWO+"@"+d.Ref)] = true
 		}
+		// Only mark findings as unresolved if they were actually attempted
+		// (i.e., part of unrecordedRefs). Recorded refs were never sent to
+		// ResolveAllRecursive and should not be marked as failures.
+		attempted := make(map[string]bool, len(unrecordedRefs))
+		for _, ref := range unrecordedRefs {
+			attempted[strings.ToLower(ref.Owner+"/"+ref.Repo+"@"+ref.Ref)] = true
+		}
 		for _, f := range wr.Findings {
 			if f.ActionRef == nil {
 				continue
 			}
 			key := strings.ToLower(f.ActionRef.Owner + "/" + f.ActionRef.Repo + "@" + f.ActionRef.Ref)
-			if resolved[key] {
-				continue // this ref resolved fine; process it below
+			if !attempted[key] || resolved[key] {
+				continue
 			}
 			entries = append(entries, Entry{
 				NWO:        f.ActionRef.Owner + "/" + f.ActionRef.Repo,
@@ -222,7 +226,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	// dep.Ref — the tracker records index-aligned booleans at construction,
 	// then Keys() reads post-mutation refs. Must be built while deps and
 	// ActionRefs still share the same ref strings.
-	directTracker := lockfile.NewDirectTracker(wr.ActionRefs, deps)
+	directTracker := lockfile.NewDirectTracker(unrecordedRefs, deps)
 
 	// Narrow mutable version tags to patch tags, and resolve bare-SHA refs
 	// to a symbolic tag when one exists.
@@ -338,9 +342,13 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 		}
 	}
 
-	// Build entries for all pinned deps.
+	// Build entries for all pinned deps (skip any already emitted from inventory).
 	directKeys := directTracker.Keys(deps)
 	for _, dep := range deps {
+		nwoSHA := strings.ToLower(dep.NWO) + ":" + dep.SHA
+		if inventorySHA[nwoSHA] {
+			continue // already emitted as Verified from inventory
+		}
 		depKey := dep.Key()
 		parents := parentMap[depKey]
 		res := Pinned
@@ -430,4 +438,41 @@ func dropDeps(deps []dep.Dependency, pm dep.ParentMap, bad map[string]bool) ([]d
 		}
 	}
 	return kept, newPM
+}
+
+// partitionByInventory splits refs into those with a matching inventory
+// entry (recorded) and those without (unrecorded). Returns the unrecorded
+// refs and an NWO:SHA index for deduplicating resolved deps later.
+func partitionByInventory(inventory []checks.InventoryEntry, refs []parserlock.ActionRef) (unrecorded []parserlock.ActionRef, shaSeen map[string]bool) {
+	byKey := make(map[string]bool, len(inventory))
+	shaSeen = make(map[string]bool, len(inventory))
+	for _, inv := range inventory {
+		nwo := strings.ToLower(inv.Dep.NWO)
+		byKey[nwo+"@"+strings.ToLower(inv.Dep.Ref)] = true
+		shaSeen[nwo+":"+inv.Dep.SHA] = true
+	}
+	for _, ref := range refs {
+		key := strings.ToLower(ref.Owner+"/"+ref.Repo) + "@" + strings.ToLower(ref.Ref)
+		if !byKey[key] {
+			unrecorded = append(unrecorded, ref)
+		}
+	}
+	return unrecorded, shaSeen
+}
+
+// verifiedEntries builds Verified plan entries for every inventory item.
+func verifiedEntries(inventory []checks.InventoryEntry, path string) []Entry {
+	out := make([]Entry, len(inventory))
+	for i, inv := range inventory {
+		out[i] = Entry{
+			NWO:        inv.Dep.NWO,
+			Ref:        inv.Dep.Ref,
+			SHA:        inv.Dep.SHA,
+			Resolution: Verified,
+			Workflows:  []string{path},
+			Direct:     inv.Direct,
+			RequiredBy: inv.Parents,
+		}
+	}
+	return out
 }

--- a/internal/pipeline/checks/parsed.go
+++ b/internal/pipeline/checks/parsed.go
@@ -1,6 +1,8 @@
 package checks
 
 import (
+	"strings"
+
 	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
 	"github.com/github/gh-actions-pin/internal/dep"
 )
@@ -48,10 +50,10 @@ func (pw ParsedWorkflow) PartitionRefs() (recorded, unrecorded []parserlock.Acti
 	}
 	haveDep := make(map[string]bool, len(pw.ExistingDeps))
 	for _, d := range pw.ExistingDeps {
-		haveDep[d.NWO+"@"+d.Ref] = true
+		haveDep[strings.ToLower(d.NWO)+"@"+d.Ref] = true
 	}
 	for _, r := range pw.Refs {
-		if haveDep[r.Owner+"/"+r.Repo+"@"+r.Ref] {
+		if haveDep[strings.ToLower(r.Owner+"/"+r.Repo)+"@"+r.Ref] {
 			recorded = append(recorded, r)
 		} else {
 			unrecorded = append(unrecorded, r)
@@ -72,7 +74,7 @@ func (pw ParsedWorkflow) IsFullyRecorded() bool {
 func (pw ParsedWorkflow) RecordedDeps(recorded []parserlock.ActionRef) []dep.Dependency {
 	refKeys := make(map[string]bool, len(recorded))
 	for _, r := range recorded {
-		refKeys[r.Owner+"/"+r.Repo+"@"+r.Ref] = true
+		refKeys[strings.ToLower(r.Owner+"/"+r.Repo)+"@"+r.Ref] = true
 	}
 	var out []dep.Dependency
 	for _, d := range pw.ExistingDeps {

--- a/internal/pipeline/checks/parsed.go
+++ b/internal/pipeline/checks/parsed.go
@@ -35,3 +35,50 @@ type ParsedWorkflow struct {
 	// is in effect.
 	SkipReachWhenUnchanged bool
 }
+
+// PartitionRefs splits refs into recorded (matching a lockfile entry by
+// NWO@Ref) and unrecorded (need network resolution). When an error
+// prevented loading refs or deps, everything is unrecorded.
+func (pw ParsedWorkflow) PartitionRefs() (recorded, unrecorded []parserlock.ActionRef) {
+	if pw.LoadErr != nil || pw.DepsErr != nil {
+		return nil, pw.Refs
+	}
+	if len(pw.Refs) == 0 {
+		return nil, nil
+	}
+	haveDep := make(map[string]bool, len(pw.ExistingDeps))
+	for _, d := range pw.ExistingDeps {
+		haveDep[d.NWO+"@"+d.Ref] = true
+	}
+	for _, r := range pw.Refs {
+		if haveDep[r.Owner+"/"+r.Repo+"@"+r.Ref] {
+			recorded = append(recorded, r)
+		} else {
+			unrecorded = append(unrecorded, r)
+		}
+	}
+	return recorded, unrecorded
+}
+
+// IsFullyRecorded returns true when every direct ref has a matching
+// lockfile entry — the steady-state happy path.
+func (pw ParsedWorkflow) IsFullyRecorded() bool {
+	_, unrecorded := pw.PartitionRefs()
+	return len(pw.Refs) == 0 || len(unrecorded) == 0
+}
+
+// RecordedDeps returns the subset of ExistingDeps whose NWO@Ref matches
+// one of the given recorded refs.
+func (pw ParsedWorkflow) RecordedDeps(recorded []parserlock.ActionRef) []dep.Dependency {
+	refKeys := make(map[string]bool, len(recorded))
+	for _, r := range recorded {
+		refKeys[r.Owner+"/"+r.Repo+"@"+r.Ref] = true
+	}
+	var out []dep.Dependency
+	for _, d := range pw.ExistingDeps {
+		if refKeys[d.Key()] {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 
 	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
 	"github.com/github/gh-actions-pin/internal/dep"
@@ -82,7 +83,7 @@ func collectResolvable(parsed []checks.ParsedWorkflow, excludeKeys map[string]bo
 	var refs []parserlock.ActionRef
 	for _, pw := range parsed {
 		for _, ref := range pw.Refs {
-			nwoRef := ref.Owner + "/" + ref.Repo + "@" + ref.Ref
+			nwoRef := strings.ToLower(ref.Owner+"/"+ref.Repo) + "@" + ref.Ref
 			if excludeKeys[nwoRef] {
 				continue
 			}

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -65,10 +65,27 @@ func ParseAll(paths []string, store *lockfile.State) []checks.ParsedWorkflow {
 // across all parsed workflows. Use the returned slices to pre-warm the
 // resolver caches once before per-workflow diagnostics.
 func CollectResolvable(parsed []checks.ParsedWorkflow) ([]parserlock.ActionRef, []dep.Dependency) {
+	return collectResolvable(parsed, nil)
+}
+
+// CollectUnrecordedResolvable is like CollectResolvable but excludes refs
+// whose NWO@Ref key appears in recordedKeys. Deps whose key is in
+// recordedKeys are also excluded. Use this when per-dep lockfile trust
+// has already seeded the resolver cache for recorded deps, so only
+// genuinely new refs need network resolution.
+func CollectUnrecordedResolvable(parsed []checks.ParsedWorkflow, recordedKeys map[string]bool) ([]parserlock.ActionRef, []dep.Dependency) {
+	return collectResolvable(parsed, recordedKeys)
+}
+
+func collectResolvable(parsed []checks.ParsedWorkflow, excludeKeys map[string]bool) ([]parserlock.ActionRef, []dep.Dependency) {
 	seenRef := make(map[ghapi.ActionRef]bool)
 	var refs []parserlock.ActionRef
 	for _, pw := range parsed {
 		for _, ref := range pw.Refs {
+			nwoRef := ref.Owner + "/" + ref.Repo + "@" + ref.Ref
+			if excludeKeys[nwoRef] {
+				continue
+			}
 			key := ghapi.ForActionRef(ref.Owner, ref.Repo, ref.Path, ref.Ref)
 			if seenRef[key] {
 				continue
@@ -82,7 +99,7 @@ func CollectResolvable(parsed []checks.ParsedWorkflow) ([]parserlock.ActionRef, 
 	for _, pw := range parsed {
 		for _, dep := range pw.ExistingDeps {
 			key := dep.Key()
-			if seenDep[key] {
+			if excludeKeys[key] || seenDep[key] {
 				continue
 			}
 			seenDep[key] = true

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"context"
 
-	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
 	"github.com/github/gh-actions-pin/internal/dep"
 	"github.com/github/gh-actions-pin/internal/lockfile"
 	"github.com/github/gh-actions-pin/internal/pinpool"
@@ -58,7 +57,7 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	recordedKeys := make(map[string]bool)
 	if !opts.Rescan {
 		for i := range parsed {
-			recorded, unrecorded := partitionRefs(parsed[i])
+			recorded, unrecorded := parsed[i].PartitionRefs()
 			if len(parsed[i].Refs) == 0 || len(unrecorded) == 0 {
 				parsed[i].Resolved = true
 				skippedRescan++
@@ -68,7 +67,7 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 				// seeding. These refs have matching lockfile entries,
 				// so their resolve + reachability results can be
 				// served from the lockfile rather than the network.
-				rd := recordedDeps(parsed[i], recorded)
+				rd := parsed[i].RecordedDeps(recorded)
 				seedDeps = append(seedDeps, rd...)
 				for _, r := range recorded {
 					recordedKeys[r.Owner+"/"+r.Repo+"@"+r.Ref] = true
@@ -85,7 +84,7 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	// Trust boundary: seeded entries have no actionYML, so the BFS in
 	// ResolveAllRecursive won't discover new transitive deps through
 	// them. This is intentional — the same trust model as
-	// isFullyRecorded, which skips resolution entirely. If the
+	// IsFullyRecorded, which skips resolution entirely. If the
 	// lockfile's transitive closure is incomplete, --rescan detects it.
 	if r != nil && len(seedDeps) > 0 {
 		r.SeedFromLockfile(dep.Dedup(seedDeps))
@@ -191,55 +190,6 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 		Valid:         valid,
 		SkippedRescan: skippedRescan,
 	}, nil
-}
-
-// partitionRefs splits a workflow's refs into recorded (have a matching
-// lockfile entry) and unrecorded (need network resolution). The split
-// uses NWO@Ref identity — the same granularity the lockfile pins at.
-// When an error prevented loading refs or deps, everything is unrecorded.
-func partitionRefs(pw checks.ParsedWorkflow) (recorded, unrecorded []parserlock.ActionRef) {
-	if pw.LoadErr != nil || pw.DepsErr != nil {
-		return nil, pw.Refs
-	}
-	if len(pw.Refs) == 0 {
-		return nil, nil
-	}
-	haveDep := make(map[string]bool, len(pw.ExistingDeps))
-	for _, d := range pw.ExistingDeps {
-		haveDep[d.NWO+"@"+d.Ref] = true
-	}
-	for _, r := range pw.Refs {
-		if haveDep[r.Owner+"/"+r.Repo+"@"+r.Ref] {
-			recorded = append(recorded, r)
-		} else {
-			unrecorded = append(unrecorded, r)
-		}
-	}
-	return recorded, unrecorded
-}
-
-// isFullyRecorded returns true when every direct ref in the workflow has a
-// matching lockfile entry — the steady-state happy path.
-func isFullyRecorded(pw checks.ParsedWorkflow) bool {
-	_, unrecorded := partitionRefs(pw)
-	return len(pw.Refs) == 0 || len(unrecorded) == 0
-}
-
-// recordedDeps returns the subset of pw.ExistingDeps whose NWO@Ref matches
-// one of the recorded refs. These are the lockfile entries that correspond
-// to refs the workflow already has pinned.
-func recordedDeps(pw checks.ParsedWorkflow, recorded []parserlock.ActionRef) []dep.Dependency {
-	refKeys := make(map[string]bool, len(recorded))
-	for _, r := range recorded {
-		refKeys[r.Owner+"/"+r.Repo+"@"+r.Ref] = true
-	}
-	var out []dep.Dependency
-	for _, d := range pw.ExistingDeps {
-		if refKeys[d.Key()] {
-			out = append(out, d)
-		}
-	}
-	return out
 }
 
 func hasImpostorFindings(r *checks.Report) bool {

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 
+	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
 	"github.com/github/gh-actions-pin/internal/dep"
 	"github.com/github/gh-actions-pin/internal/lockfile"
 	"github.com/github/gh-actions-pin/internal/pinpool"
@@ -49,17 +50,45 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 		return nil, ctx.Err()
 	}
 
-	// Fast path: trust fully-recorded workflows.
+	// Fast path: trust fully-recorded workflows. For partially-recorded
+	// workflows, seed the resolver cache with recorded deps so only
+	// unrecorded refs hit the network.
 	skippedRescan := 0
+	var seedDeps []dep.Dependency
+	recordedKeys := make(map[string]bool)
 	if !opts.Rescan {
 		for i := range parsed {
-			if isFullyRecorded(parsed[i]) {
+			recorded, unrecorded := partitionRefs(parsed[i])
+			if len(parsed[i].Refs) == 0 || len(unrecorded) == 0 {
 				parsed[i].Resolved = true
 				skippedRescan++
 			} else {
 				parsed[i].SkipReachWhenUnchanged = true
+				// Collect deps covered by recorded refs for cache
+				// seeding. These refs have matching lockfile entries,
+				// so their resolve + reachability results can be
+				// served from the lockfile rather than the network.
+				rd := recordedDeps(parsed[i], recorded)
+				seedDeps = append(seedDeps, rd...)
+				for _, r := range recorded {
+					recordedKeys[r.Owner+"/"+r.Repo+"@"+r.Ref] = true
+				}
 			}
 		}
+	}
+
+	// Seed the resolver cache with lockfile entries for recorded deps
+	// in partially-recorded workflows. This makes the pipeline
+	// self-sufficient: diagnoseOneParsed re-resolves ALL refs per
+	// workflow, and seeded entries become free cache hits.
+	//
+	// Trust boundary: seeded entries have no actionYML, so the BFS in
+	// ResolveAllRecursive won't discover new transitive deps through
+	// them. This is intentional — the same trust model as
+	// isFullyRecorded, which skips resolution entirely. If the
+	// lockfile's transitive closure is incomplete, --rescan detects it.
+	if r != nil && len(seedDeps) > 0 {
+		r.SeedFromLockfile(dep.Dedup(seedDeps))
 	}
 
 	// Collect unresolved workflows for network work.
@@ -69,7 +98,7 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 			unresolved = append(unresolved, pw)
 		}
 	}
-	refs, deps := CollectResolvable(unresolved)
+	refs, deps := CollectUnrecordedResolvable(unresolved, recordedKeys)
 
 	// Phase 2: Resolve.
 	if r == nil {
@@ -105,6 +134,12 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 			}
 		} else {
 			live, _, _ := r.ResolveAllRecursive(ctx, refs)
+			// Merge recorded deps into the live set so CollectReachDeps
+			// treats them as confirmed at their lockfile SHAs, preventing
+			// unnecessary reachability network checks.
+			if len(seedDeps) > 0 {
+				live = append(live, dep.Dedup(seedDeps)...)
+			}
 			reachDeps = CollectReachDeps(unresolved, live)
 			liveMoved = CollectLiveMovedReachDeps(unresolved, live)
 			liveDirect = CollectLiveDirectReachDeps(unresolved, live)
@@ -158,25 +193,53 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	}, nil
 }
 
-// isFullyRecorded returns true when every direct ref in the workflow has a
-// matching lockfile entry — the steady-state happy path.
-func isFullyRecorded(pw checks.ParsedWorkflow) bool {
+// partitionRefs splits a workflow's refs into recorded (have a matching
+// lockfile entry) and unrecorded (need network resolution). The split
+// uses NWO@Ref identity — the same granularity the lockfile pins at.
+// When an error prevented loading refs or deps, everything is unrecorded.
+func partitionRefs(pw checks.ParsedWorkflow) (recorded, unrecorded []parserlock.ActionRef) {
 	if pw.LoadErr != nil || pw.DepsErr != nil {
-		return false
+		return nil, pw.Refs
 	}
 	if len(pw.Refs) == 0 {
-		return true
+		return nil, nil
 	}
 	haveDep := make(map[string]bool, len(pw.ExistingDeps))
 	for _, d := range pw.ExistingDeps {
 		haveDep[d.NWO+"@"+d.Ref] = true
 	}
 	for _, r := range pw.Refs {
-		if !haveDep[r.Owner+"/"+r.Repo+"@"+r.Ref] {
-			return false
+		if haveDep[r.Owner+"/"+r.Repo+"@"+r.Ref] {
+			recorded = append(recorded, r)
+		} else {
+			unrecorded = append(unrecorded, r)
 		}
 	}
-	return true
+	return recorded, unrecorded
+}
+
+// isFullyRecorded returns true when every direct ref in the workflow has a
+// matching lockfile entry — the steady-state happy path.
+func isFullyRecorded(pw checks.ParsedWorkflow) bool {
+	_, unrecorded := partitionRefs(pw)
+	return len(pw.Refs) == 0 || len(unrecorded) == 0
+}
+
+// recordedDeps returns the subset of pw.ExistingDeps whose NWO@Ref matches
+// one of the recorded refs. These are the lockfile entries that correspond
+// to refs the workflow already has pinned.
+func recordedDeps(pw checks.ParsedWorkflow, recorded []parserlock.ActionRef) []dep.Dependency {
+	refKeys := make(map[string]bool, len(recorded))
+	for _, r := range recorded {
+		refKeys[r.Owner+"/"+r.Repo+"@"+r.Ref] = true
+	}
+	var out []dep.Dependency
+	for _, d := range pw.ExistingDeps {
+		if refKeys[d.Key()] {
+			out = append(out, d)
+		}
+	}
+	return out
 }
 
 func hasImpostorFindings(r *checks.Report) bool {

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 
 	"github.com/github/gh-actions-pin/internal/dep"
 	"github.com/github/gh-actions-pin/internal/lockfile"
@@ -70,7 +71,7 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 				rd := parsed[i].RecordedDeps(recorded)
 				seedDeps = append(seedDeps, rd...)
 				for _, r := range recorded {
-					recordedKeys[r.Owner+"/"+r.Repo+"@"+r.Ref] = true
+					recordedKeys[strings.ToLower(r.Owner+"/"+r.Repo)+"@"+r.Ref] = true
 				}
 			}
 		}

--- a/internal/pipeline/run_test.go
+++ b/internal/pipeline/run_test.go
@@ -1,0 +1,231 @@
+package pipeline
+
+import (
+	"testing"
+
+	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
+	"github.com/github/gh-actions-pin/internal/dep"
+	"github.com/github/gh-actions-pin/internal/pipeline/checks"
+	"github.com/stretchr/testify/assert"
+)
+
+func ref(owner, repo, path, ref string) parserlock.ActionRef {
+	return parserlock.ActionRef{Owner: owner, Repo: repo, Path: path, Ref: ref}
+}
+
+func mkDep(nwo, ref, sha string) dep.Dependency {
+	return dep.Dependency{NWO: nwo, Ref: ref, SHA: sha}
+}
+
+func TestPartitionRefs(t *testing.T) {
+	tests := []struct {
+		name             string
+		pw               checks.ParsedWorkflow
+		wantRecordedLen  int
+		wantUnrecordLen  int
+		wantRecordedNWOs []string
+	}{
+		{
+			name: "all recorded",
+			pw: checks.ParsedWorkflow{
+				Refs: []parserlock.ActionRef{
+					ref("actions", "checkout", "", "v4"),
+					ref("actions", "setup-go", "", "v5"),
+				},
+				ExistingDeps: []dep.Dependency{
+					mkDep("actions/checkout", "v4", "aaa"),
+					mkDep("actions/setup-go", "v5", "bbb"),
+				},
+			},
+			wantRecordedLen: 2,
+			wantUnrecordLen: 0,
+		},
+		{
+			name: "none recorded",
+			pw: checks.ParsedWorkflow{
+				Refs: []parserlock.ActionRef{
+					ref("actions", "checkout", "", "v4"),
+				},
+				ExistingDeps: nil,
+			},
+			wantRecordedLen: 0,
+			wantUnrecordLen: 1,
+		},
+		{
+			name: "mixed: one recorded one not",
+			pw: checks.ParsedWorkflow{
+				Refs: []parserlock.ActionRef{
+					ref("actions", "checkout", "", "v4"),
+					ref("mmastrac", "mmm-matrix", "", "v1"),
+				},
+				ExistingDeps: []dep.Dependency{
+					mkDep("actions/checkout", "v4", "aaa"),
+				},
+			},
+			wantRecordedLen:  1,
+			wantUnrecordLen:  1,
+			wantRecordedNWOs: []string{"actions/checkout"},
+		},
+		{
+			name: "load error makes everything unrecorded",
+			pw: checks.ParsedWorkflow{
+				Refs: []parserlock.ActionRef{
+					ref("actions", "checkout", "", "v4"),
+				},
+				ExistingDeps: []dep.Dependency{
+					mkDep("actions/checkout", "v4", "aaa"),
+				},
+				LoadErr: assert.AnError,
+			},
+			wantRecordedLen: 0,
+			wantUnrecordLen: 1,
+		},
+		{
+			name:            "empty refs",
+			pw:              checks.ParsedWorkflow{},
+			wantRecordedLen: 0,
+			wantUnrecordLen: 0,
+		},
+		{
+			name: "sub-action path collapses to NWO level",
+			pw: checks.ParsedWorkflow{
+				Refs: []parserlock.ActionRef{
+					ref("actions", "cache", "save", "v4"),
+					ref("actions", "cache", "restore", "v4"),
+				},
+				ExistingDeps: []dep.Dependency{
+					mkDep("actions/cache", "v4", "ccc"),
+				},
+			},
+			wantRecordedLen: 2, // both sub-actions match the dep
+			wantUnrecordLen: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorded, unrecorded := partitionRefs(tt.pw)
+			assert.Len(t, recorded, tt.wantRecordedLen)
+			assert.Len(t, unrecorded, tt.wantUnrecordLen)
+
+			if len(tt.wantRecordedNWOs) > 0 {
+				var gotNWOs []string
+				for _, r := range recorded {
+					gotNWOs = append(gotNWOs, r.Owner+"/"+r.Repo)
+				}
+				assert.Equal(t, tt.wantRecordedNWOs, gotNWOs)
+			}
+		})
+	}
+}
+
+func TestIsFullyRecorded(t *testing.T) {
+	t.Run("fully recorded", func(t *testing.T) {
+		pw := checks.ParsedWorkflow{
+			Refs: []parserlock.ActionRef{
+				ref("actions", "checkout", "", "v4"),
+			},
+			ExistingDeps: []dep.Dependency{
+				mkDep("actions/checkout", "v4", "aaa"),
+			},
+		}
+		assert.True(t, isFullyRecorded(pw))
+	})
+
+	t.Run("partially recorded", func(t *testing.T) {
+		pw := checks.ParsedWorkflow{
+			Refs: []parserlock.ActionRef{
+				ref("actions", "checkout", "", "v4"),
+				ref("actions", "setup-go", "", "v5"),
+			},
+			ExistingDeps: []dep.Dependency{
+				mkDep("actions/checkout", "v4", "aaa"),
+			},
+		}
+		assert.False(t, isFullyRecorded(pw))
+	})
+
+	t.Run("no refs", func(t *testing.T) {
+		pw := checks.ParsedWorkflow{}
+		assert.True(t, isFullyRecorded(pw))
+	})
+}
+
+func TestRecordedDeps(t *testing.T) {
+	pw := checks.ParsedWorkflow{
+		ExistingDeps: []dep.Dependency{
+			mkDep("actions/checkout", "v4", "aaa"),
+			mkDep("actions/setup-go", "v5", "bbb"),
+			mkDep("third-party/tool", "v1", "ccc"),
+		},
+	}
+	recorded := []parserlock.ActionRef{
+		ref("actions", "checkout", "", "v4"),
+		ref("third-party", "tool", "", "v1"),
+	}
+
+	got := recordedDeps(pw, recorded)
+	assert.Len(t, got, 2)
+
+	keys := make(map[string]bool)
+	for _, d := range got {
+		keys[d.Key()] = true
+	}
+	assert.True(t, keys["actions/checkout@v4"])
+	assert.True(t, keys["third-party/tool@v1"])
+	assert.False(t, keys["actions/setup-go@v5"])
+}
+
+func TestCollectUnrecordedResolvable(t *testing.T) {
+	parsed := []checks.ParsedWorkflow{
+		{
+			Refs: []parserlock.ActionRef{
+				ref("actions", "checkout", "", "v4"),
+				ref("actions", "setup-go", "", "v5"),
+				ref("mmastrac", "mmm-matrix", "", "v1"),
+			},
+			ExistingDeps: []dep.Dependency{
+				mkDep("actions/checkout", "v4", "aaa"),
+				mkDep("actions/setup-go", "v5", "bbb"),
+				mkDep("mmastrac/mmm-matrix", "v1", "ccc"),
+			},
+		},
+	}
+
+	recordedKeys := map[string]bool{
+		"actions/checkout@v4": true,
+		"actions/setup-go@v5": true,
+	}
+
+	refs, deps := CollectUnrecordedResolvable(parsed, recordedKeys)
+
+	// Only the unrecorded ref should be collected.
+	assert.Len(t, refs, 1)
+	assert.Equal(t, "mmastrac", refs[0].Owner)
+	assert.Equal(t, "mmm-matrix", refs[0].Repo)
+
+	// Only the unrecorded dep should be collected.
+	assert.Len(t, deps, 1)
+	assert.Equal(t, "mmastrac/mmm-matrix", deps[0].NWO)
+}
+
+func TestCollectUnrecordedResolvable_NilExclude(t *testing.T) {
+	parsed := []checks.ParsedWorkflow{
+		{
+			Refs: []parserlock.ActionRef{
+				ref("actions", "checkout", "", "v4"),
+				ref("actions", "setup-go", "", "v5"),
+			},
+			ExistingDeps: []dep.Dependency{
+				mkDep("actions/checkout", "v4", "aaa"),
+			},
+		},
+	}
+
+	// With nil recordedKeys, CollectResolvable and CollectUnrecordedResolvable
+	// should return the same results.
+	refsAll, depsAll := CollectResolvable(parsed)
+	refsFiltered, depsFiltered := CollectUnrecordedResolvable(parsed, nil)
+
+	assert.Equal(t, refsAll, refsFiltered)
+	assert.Equal(t, depsAll, depsFiltered)
+}

--- a/internal/pipeline/run_test.go
+++ b/internal/pipeline/run_test.go
@@ -103,7 +103,7 @@ func TestPartitionRefs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recorded, unrecorded := partitionRefs(tt.pw)
+			recorded, unrecorded := tt.pw.PartitionRefs()
 			assert.Len(t, recorded, tt.wantRecordedLen)
 			assert.Len(t, unrecorded, tt.wantUnrecordLen)
 
@@ -128,7 +128,7 @@ func TestIsFullyRecorded(t *testing.T) {
 				mkDep("actions/checkout", "v4", "aaa"),
 			},
 		}
-		assert.True(t, isFullyRecorded(pw))
+		assert.True(t, pw.IsFullyRecorded())
 	})
 
 	t.Run("partially recorded", func(t *testing.T) {
@@ -141,12 +141,12 @@ func TestIsFullyRecorded(t *testing.T) {
 				mkDep("actions/checkout", "v4", "aaa"),
 			},
 		}
-		assert.False(t, isFullyRecorded(pw))
+		assert.False(t, pw.IsFullyRecorded())
 	})
 
 	t.Run("no refs", func(t *testing.T) {
 		pw := checks.ParsedWorkflow{}
-		assert.True(t, isFullyRecorded(pw))
+		assert.True(t, pw.IsFullyRecorded())
 	})
 }
 
@@ -163,7 +163,7 @@ func TestRecordedDeps(t *testing.T) {
 		ref("third-party", "tool", "", "v1"),
 	}
 
-	got := recordedDeps(pw, recorded)
+	got := pw.RecordedDeps(recorded)
 	assert.Len(t, got, 2)
 
 	keys := make(map[string]bool)

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -3,6 +3,7 @@
 package profile
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,25 @@ import (
 	"sync/atomic"
 	"time"
 )
+
+type gqlLabelKeyT struct{}
+
+var gqlLabelKey gqlLabelKeyT
+
+// WithGraphQLLabel returns a context that tags subsequent HTTP requests
+// with a GraphQL operation label (e.g. "resolve", "reachability", "peel").
+// The loggingTransport uses this to break down POST /graphql by purpose.
+func WithGraphQLLabel(ctx context.Context, label string) context.Context {
+	return context.WithValue(ctx, gqlLabelKey, label)
+}
+
+// GraphQLLabel extracts the operation label from ctx, or "" if absent.
+func GraphQLLabel(ctx context.Context) string {
+	if v, ok := ctx.Value(gqlLabelKey).(string); ok {
+		return v
+	}
+	return ""
+}
 
 // Session holds all profiling state for one CLI invocation.
 // Create with Start, tear down with Stop (writes summaries).
@@ -182,6 +202,7 @@ type HTTPLog struct {
 type httpEntry struct {
 	method   string
 	path     string
+	gqlLabel string
 	status   int
 	duration time.Duration
 	ts       time.Time
@@ -222,7 +243,7 @@ func (h *HTTPLog) WriteSummary(w io.Writer) {
 	var totalErrors int
 
 	for _, e := range entries {
-		pat := classifyPath(e.method, e.path)
+		pat := classifyPath(e.method, e.path, e.gqlLabel)
 		b, ok := byPattern[pat]
 		if !ok {
 			b = &bucket{pattern: pat, min: e.duration}
@@ -270,8 +291,12 @@ func (h *HTTPLog) WriteSummary(w io.Writer) {
 }
 
 // classifyPath normalizes API paths into patterns for aggregation.
-func classifyPath(method, path string) string {
+func classifyPath(method, path, gqlLabel string) string {
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	// GraphQL: break down by operation label when available.
+	if method == "POST" && path == "/graphql" && gqlLabel != "" {
+		return "POST /graphql (" + gqlLabel + ")"
+	}
 	if len(parts) < 3 {
 		return method + " " + path
 	}
@@ -319,6 +344,7 @@ func (lt *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	lt.log.record(httpEntry{
 		method:   req.Method,
 		path:     req.URL.Path,
+		gqlLabel: GraphQLLabel(req.Context()),
 		status:   status,
 		duration: dur,
 		ts:       start,


### PR DESCRIPTION
## Problem

When a workflow has N pinned actions and 1 unpinned action, `isFullyRecorded()` returns false for the whole workflow, pushing all N+1 deps through the resolve + reachability network path. This causes O(N) wasted HTTP requests.

Real-world example: next.js `build_and_deploy.yml` has 17 actions. Only `mmastrac/mmm-matrix` needs investigation. But all 17 actions go through `ResolveAllRecursive` and `CheckReachabilityAll`, resulting in 72 HTTP requests instead of ~42.

## Approach

**Per-dep partitioning in the pipeline** (`run.go`, `parse.go`):
- `partitionRefs()` splits a workflow's refs into recorded (matching lockfile entry by NWO@Ref) and unrecorded
- Only unrecorded refs enter `CollectResolvable` and the resolve phase
- Recorded deps are seeded into the resolver cache and merged into the `live` set before `CollectReachDeps`, so the reachability pre-warm treats them as confirmed and skips network checks

**Per-dep trust in planWorkflow** (`plan.go`):
- Partitions `ActionRefs` by inventory match using extracted `partitionByInventory()` helper
- Emits `Verified` entries for recorded deps immediately via shared `verifiedEntries()` helper
- Only unrecorded refs go through `ResolveAllRecursive`, `DirectTracker`, and the narrowing/reverse-lookup pipeline
- Transitive deps overlapping with inventory are deduplicated by NWO+SHA

**GraphQL operation labels in profile** (`profile.go`, `graphql_*.go`):
- Tags each GraphQL call site with an operation label (resolve, reachability, peel) via context value
- Profile summary now shows `POST /graphql (resolve)` vs `POST /graphql (reachability)` instead of a single opaque bucket

## Results

Tested against vercel/next.js (17 actions, 1 impostor `mmastrac/mmm-matrix`):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| HTTP requests | 72 | 42 | -42% |
| Total time | 12.4s | 4.5s | -64% |
| pin.Plan | 7.8s | 1ms | ~0 |

All non-GraphQL requests now exclusively target the single unrecorded dep. The remaining 42 requests are the irreducible cost of investigating an impostor commit (22 reachability GraphQL + 2 resolve GraphQL + 18 REST metadata/branch probes).

The `--rescan` flag still forces full re-verification. Existing tests pass, new unit tests cover `partitionRefs`, `isFullyRecorded`, `recordedDeps`, and `CollectUnrecordedResolvable`.

## Non-obvious details

- Recorded deps are identified by `NWO@Ref` identity (case-insensitive), not SHA. This matches how the lockfile parser stores entries and avoids false negatives from SHA format differences.
- The `seedDeps -> live` merge in `Run()` is critical: without it, `CollectReachDeps` sees recorded deps as "not confirmed by live resolve" and sends them all to reachability pre-warm, negating the optimization.
- Sub-action path mismatch (lockfile `Path=""` vs YAML `Path="restore"` for `actions/cache/restore`) is handled correctly because the resolve cache key uses `ForActionRef` which includes path, and `SeedFromLockfile` is called separately in `check.go` before the pipeline runs.