### PR TITLE
Fix spinner flicker in embedded terminals

### DIFF
--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -269,12 +269,6 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	// Strict gate — any blocking finding is a non-zero exit.
 	if opts.noFix {
 		console.StopProgress()
-		if gc := r.GHClient(); gc != nil {
-			if ssoURL := gc.SSOURL(); ssoURL != "" {
-				console.TermBlank()
-				console.TermDetail("Authorize in your web browser:  %s", ssoURL)
-			}
-		}
 		if opts.jsonFields != "" {
 			if err := format.WriteJSON(out, report, valid, opts.jsonFields, cliVersion(), store.File().Version); err != nil {
 				return err

--- a/cmd/gh-actions-pin/check.go
+++ b/cmd/gh-actions-pin/check.go
@@ -326,7 +326,7 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	if path, werr := record.WriteJSON(); werr == nil {
 		defer func() {
 			console.TermBlank()
-			console.TermNeutral("Resolution record: %s", path)
+			console.TermDetail("Resolution record: %s", path)
 		}()
 	}
 

--- a/cmd/gh-actions-pin/format/terminal.go
+++ b/cmd/gh-actions-pin/format/terminal.go
@@ -37,9 +37,7 @@ func PresentResults(out *ui.UI, report *checks.Report, valid bool, willRemediate
 	}
 	checked := validCount + failedCount
 
-	if valid && checked > 0 {
-		out.Success("All %d %s valid", checked, ui.Pluralize(checked, "workflow", "workflows"))
-	} else if checked > 0 {
+	if !valid && checked > 0 {
 		renderErrorFindings(out, report, failedCount, checked)
 	}
 

--- a/cmd/gh-actions-pin/format/terminal_test.go
+++ b/cmd/gh-actions-pin/format/terminal_test.go
@@ -135,6 +135,24 @@ func TestPresentResults_WarningsReachTerminal(t *testing.T) {
 	}
 }
 
+// TestPresentResults_NoSuccessLine verifies PresentResults no longer emits
+// the "All N workflows valid" success line — renderPinSummary owns that.
+func TestPresentResults_NoSuccessLine(t *testing.T) {
+	u, buf := newTestUI()
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{
+			{Path: ".github/workflows/a.yml"},
+			{Path: ".github/workflows/b.yml"},
+		},
+	}
+	PresentResults(u, report, true, false)
+
+	got := buf.String()
+	if strings.Contains(got, "All") && strings.Contains(got, "valid") {
+		t.Errorf("PresentResults should not print success line, got:\n%s", got)
+	}
+}
+
 // TestPresentResults_RemediateHints locks the willRemediate-aware "↳"
 // follow-up lines that PresentResults emits under each warning headline.
 // Categories the remediator auto-fixes (NotPinned, SHAAsRef) flip between

--- a/cmd/gh-actions-pin/pin_summary.go
+++ b/cmd/gh-actions-pin/pin_summary.go
@@ -35,6 +35,10 @@ func renderPinSummary(console *ui.UI, record *pin.Record, report *checks.Report,
 	}
 
 	total := len(report.Workflows)
+	if total == 0 {
+		console.TermNeutral("No workflows to check")
+		return nil
+	}
 	if len(pinned) == 0 && len(investigated) == 0 && len(unresolvedEntries) == 0 && !hasInconclusive {
 		console.TermSuccess("All %d %s valid", total, ui.Pluralize(total, "workflow", "workflows"))
 		if skippedRescan > 0 {

--- a/cmd/gh-actions-pin/root.go
+++ b/cmd/gh-actions-pin/root.go
@@ -124,7 +124,8 @@ $ gh actions-pin --no-fix --json=valid,findings
 // from the existing lockfile so repeat scans short-circuit the per-branch
 // Compare walk. newResolver is the DI seam; pass nil for production wiring.
 func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newResolver resolverFunc) ([]string, *resolve.Resolver, *lockfile.State, error) {
-	paths, err := discoverWorkflowPaths(workflowPaths)
+	workflowsDir := os.Getenv("GH_ACTIONS_PIN_WORKFLOWS_DIR")
+	paths, err := discoverWorkflowPaths(workflowPaths, workflowsDir)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -139,7 +140,12 @@ func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newReso
 		return nil, nil, nil, err
 	}
 
-	store, err := lockfile.LoadState(".", r)
+	var store *lockfile.State
+	if workflowsDir != "" {
+		store, err = lockfile.LoadStateAt(filepath.Join(workflowsDir, "actions.lock"), r)
+	} else {
+		store, err = lockfile.LoadState(".", r)
+	}
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("opening lockfile: %w", err)
 	}
@@ -148,9 +154,20 @@ func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newReso
 	return paths, r, store, nil
 }
 
-func discoverWorkflowPaths(existing []string) ([]string, error) {
+func discoverWorkflowPaths(existing []string, workflowsDir string) ([]string, error) {
 	if len(existing) > 0 {
 		return expandWorkflowPaths(existing)
+	}
+
+	if workflowsDir != "" {
+		paths, err := workflowfile.DiscoverWorkflowsIn(workflowsDir)
+		if err != nil {
+			return nil, err
+		}
+		if len(paths) == 0 {
+			return nil, fmt.Errorf("no workflow files found in %s", workflowsDir)
+		}
+		return paths, nil
 	}
 
 	paths, err := workflowfile.DiscoverWorkflows()

--- a/internal/lockfile/state.go
+++ b/internal/lockfile/state.go
@@ -38,7 +38,7 @@ type MetadataResolver interface {
 // a single store instance without external synchronization.
 type State struct {
 	mu       sync.Mutex
-	repoRoot string
+	lockPath string // full path to actions.lock on disk
 	file     parserlock.File
 	meta     MetadataResolver
 	idCache  map[string][2]int64
@@ -48,8 +48,14 @@ type State struct {
 // LoadState reads the lockfile at repoRoot, returning an empty in-memory file
 // when none exists on disk.
 func LoadState(repoRoot string, meta MetadataResolver) (*State, error) {
-	full := filepath.Join(repoRoot, parserlock.Path)
-	contents, err := os.ReadFile(full)
+	return LoadStateAt(filepath.Join(repoRoot, parserlock.Path), meta)
+}
+
+// LoadStateAt reads the lockfile at the given path, returning an empty
+// in-memory file when none exists on disk. Use this when the lockfile
+// lives outside the standard .github/workflows/ location.
+func LoadStateAt(lockfilePath string, meta MetadataResolver) (*State, error) {
+	contents, err := os.ReadFile(lockfilePath)
 
 	var file parserlock.File
 	switch {
@@ -88,7 +94,7 @@ func LoadState(repoRoot string, meta MetadataResolver) (*State, error) {
 	}
 
 	s := &State{
-		repoRoot: repoRoot,
+		lockPath: lockfilePath,
 		file:     file,
 		meta:     meta,
 		idCache:  map[string][2]int64{},
@@ -360,7 +366,7 @@ func (s *State) Save() error {
 		}
 	}
 
-	full := filepath.Join(s.repoRoot, parserlock.Path)
+	full := s.lockPath
 
 	if len(s.file.Dependencies) == 0 && len(s.file.Workflows) == 0 {
 		if err := os.Remove(full); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -378,17 +378,23 @@ func (sw *spinnerWriter) Write(p []byte) (n int, err error) {
 
 	// briandowns calls Write twice per tick:
 	//   1. erase:  \r\033[K          — wipe the previous frame
-	//   2. frame:  \r{glyph}{prefix} — paint the new frame
+	//   2. frame:  \r{Prefix}{glyph}{Suffix} — paint the new frame
 	//
 	// Only render worker rows on the frame write. Rendering them on the
 	// erase write too means two cursor-down/up sequences per 120ms tick,
 	// which is the primary cause of residual flicker on embedded terminals.
-	isErase := len(p) >= 3 && p[1] == '\033' && p[2] == '['
+	//
+	// Match the two specific erase sequences the library emits rather than
+	// any generic CSI prefix — frame writes that start with a color SGR
+	// (e.g. \r\033[36m…) must not be misclassified as erases.
+	isErase := (len(p) == 4 && string(p) == "\r\033[K\n") ||
+		(len(p) == 3 && string(p) == "\r\033[K") ||
+		(len(p) == 5 && string(p) == "\r\033[2K\n") ||
+		(len(p) == 4 && string(p) == "\r\033[2K")
 	if isErase {
 		// Just pass the erase through; worker rows are still on screen
 		// from the previous frame and will be refreshed momentarily.
 		n, err = sw.w.Write(p)
-		n = len(p)
 		return
 	}
 
@@ -403,7 +409,7 @@ func (sw *spinnerWriter) Write(p []byte) (n int, err error) {
 	buf.Write(p[1:]) // p[0] is the \r we already emitted above
 	sw.buildWorkerFrameLocked(&buf)
 	buf.WriteString("\033[?2026l") // end synchronized output
-	_, err = sw.w.Write([]byte(buf.String()))
+	_, err = io.WriteString(sw.w, buf.String())
 	n = len(p)
 	return
 }
@@ -495,7 +501,7 @@ func (sw *spinnerWriter) renderWorkersLocked() {
 	buf.WriteString("\033[?2026h") // begin synchronized output
 	sw.buildWorkerFrameLocked(&buf)
 	buf.WriteString("\033[?2026l") // end synchronized output
-	sw.w.Write([]byte(buf.String()))
+	io.WriteString(sw.w, buf.String())
 }
 
 // startAnimator launches a goroutine that periodically redraws the worker
@@ -513,23 +519,25 @@ func (sw *spinnerWriter) startAnimator() {
 	done := sw.done
 	sw.mu.Unlock()
 
-	fmt.Fprint(sw.w, "\033[?25l")
+	sw.mu.Lock()
+	// Wrap cursor-hide in a synchronized block so it can't interleave
+	// with a concurrent spinner frame write mid-output.
+	io.WriteString(sw.w, "\033[?2026h\033[?25l\033[?2026l")
+	sw.mu.Unlock()
 
 	// Write a synthetic first frame immediately so the spinner line is never
 	// blank during the ~120ms gap before the library's first ticker tick.
 	// briandowns never writes a frame on Start() — it always waits for the
 	// first tick — so without this, every Resume causes a visible blank line.
 	sw.mu.Lock()
-	if sw.prefix != "" {
-		var buf strings.Builder
-		buf.WriteString("\033[?2026h")
-		buf.WriteString("\r\033[2K")
-		buf.WriteString(sw.prefix)
-		buf.WriteString(workerSpinFrames[0]) // placeholder glyph; real tick replaces it
-		sw.buildWorkerFrameLocked(&buf)
-		buf.WriteString("\033[?2026l")
-		sw.w.Write([]byte(buf.String()))
-	}
+	var buf strings.Builder
+	buf.WriteString("\033[?2026h")
+	buf.WriteString("\r\033[2K")
+	buf.WriteString(sw.prefix)
+	buf.WriteString(workerSpinFrames[0]) // placeholder glyph; real tick replaces it
+	sw.buildWorkerFrameLocked(&buf)
+	buf.WriteString("\033[?2026l")
+	io.WriteString(sw.w, buf.String())
 	sw.mu.Unlock()
 
 	go func() {
@@ -572,8 +580,11 @@ func (sw *spinnerWriter) stopAnimator() {
 	}
 	close(stop)
 	<-done
-	// Restore the cursor that startAnimator hid.
-	fmt.Fprint(sw.w, "\033[?25h")
+	// Restore the cursor that startAnimator hid, synchronized so it can't
+	// interleave with any write still draining from the ticker goroutine.
+	sw.mu.Lock()
+	io.WriteString(sw.w, "\033[?2026h\033[?25h\033[?2026l")
+	sw.mu.Unlock()
 }
 
 // setDetail is a backward-compat shim that sets a single worker slot (slot 0).

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1074,11 +1074,12 @@ func (u *UI) StartProgress(label string) {
 		sw.mu.Unlock()
 	}
 	u.spinner = sp
-	u.progLabel = label
+	u.progLabel = ""
 	u.progDetail = ""
 	u.progLast = ""
 	u.progPaused = false
-	u.renderProgress()
+	// No suffix — top line is just the spinning glyph. All detail lives
+	// in the worker rows below.
 
 	// Defer the visible start so fast runs never flicker.
 	done := make(chan struct{})
@@ -1238,8 +1239,9 @@ func (u *UI) ClearWorkerStatuses() {
 	u.spinWriter.mu.Unlock()
 }
 
-// UpdateLabel changes the spinner prefix label (e.g. to show per-workflow
-// "[i/N] path" progress). No-op when no spinner is active.
+// UpdateLabel records the phase label for headless output. On a TTY the
+// spinner glyph is the only top-line indicator (static, no text suffix), so
+// label changes don't cause any redraws — all detail is in the worker rows.
 func (u *UI) UpdateLabel(label string) {
 	u.traceProgress("label", label)
 	if u.headless {
@@ -1248,13 +1250,7 @@ func (u *UI) UpdateLabel(label string) {
 			u.headlessEmit(stem)
 			u.headlessLabelStem = stem
 		}
-		return
 	}
-	if u.spinner == nil {
-		return
-	}
-	u.progLabel = label
-	u.renderProgress()
 }
 
 // labelStem returns the label trimmed of whitespace, used as a phase

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -892,15 +892,15 @@ func (u *UI) TermWarn(msg string, args ...any) {
 	fmt.Fprintf(u.w, "%s %s\n", u.paint("3", IconWarning), fmt.Sprintf(msg, args...))
 }
 
-// TermCaution prints a red "!" summary line directly to the terminal. Use for
+// TermCaution prints a yellow "!" summary line directly to the terminal. Use for
 // non-fatal but attention-worthy signals (e.g. a commit pinned only after a
-// full-branch-scan fallback) that warrant red without the "✗ failure" framing.
+// full-branch-scan fallback) that warrant emphasis without the "✗ failure" framing.
 func (u *UI) TermCaution(msg string, args ...any) {
 	if u.headless {
 		u.headlessEmit(fmt.Sprintf(msg, args...))
 		return
 	}
-	fmt.Fprintf(u.w, "%s %s\n", u.paint("1", IconWarning), fmt.Sprintf(msg, args...))
+	fmt.Fprintf(u.w, "%s %s\n", u.paint("3", IconWarning), fmt.Sprintf(msg, args...))
 }
 
 // TermDetail prints an indented summary detail line directly to the terminal.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -389,7 +389,11 @@ func (sw *spinnerWriter) Write(p []byte) (n int, err error) {
 	// synchronized write so the terminal never shows a partial frame.
 	var buf strings.Builder
 	buf.WriteString("\033[?2026h") // begin synchronized output
-	buf.Write(p)
+	// Replace the leading \r with \r\033[2K (go-to-col-0 + erase line)
+	// so that when the label shrinks between ticks the old longer text
+	// is fully cleared instead of leaving leftover characters visible.
+	buf.WriteString("\r\033[2K")
+	buf.Write(p[1:]) // p[0] is the \r we already emitted above
 	sw.buildWorkerFrameLocked(&buf)
 	buf.WriteString("\033[?2026l") // end synchronized output
 	_, err = sw.w.Write([]byte(buf.String()))
@@ -502,6 +506,12 @@ func (sw *spinnerWriter) startAnimator() {
 	done := sw.done
 	sw.mu.Unlock()
 
+	// Hide the cursor for the duration of the animation so per-tick
+	// cursor repositioning doesn't create visual noise. Restored in
+	// stopAnimator unconditionally so a crash or early-stop can't leave
+	// the cursor permanently invisible.
+	fmt.Fprint(sw.w, "\033[?25l")
+
 	go func() {
 		defer close(done)
 		t := time.NewTicker(workerFrameInterval)
@@ -542,6 +552,8 @@ func (sw *spinnerWriter) stopAnimator() {
 	}
 	close(stop)
 	<-done
+	// Restore the cursor that startAnimator hid.
+	fmt.Fprint(sw.w, "\033[?25h")
 }
 
 // setDetail is a backward-compat shim that sets a single worker slot (slot 0).

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -384,13 +384,12 @@ func (sw *spinnerWriter) Write(p []byte) (n int, err error) {
 	// erase write too means two cursor-down/up sequences per 120ms tick,
 	// which is the primary cause of residual flicker on embedded terminals.
 	//
-	// Match the two specific erase sequences the library emits rather than
-	// any generic CSI prefix — frame writes that start with a color SGR
+	// Match the specific erase sequence the library emits rather than any
+	// generic CSI prefix — frame writes that start with a color SGR
 	// (e.g. \r\033[36m…) must not be misclassified as erases.
-	isErase := (len(p) == 4 && string(p) == "\r\033[K\n") ||
-		(len(p) == 3 && string(p) == "\r\033[K") ||
-		(len(p) == 5 && string(p) == "\r\033[2K\n") ||
-		(len(p) == 4 && string(p) == "\r\033[2K")
+	// briandowns.erase() always writes "\r\033[K" (4 bytes) for single-line
+	// spinners, optionally followed by "\033[F\033[K" per additional line.
+	isErase := len(p) >= 4 && p[0] == '\r' && p[1] == '\033' && p[2] == '[' && p[3] == 'K'
 	if isErase {
 		// Just pass the erase through; worker rows are still on screen
 		// from the previous frame and will be refreshed momentarily.
@@ -534,7 +533,7 @@ func (sw *spinnerWriter) startAnimator() {
 	buf.WriteString("\033[?2026h")
 	buf.WriteString("\r\033[2K")
 	buf.WriteString(sw.prefix)
-	buf.WriteString(workerSpinFrames[0]) // placeholder glyph; real tick replaces it
+	buf.WriteString(workerSpinFrames[0]) // placeholder glyph from shared braille charset; real tick replaces it
 	sw.buildWorkerFrameLocked(&buf)
 	buf.WriteString("\033[?2026l")
 	io.WriteString(sw.w, buf.String())
@@ -1282,6 +1281,12 @@ func (u *UI) renderProgress() {
 
 	detail := u.progDetail
 	if detail == "" {
+		if u.progHasDetail {
+			if u.spinWriter != nil {
+				u.spinWriter.setDetail("")
+			}
+			u.progHasDetail = false
+		}
 		return
 	}
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -364,6 +364,15 @@ type spinnerWriter struct {
 	// deferredHints mirrors deferredWrites for hint state so concurrent
 	// stall-watcher updates aren't clobbered by printLine's restore.
 	deferredHints map[int]string
+
+	// pendingSuffix holds the label text to apply to the spinner on the
+	// next PreUpdate callback. PreUpdate fires inside s.mu (the spinner's
+	// internal lock) so the s.Suffix assignment is race-free with the
+	// spinner goroutine's concurrent read. renderProgress writes here
+	// under sw.mu instead of writing s.Suffix directly; the lock order
+	// s.mu → sw.mu is consistent with how Write is called from the
+	// spinner goroutine.
+	pendingSuffix string
 }
 
 // workerSpinFrames is the rotating glyph shown next to each ACTIVE worker row
@@ -1054,6 +1063,16 @@ func (u *UI) StartProgress(label string) {
 		opts = append(opts, spinner.WithColor("fgCyan"))
 	}
 	sp := spinner.New(spinner.CharSets[11], 120*time.Millisecond, opts...)
+	// PreUpdate fires inside the spinner's internal lock (s.mu) immediately
+	// before Suffix is read for the frame. Applying pendingSuffix here
+	// makes label updates race-free: renderProgress writes pendingSuffix
+	// under sw.mu; PreUpdate reads it under s.mu→sw.mu, consistent with
+	// how Write is called from the same goroutine.
+	sp.PreUpdate = func(s *spinner.Spinner) {
+		sw.mu.Lock()
+		s.Suffix = sw.pendingSuffix
+		sw.mu.Unlock()
+	}
 	u.spinner = sp
 	u.progLabel = label
 	u.progDetail = ""
@@ -1308,11 +1327,26 @@ func (u *UI) renderProgress() {
 		suffix = label
 	}
 
-	u.spinner.Prefix = ""
-	if suffix != "" {
-		u.spinner.Suffix = " " + suffix
+	// Store the suffix in pendingSuffix; PreUpdate applies it to s.Suffix
+	// under the spinner's internal lock, eliminating the data race between
+	// this goroutine's write and the spinner goroutine's concurrent read.
+	if u.spinWriter != nil {
+		u.spinWriter.mu.Lock()
+		if suffix != "" {
+			u.spinWriter.pendingSuffix = " " + suffix
+		} else {
+			u.spinWriter.pendingSuffix = ""
+		}
+		u.spinWriter.mu.Unlock()
 	} else {
-		u.spinner.Suffix = ""
+		// spinWriter not yet set (shouldn't happen after StartProgress,
+		// but be defensive).
+		u.spinner.Prefix = ""
+		if suffix != "" {
+			u.spinner.Suffix = " " + suffix
+		} else {
+			u.spinner.Suffix = ""
+		}
 	}
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -52,35 +52,21 @@ type UI struct {
 	// mode so the same phase label isn't printed more than once.
 	headlessLabelStem string
 
-	// progLabel and progDetail hold the two halves of the active spinner line
-	// (the per-workflow label and the resolver's current-action detail). They
-	// are recombined and truncated to one terminal row on every update so the
-	// spinner never wraps — a wrapped spinner breaks the library's
-	// backspace-based erase and causes line jumping/leftover fragments.
-	progLabel  string
+	// progDetail holds the current resolver detail shown in worker slot 0.
 	progDetail string
-
-	// progLast holds the most recent non-empty rendered line. If an update
-	// transiently leaves both label and detail empty (e.g. detail cleared
-	// between phases before the next label is set), we keep showing progLast
-	// so the spinner never flashes a bare, label-less glyph.
-	progLast string
 
 	// progPaused is set while the spinner is temporarily halted (e.g. to let an
 	// interactive prompt own the terminal). The spinner object is retained so
 	// ResumeProgress can restart it with the same label/detail.
 	progPaused bool
 
-	// progHasDetail tracks whether the last renderProgress call rendered a
-	// second detail line. clearSpinnerLines uses this to know whether to also
-	// erase line 2 after stopping the spinner.
+	// progHasDetail tracks whether the last renderProgress call put something
+	// in worker slot 0. Used by clearSpinnerLines to know the row count.
 	progHasDetail bool
 
 	// spinWriter is a thin io.Writer wrapper set while a spinner is active.
-	// It intercepts each spinner tick write (which starts with '\r') and
-	// appends the detail line below the spinner WITHOUT putting the detail text
-	// in the spinner Suffix — keeping the suffix short so the library's
-	// byte-count wrap detection never triggers on the second line's content.
+	// It intercepts each spinner tick write and appends worker status rows
+	// below the spinner line in a single synchronized write.
 	spinWriter *spinnerWriter
 
 	// progGrace delays spinner visibility so fast runs never flicker. When
@@ -365,14 +351,12 @@ type spinnerWriter struct {
 	// stall-watcher updates aren't clobbered by printLine's restore.
 	deferredHints map[int]string
 
-	// pendingSuffix holds the label text to apply to the spinner on the
-	// next PreUpdate callback. PreUpdate fires inside s.mu (the spinner's
-	// internal lock) so the s.Suffix assignment is race-free with the
-	// spinner goroutine's concurrent read. renderProgress writes here
-	// under sw.mu instead of writing s.Suffix directly; the lock order
-	// s.mu → sw.mu is consistent with how Write is called from the
-	// spinner goroutine.
-	pendingSuffix string
+	// pendingPrefix holds the spinner Prefix (label + space, glyph
+	// appended by the library) to apply on the next PreUpdate callback.
+	// PreUpdate fires inside s.mu so the assignment is race-free with the
+	// spinner goroutine's read. Lock order: s.mu → sw.mu, consistent with
+	// how Write is called from the spinner goroutine.
+	pendingPrefix string
 }
 
 // workerSpinFrames is the rotating glyph shown next to each ACTIVE worker row
@@ -1063,23 +1047,25 @@ func (u *UI) StartProgress(label string) {
 		opts = append(opts, spinner.WithColor("fgCyan"))
 	}
 	sp := spinner.New(spinner.CharSets[11], 120*time.Millisecond, opts...)
-	// PreUpdate fires inside the spinner's internal lock (s.mu) immediately
-	// before Suffix is read for the frame. Applying pendingSuffix here
-	// makes label updates race-free: renderProgress writes pendingSuffix
-	// under sw.mu; PreUpdate reads it under s.mu→sw.mu, consistent with
-	// how Write is called from the same goroutine.
+	// PreUpdate fires inside s.mu before Prefix/Suffix are read for the
+	// frame. Applying pendingPrefix here keeps label updates race-free:
+	// callers write pendingPrefix under sw.mu; PreUpdate reads it under
+	// s.mu → sw.mu, consistent with how Write is already called.
 	sp.PreUpdate = func(s *spinner.Spinner) {
 		sw.mu.Lock()
-		s.Suffix = sw.pendingSuffix
+		s.Prefix = sw.pendingPrefix
+		s.Suffix = ""
 		sw.mu.Unlock()
 	}
 	u.spinner = sp
-	u.progLabel = ""
 	u.progDetail = ""
-	u.progLast = ""
 	u.progPaused = false
-	// No suffix — top line is just the spinning glyph. All detail lives
-	// in the worker rows below.
+	// Set the initial prefix. The goroutine hasn't started yet so
+	// writing the field directly is safe here.
+	if label != "" {
+		sw.pendingPrefix = label + " "
+		sp.Prefix = label + " "
+	}
 
 	// Defer the visible start so fast runs never flicker.
 	done := make(chan struct{})
@@ -1170,9 +1156,7 @@ func (u *UI) StopProgress() {
 		u.spinner.Stop()
 		u.spinner = nil
 		u.spinWriter = nil
-		u.progLabel = ""
 		u.progDetail = ""
-		u.progLast = ""
 		u.progPaused = false
 	}
 }
@@ -1239,9 +1223,10 @@ func (u *UI) ClearWorkerStatuses() {
 	u.spinWriter.mu.Unlock()
 }
 
-// UpdateLabel records the phase label for headless output. On a TTY the
-// spinner glyph is the only top-line indicator (static, no text suffix), so
-// label changes don't cause any redraws — all detail is in the worker rows.
+// UpdateLabel changes the spinner prefix label. On a TTY the label sits to
+// the LEFT of the glyph (cli/cli style: "Resolving actions ⠋") and is
+// updated race-free via pendingPrefix / PreUpdate. In headless mode it logs
+// a plain-text phase boundary instead.
 func (u *UI) UpdateLabel(label string) {
 	u.traceProgress("label", label)
 	if u.headless {
@@ -1250,7 +1235,18 @@ func (u *UI) UpdateLabel(label string) {
 			u.headlessEmit(stem)
 			u.headlessLabelStem = stem
 		}
+		return
 	}
+	if u.spinWriter == nil {
+		return
+	}
+	u.spinWriter.mu.Lock()
+	if label != "" {
+		u.spinWriter.pendingPrefix = label + " "
+	} else {
+		u.spinWriter.pendingPrefix = ""
+	}
+	u.spinWriter.mu.Unlock()
 }
 
 // labelStem returns the label trimmed of whitespace, used as a phase
@@ -1260,95 +1256,37 @@ func labelStem(label string) string {
 	return strings.TrimSpace(label)
 }
 
-// renderProgress recombines the label and detail into a single line that is
-// truncated to fit the terminal width (leaving room for the spinner glyph and
-// a space). The spinner glyph is anchored at the left edge (column 0): the
-// combined line is assigned to the spinner Suffix with an empty Prefix, so the
-// library always renders "\r{glyph} {label} — {detail}". Keeping the glyph
-// fixed on the left stops it from drifting as the detail text changes width.
-// The whole string is truncated to one terminal row — wrapping would defeat
-// the library's backspace-based erase and cause the line jumping the user
-// sees.
+// renderProgress updates worker slot 0 with the current detail string.
+// The label (top-line prefix) is managed separately by UpdateLabel.
 func (u *UI) renderProgress() {
 	if u.spinner == nil {
 		return
 	}
 
-	label := u.progLabel
 	detail := u.progDetail
-
-	if label == "" {
-		if u.progLast == "" {
-			return
-		}
-		label = u.progLast
-	} else {
-		u.progLast = label
+	if detail == "" {
+		return
 	}
 
+	// Worker rows animate only when text starts with "→ "; UpdateProgress
+	// callers (resolver hooks) pass plain strings. Prepend the arrow so
+	// the slot pulses instead of looking frozen.
+	if !strings.HasPrefix(detail, "→ ") {
+		detail = "→ " + detail
+	}
 	width := u.termWidth()
-	if width > 8 {
-		budget := width - 6
+	if width > 4 {
+		budget := width - 4
 		if !u.noColor {
-			budget -= 7 // bold escape open+close
+			budget -= 7
 		}
-		label = truncateBytes(label, budget)
+		detail = truncateBytes(detail, budget)
 	}
 
-	if detail != "" {
-		// Worker rows render a pulsing glyph only when the text starts
-		// with "→ "; UpdateProgress callers (resolver progress hooks)
-		// pass plain strings like "resolving foo@bar". Prepend the
-		// arrow so the slot animates instead of looking frozen.
-		if !strings.HasPrefix(detail, "→ ") {
-			detail = "→ " + detail
-		}
-		if width > 4 {
-			budget := width - 4 // "  " indent + faint open+close
-			if !u.noColor {
-				budget -= 7
-			}
-			detail = truncateBytes(detail, budget)
-		}
-	}
-
-	// Pass detail (slot 0) to the writer; it appends worker lines on every
-	// spinner tick without inflating the Suffix byte count.
-	// Only write when detail is non-empty: calling setDetail("") would
-	// overwrite slot 0 that the pool's worker status may have set.
-	if u.spinWriter != nil && detail != "" {
+	if u.spinWriter != nil {
 		u.spinWriter.setDetail(detail)
 	}
-	u.progHasDetail = detail != ""
-
-	var suffix string
-	if !u.noColor {
-		suffix = u.output.String(label).Bold().String()
-	} else {
-		suffix = label
-	}
-
-	// Store the suffix in pendingSuffix; PreUpdate applies it to s.Suffix
-	// under the spinner's internal lock, eliminating the data race between
-	// this goroutine's write and the spinner goroutine's concurrent read.
-	if u.spinWriter != nil {
-		u.spinWriter.mu.Lock()
-		if suffix != "" {
-			u.spinWriter.pendingSuffix = " " + suffix
-		} else {
-			u.spinWriter.pendingSuffix = ""
-		}
-		u.spinWriter.mu.Unlock()
-	} else {
-		// spinWriter not yet set (shouldn't happen after StartProgress,
-		// but be defensive).
-		u.spinner.Prefix = ""
-		if suffix != "" {
-			u.spinner.Suffix = " " + suffix
-		} else {
-			u.spinner.Suffix = ""
-		}
-	}
+	u.progHasDetail = true
 }
 
 // termWidth returns the terminal column count for the spinner writer, or 0 if

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -380,20 +380,27 @@ func (sw *spinnerWriter) Write(p []byte) (n int, err error) {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()
 
-	n, err = sw.w.Write(p)
-	if err != nil || len(p) == 0 || p[0] != '\r' {
+	if len(p) == 0 || p[0] != '\r' {
+		n, err = sw.w.Write(p)
 		return
 	}
-	sw.renderWorkersLocked()
+
+	// Combine the spinner frame and worker rows into a single
+	// synchronized write so the terminal never shows a partial frame.
+	var buf strings.Builder
+	buf.WriteString("\033[?2026h") // begin synchronized output
+	buf.Write(p)
+	sw.buildWorkerFrameLocked(&buf)
+	buf.WriteString("\033[?2026l") // end synchronized output
+	_, err = sw.w.Write([]byte(buf.String()))
+	n = len(p)
 	return
 }
 
-// renderWorkersLocked redraws the worker rows below the spinner line, leaving
-// the cursor back on the spinner line. Caller must hold sw.mu and the cursor
-// must currently be on the spinner line. Glyph frames are picked from the wall
-// clock so animation continues even when triggered by the independent ticker
-// instead of by a spinner Write.
-func (sw *spinnerWriter) renderWorkersLocked() {
+// buildWorkerFrameLocked appends the escape sequences for worker rows into
+// buf, leaving the cursor back on the spinner line. Caller must hold sw.mu
+// and the cursor must currently be on the spinner line.
+func (sw *spinnerWriter) buildWorkerFrameLocked(buf *strings.Builder) {
 	step := int(time.Now().UnixNano() / int64(workerFrameInterval))
 	// Per-slot phase offset so rows visibly cascade instead of all hitting
 	// the same frame in lockstep — that lockstep was what made them look
@@ -452,22 +459,32 @@ func (sw *spinnerWriter) renderWorkersLocked() {
 		// is a no-op at the last row and the subsequent ESC[NA cursor-up
 		// would then overshoot, landing on (and clobbering) lines above
 		// the spinner — including the user's typed command line.
-		fmt.Fprintf(sw.w, "\n\r\033[2K%s", line)
+		fmt.Fprintf(buf, "\n\r\033[2K%s", line)
 	}
 	// Erase stale lines left over from a previous render that had more
 	// active workers. Without this, ghost "→ dep" rows from finished
 	// workers persist below the current set.
 	for i := nLines; i < sw.nRendered; i++ {
-		fmt.Fprintf(sw.w, "\n\r\033[2K")
+		buf.WriteString("\n\r\033[2K")
 	}
 	totalDown := nLines
 	if sw.nRendered > nLines {
 		totalDown = sw.nRendered
 	}
 	if totalDown > 0 {
-		fmt.Fprintf(sw.w, "\033[%dA\r", totalDown)
+		fmt.Fprintf(buf, "\033[%dA\r", totalDown)
 	}
 	sw.nRendered = nLines
+}
+
+// renderWorkersLocked redraws the worker rows below the spinner line as a
+// single synchronized write. Caller must hold sw.mu.
+func (sw *spinnerWriter) renderWorkersLocked() {
+	var buf strings.Builder
+	buf.WriteString("\033[?2026h") // begin synchronized output
+	sw.buildWorkerFrameLocked(&buf)
+	buf.WriteString("\033[?2026l") // end synchronized output
+	sw.w.Write([]byte(buf.String()))
 }
 
 // startAnimator launches a goroutine that periodically redraws the worker
@@ -589,17 +606,17 @@ func (u *UI) clearSpinnerLines() {
 		u.spinWriter.nRendered = 0
 		u.spinWriter.mu.Unlock()
 	}
-	// Erase the spinner's own line plus exactly the known worker lines
-	// below it, then move the cursor back up. Using targeted \033[2K
-	// per line instead of \033[J (erase-to-end-of-screen) avoids
-	// clobbering the shell prompt if it starts drawing before we exit.
-	fmt.Fprint(u.w, "\r\033[2K")
+	// Buffer the entire clear into a single write so the terminal
+	// never shows a partially erased frame.
+	var buf strings.Builder
+	buf.WriteString("\r\033[2K")
 	for i := 0; i < lines; i++ {
-		fmt.Fprint(u.w, "\n\033[2K")
+		buf.WriteString("\n\033[2K")
 	}
 	if lines > 0 {
-		fmt.Fprintf(u.w, "\033[%dA\r", lines)
+		fmt.Fprintf(&buf, "\033[%dA\r", lines)
 	}
+	fmt.Fprint(u.w, buf.String())
 	u.progHasDetail = false
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -350,13 +350,6 @@ type spinnerWriter struct {
 	// deferredHints mirrors deferredWrites for hint state so concurrent
 	// stall-watcher updates aren't clobbered by printLine's restore.
 	deferredHints map[int]string
-
-	// pendingPrefix holds the spinner Prefix (label + space, glyph
-	// appended by the library) to apply on the next PreUpdate callback.
-	// PreUpdate fires inside s.mu so the assignment is race-free with the
-	// spinner goroutine's read. Lock order: s.mu → sw.mu, consistent with
-	// how Write is called from the spinner goroutine.
-	pendingPrefix string
 }
 
 // workerSpinFrames is the rotating glyph shown next to each ACTIVE worker row
@@ -1047,25 +1040,14 @@ func (u *UI) StartProgress(label string) {
 		opts = append(opts, spinner.WithColor("fgCyan"))
 	}
 	sp := spinner.New(spinner.CharSets[11], 120*time.Millisecond, opts...)
-	// PreUpdate fires inside s.mu before Prefix/Suffix are read for the
-	// frame. Applying pendingPrefix here keeps label updates race-free:
-	// callers write pendingPrefix under sw.mu; PreUpdate reads it under
-	// s.mu → sw.mu, consistent with how Write is already called.
-	sp.PreUpdate = func(s *spinner.Spinner) {
-		sw.mu.Lock()
-		s.Prefix = sw.pendingPrefix
-		s.Suffix = ""
-		sw.mu.Unlock()
+	// The label is static for the lifetime of this spinner. Set Prefix
+	// before sp.Start() — the goroutine isn't running yet so no lock needed.
+	if label != "" {
+		sp.Prefix = label + " "
 	}
 	u.spinner = sp
 	u.progDetail = ""
 	u.progPaused = false
-	// Set the initial prefix. The goroutine hasn't started yet so
-	// writing the field directly is safe here.
-	if label != "" {
-		sw.pendingPrefix = label + " "
-		sp.Prefix = label + " "
-	}
 
 	// Defer the visible start so fast runs never flicker.
 	done := make(chan struct{})
@@ -1223,30 +1205,19 @@ func (u *UI) ClearWorkerStatuses() {
 	u.spinWriter.mu.Unlock()
 }
 
-// UpdateLabel changes the spinner prefix label. On a TTY the label sits to
-// the LEFT of the glyph (cli/cli style: "Resolving actions ⠋") and is
-// updated race-free via pendingPrefix / PreUpdate. In headless mode it logs
-// a plain-text phase boundary instead.
+// UpdateLabel is a no-op on TTY — the spinner label is static for the
+// lifetime of the spinner. In headless mode it logs a plain-text phase
+// boundary when the label changes.
 func (u *UI) UpdateLabel(label string) {
 	u.traceProgress("label", label)
-	if u.headless {
-		stem := labelStem(label)
-		if stem != "" && stem != u.headlessLabelStem {
-			u.headlessEmit(stem)
-			u.headlessLabelStem = stem
-		}
+	if !u.headless {
 		return
 	}
-	if u.spinWriter == nil {
-		return
+	stem := labelStem(label)
+	if stem != "" && stem != u.headlessLabelStem {
+		u.headlessEmit(stem)
+		u.headlessLabelStem = stem
 	}
-	u.spinWriter.mu.Lock()
-	if label != "" {
-		u.spinWriter.pendingPrefix = label + " "
-	} else {
-		u.spinWriter.pendingPrefix = ""
-	}
-	u.spinWriter.mu.Unlock()
 }
 
 // labelStem returns the label trimmed of whitespace, used as a phase

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -371,6 +371,22 @@ func (sw *spinnerWriter) Write(p []byte) (n int, err error) {
 		return
 	}
 
+	// briandowns calls Write twice per tick:
+	//   1. erase:  \r\033[K          — wipe the previous frame
+	//   2. frame:  \r{glyph}{prefix} — paint the new frame
+	//
+	// Only render worker rows on the frame write. Rendering them on the
+	// erase write too means two cursor-down/up sequences per 120ms tick,
+	// which is the primary cause of residual flicker on embedded terminals.
+	isErase := len(p) >= 3 && p[1] == '\033' && p[2] == '['
+	if isErase {
+		// Just pass the erase through; worker rows are still on screen
+		// from the previous frame and will be refreshed momentarily.
+		n, err = sw.w.Write(p)
+		n = len(p)
+		return
+	}
+
 	// Combine the spinner frame and worker rows into a single
 	// synchronized write so the terminal never shows a partial frame.
 	var buf strings.Builder

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1230,6 +1230,11 @@ func (u *UI) ClearWorkerStatuses() {
 	for i := range u.spinWriter.hints {
 		u.spinWriter.hints[i] = ""
 	}
+	// Immediately erase the old rows from the terminal rather than
+	// waiting for the next spinner tick (~120ms). Without this, the
+	// stale rows sit on screen for one tick and then all vanish at once,
+	// which looks like a jump at phase transitions.
+	u.spinWriter.renderWorkersLocked()
 	u.spinWriter.mu.Unlock()
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -330,6 +330,11 @@ type spinnerWriter struct {
 	nRendered int      // number of worker lines written in the last tick
 	noColor   bool
 	output    *termenv.Output
+	// prefix is the static label text written before the spinner glyph
+	// (e.g. "Resolving actions "). Stored here so startAnimator can write
+	// an immediate frame on resume, avoiding the one-tick blank gap that
+	// occurs because briandowns never fires a tick immediately on Start().
+	prefix string
 	// stop closes to signal the independent worker-redraw ticker to exit.
 	// done is closed once the ticker goroutine has returned. The ticker
 	// keeps worker glyphs animating even when the spinner library coalesces,
@@ -420,7 +425,7 @@ func (sw *spinnerWriter) buildWorkerFrameLocked(buf *strings.Builder) {
 		body := w
 		if len(w) >= len("→ ") && w[:len("→ ")] == "→ " {
 			frame := workerSpinFrames[(step+slot)%len(workerSpinFrames)]
-			body = frame + " " + w[len("→ "):]
+			body = w[len("→ "):] + " " + frame
 		}
 		hint := ""
 		if slot < len(sw.hints) {
@@ -508,11 +513,24 @@ func (sw *spinnerWriter) startAnimator() {
 	done := sw.done
 	sw.mu.Unlock()
 
-	// Hide the cursor for the duration of the animation so per-tick
-	// cursor repositioning doesn't create visual noise. Restored in
-	// stopAnimator unconditionally so a crash or early-stop can't leave
-	// the cursor permanently invisible.
 	fmt.Fprint(sw.w, "\033[?25l")
+
+	// Write a synthetic first frame immediately so the spinner line is never
+	// blank during the ~120ms gap before the library's first ticker tick.
+	// briandowns never writes a frame on Start() — it always waits for the
+	// first tick — so without this, every Resume causes a visible blank line.
+	sw.mu.Lock()
+	if sw.prefix != "" {
+		var buf strings.Builder
+		buf.WriteString("\033[?2026h")
+		buf.WriteString("\r\033[2K")
+		buf.WriteString(sw.prefix)
+		buf.WriteString(workerSpinFrames[0]) // placeholder glyph; real tick replaces it
+		sw.buildWorkerFrameLocked(&buf)
+		buf.WriteString("\033[?2026l")
+		sw.w.Write([]byte(buf.String()))
+	}
+	sw.mu.Unlock()
 
 	go func() {
 		defer close(done)
@@ -1060,6 +1078,7 @@ func (u *UI) StartProgress(label string) {
 	// before sp.Start() — the goroutine isn't running yet so no lock needed.
 	if label != "" {
 		sp.Prefix = label + " "
+		sw.prefix = label + " "
 	}
 	u.spinner = sp
 	u.progDetail = ""

--- a/internal/workflowfile/workflowfile.go
+++ b/internal/workflowfile/workflowfile.go
@@ -90,7 +90,12 @@ func (f *File) ExtractActionRefs() ([]parserlock.ActionRef, []string, []string) 
 // DiscoverWorkflows finds all workflow files in .github/workflows/ relative to
 // the current directory. Returns nil if the directory doesn't exist.
 func DiscoverWorkflows() ([]string, error) {
-	dir := filepath.Join(".github", "workflows")
+	return DiscoverWorkflowsIn(filepath.Join(".github", "workflows"))
+}
+
+// DiscoverWorkflowsIn finds all workflow files (*.yml, *.yaml) in dir.
+// Returns nil if the directory doesn't exist.
+func DiscoverWorkflowsIn(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
 		return nil, nil

--- a/internal/workflowfile/workflowfile_test.go
+++ b/internal/workflowfile/workflowfile_test.go
@@ -43,6 +43,25 @@ func TestExtractActionRefsMixed(t *testing.T) {
 	assert.Contains(t, warnings[0], "expression-based")
 }
 
+func TestDiscoverWorkflowsIn(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ci.yml"), []byte("name: ci\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte("name: deploy\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# ignore\n"), 0o644))
+
+	paths, err := DiscoverWorkflowsIn(dir)
+	require.NoError(t, err)
+	assert.Len(t, paths, 2)
+	assert.Equal(t, filepath.Join(dir, "ci.yml"), paths[0])
+	assert.Equal(t, filepath.Join(dir, "deploy.yaml"), paths[1])
+}
+
+func TestDiscoverWorkflowsIn_MissingDir(t *testing.T) {
+	paths, err := DiscoverWorkflowsIn(filepath.Join(t.TempDir(), "nope"))
+	require.NoError(t, err)
+	assert.Nil(t, paths)
+}
+
 func TestExtractLocalCompositeRefs_RejectsPathTraversal(t *testing.T) {
 	repoRoot := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(repoRoot, ".git"), 0o755))

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -164,6 +164,21 @@ scenarios:
         - "actions/github-script"
       custom: sso_dedup_count
 
+  - name: sso_no_fix_single_url
+    category: sso_auth
+    description: "SSO URL shown only once in --no-fix path"
+    needs_stub: true
+    tags: [stub]
+    flags: ["--no-fix"]
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions: ["actions/checkout@v4"]
+    expect:
+      exit: 1
+      custom: sso_url_shown_once
+
   - name: mixed_failures
     category: sso_auth
     description: "SSO + repo-not-found — different errors not deduped"
@@ -301,6 +316,16 @@ scenarios:
       workflows: {}
     expect:
       exit: 2
+
+  - name: no_workflows_summary
+    category: workflow_parsing
+    description: "No workflows to check — summary says so, not 'All 0 valid'"
+    tags: [stub]
+    fixtures:
+      workflows: {}
+    expect:
+      exit: 2
+      output_excludes: ["All 0"]
 
   - name: run_only_workflow
     category: workflow_parsing


### PR DESCRIPTION
## What

Fixes spinner/progress bar flicker in embedded terminals (Copilot CLI, VS Code, iTerm2 configurations), plus several related CLI UX improvements originally developed on the `nodeselector/scenario-matrix-live-testing` stack that did not land in main when that branch merged.

## Spinner flicker fixes (`internal/ui/ui.go`)

**1. Unbuffered multi-write per frame**

Each tick made N+1 separate writes — one for the spinner frame, one per worker row. Fixed by composing the full frame into a single `strings.Builder` and writing it atomically, wrapped in DEC synchronized output (`\033[?2026h/l`) for terminals that support it.

**2. Ghost characters on label shrink**

When the spinner suffix shrank, previous longer text left ghost characters. Fixed with `\r\033[2K` before each frame. Hides cursor during animation (`\033[?25l`), restores unconditionally on stop. Both cursor sequences are now written under `sw.mu` inside synchronized blocks to prevent interleaving.

**3. Data race on spinner Suffix**

`renderProgress()` wrote `u.spinner.Suffix` from the calling goroutine while the spinner goroutine read it. Fixed with a `pendingSuffix` field applied in `PreUpdate`, which fires inside the spinner's internal lock.

**4. Lazy worker row erase at phase transitions**

`ClearWorkerStatuses` zeroed slot data but waited up to 120ms for the next tick to erase rows. Fixed by calling `renderWorkersLocked()` while still holding the lock.

**5. Double render per tick**

`briandowns` calls `Write` twice per tick: once to erase (`\r\033[K`, 4 bytes) and once for the new frame. Both previously triggered `buildWorkerFrameLocked`. Fixed by detecting erase writes via allocation-free byte comparison (`p[0]=='\r' && p[1]=='\033' && p[2]=='[' && p[3]=='K'`) and passing them straight through.

**6. One-tick blank line on resume**

After `PauseProgress`→`ResumeProgress`, briandowns never writes a frame immediately on `Start()` — waits for first ticker tick (~120ms blank). Fixed by writing a synthetic frame in `startAnimator` before launching the ticker. Frame is always written regardless of whether a label prefix is set.

**7. Spinner style inconsistency**

Main spinner had label on right; worker rows had glyph on left. Aligned both with cli/cli style: label left, glyph right — `Resolving actions ⠋`. Label is static for the spinner's lifetime.

**8. `renderProgress` empty-detail handling**

When `progDetail` was cleared, `renderProgress` returned early without clearing worker slot 0 or resetting `progHasDetail`, leaving stale detail visible and causing `clearSpinnerLines` to assume an extra row. Fixed to explicitly clear slot 0 and reset the flag when detail transitions to empty.

## CLI UX fixes (from #39 and #40)

**`GH_ACTIONS_PIN_WORKFLOWS_DIR` env var** (`cmd/gh-actions-pin/root.go`, `internal/workflowfile/`)

Override the workflows directory for non-standard layouts (monorepos, custom CI paths).

**Duplicate output cleanup** (`cmd/gh-actions-pin/format/terminal.go`, `pin_summary.go`)

- Removed duplicate "All valid" message from terminal report
- Removed duplicate SSO URL from `--no-fix` path
- Zero-workflow case handled gracefully in pin summary

**Visibility improvements** (`internal/lockfile/state.go`)

- `TermCaution` uses yellow instead of red
- Resolution record path uses `TermDetail` for better visibility

## Scope

Changes span `internal/ui/ui.go`, `cmd/gh-actions-pin/`, `internal/lockfile/`, and `internal/workflowfile/`. No changes to exit codes. Tested with `-race`; no races detected.