### PR TITLE
Support GH_ACTIONS_PIN_WORKFLOWS_DIR for non-standard workflow locations

### DIFF
--- a/cmd/gh-actions-pin/root.go
+++ b/cmd/gh-actions-pin/root.go
@@ -124,7 +124,8 @@ $ gh actions-pin --no-fix --json=valid,findings
 // from the existing lockfile so repeat scans short-circuit the per-branch
 // Compare walk. newResolver is the DI seam; pass nil for production wiring.
 func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newResolver resolverFunc) ([]string, *resolve.Resolver, *lockfile.State, error) {
-	paths, err := discoverWorkflowPaths(workflowPaths)
+	workflowsDir := os.Getenv("GH_ACTIONS_PIN_WORKFLOWS_DIR")
+	paths, err := discoverWorkflowPaths(workflowPaths, workflowsDir)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -139,7 +140,12 @@ func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newReso
 		return nil, nil, nil, err
 	}
 
-	store, err := lockfile.LoadState(".", r)
+	var store *lockfile.State
+	if workflowsDir != "" {
+		store, err = lockfile.LoadStateAt(filepath.Join(workflowsDir, "actions.lock"), r)
+	} else {
+		store, err = lockfile.LoadState(".", r)
+	}
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("opening lockfile: %w", err)
 	}
@@ -148,9 +154,20 @@ func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newReso
 	return paths, r, store, nil
 }
 
-func discoverWorkflowPaths(existing []string) ([]string, error) {
+func discoverWorkflowPaths(existing []string, workflowsDir string) ([]string, error) {
 	if len(existing) > 0 {
 		return expandWorkflowPaths(existing)
+	}
+
+	if workflowsDir != "" {
+		paths, err := workflowfile.DiscoverWorkflowsIn(workflowsDir)
+		if err != nil {
+			return nil, err
+		}
+		if len(paths) == 0 {
+			return nil, fmt.Errorf("no workflow files found in %s", workflowsDir)
+		}
+		return paths, nil
 	}
 
 	paths, err := workflowfile.DiscoverWorkflows()

--- a/internal/lockfile/state.go
+++ b/internal/lockfile/state.go
@@ -38,7 +38,7 @@ type MetadataResolver interface {
 // a single store instance without external synchronization.
 type State struct {
 	mu       sync.Mutex
-	repoRoot string
+	lockPath string // full path to actions.lock on disk
 	file     parserlock.File
 	meta     MetadataResolver
 	idCache  map[string][2]int64
@@ -48,8 +48,14 @@ type State struct {
 // LoadState reads the lockfile at repoRoot, returning an empty in-memory file
 // when none exists on disk.
 func LoadState(repoRoot string, meta MetadataResolver) (*State, error) {
-	full := filepath.Join(repoRoot, parserlock.Path)
-	contents, err := os.ReadFile(full)
+	return LoadStateAt(filepath.Join(repoRoot, parserlock.Path), meta)
+}
+
+// LoadStateAt reads the lockfile at the given path, returning an empty
+// in-memory file when none exists on disk. Use this when the lockfile
+// lives outside the standard .github/workflows/ location.
+func LoadStateAt(lockfilePath string, meta MetadataResolver) (*State, error) {
+	contents, err := os.ReadFile(lockfilePath)
 
 	var file parserlock.File
 	switch {
@@ -88,7 +94,7 @@ func LoadState(repoRoot string, meta MetadataResolver) (*State, error) {
 	}
 
 	s := &State{
-		repoRoot: repoRoot,
+		lockPath: lockfilePath,
 		file:     file,
 		meta:     meta,
 		idCache:  map[string][2]int64{},
@@ -360,7 +366,7 @@ func (s *State) Save() error {
 		}
 	}
 
-	full := filepath.Join(s.repoRoot, parserlock.Path)
+	full := s.lockPath
 
 	if len(s.file.Dependencies) == 0 && len(s.file.Workflows) == 0 {
 		if err := os.Remove(full); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/internal/workflowfile/workflowfile.go
+++ b/internal/workflowfile/workflowfile.go
@@ -90,7 +90,12 @@ func (f *File) ExtractActionRefs() ([]parserlock.ActionRef, []string, []string) 
 // DiscoverWorkflows finds all workflow files in .github/workflows/ relative to
 // the current directory. Returns nil if the directory doesn't exist.
 func DiscoverWorkflows() ([]string, error) {
-	dir := filepath.Join(".github", "workflows")
+	return DiscoverWorkflowsIn(filepath.Join(".github", "workflows"))
+}
+
+// DiscoverWorkflowsIn finds all workflow files (*.yml, *.yaml) in dir.
+// Returns nil if the directory doesn't exist.
+func DiscoverWorkflowsIn(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
 		return nil, nil

--- a/internal/workflowfile/workflowfile_test.go
+++ b/internal/workflowfile/workflowfile_test.go
@@ -43,6 +43,25 @@ func TestExtractActionRefsMixed(t *testing.T) {
 	assert.Contains(t, warnings[0], "expression-based")
 }
 
+func TestDiscoverWorkflowsIn(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ci.yml"), []byte("name: ci\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte("name: deploy\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# ignore\n"), 0o644))
+
+	paths, err := DiscoverWorkflowsIn(dir)
+	require.NoError(t, err)
+	assert.Len(t, paths, 2)
+	assert.Equal(t, filepath.Join(dir, "ci.yml"), paths[0])
+	assert.Equal(t, filepath.Join(dir, "deploy.yaml"), paths[1])
+}
+
+func TestDiscoverWorkflowsIn_MissingDir(t *testing.T) {
+	paths, err := DiscoverWorkflowsIn(filepath.Join(t.TempDir(), "nope"))
+	require.NoError(t, err)
+	assert.Nil(t, paths)
+}
+
 func TestExtractLocalCompositeRefs_RejectsPathTraversal(t *testing.T) {
 	repoRoot := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(repoRoot, ".git"), 0o755))


### PR DESCRIPTION
The CLI hardcodes `.github/workflows/` as the scan root for workflow discovery and lockfile placement. In lab and non-standard environments, workflows may live at a different path.

This adds an undocumented `GH_ACTIONS_PIN_WORKFLOWS_DIR` env var that overrides where the CLI looks for workflow files and the `actions.lock` lockfile. When unset, behavior is unchanged.

### Approach

Three packages touched, all surgical:

- **`workflowfile`**: extracted `DiscoverWorkflowsIn(dir)` from `DiscoverWorkflows()` -- the original becomes a thin wrapper passing `.github/workflows`
- **`lockfile`**: replaced `State.repoRoot` with `State.lockPath` (the field was only used for lockfile path computation). Added `LoadStateAt(path, meta)` constructor for explicit lockfile paths; `LoadState` wraps it
- **`root.go`**: `newRun` reads the env var and routes discovery + lockfile I/O through the override dir when set

### Testing

- Added tests for `DiscoverWorkflowsIn` (happy path + missing dir)
- All existing tests pass unchanged -- the refactor preserves existing call signatures