### PR TITLE
Don't narrow transitive composite dependencies

### DIFF
--- a/internal/lockfile/direct_tracker.go
+++ b/internal/lockfile/direct_tracker.go
@@ -38,6 +38,13 @@ func NewDirectTracker(refs []parserlock.ActionRef, deps []dep.Dependency) Direct
 	return DirectTracker{direct: direct}
 }
 
+// IsDirect reports whether the dep at index i is a workflow-direct use.
+// Out-of-range indices are treated as transitive (false) so callers can
+// gate ref-rewriting on directness without bounds-checking.
+func (t DirectTracker) IsDirect(i int) bool {
+	return i >= 0 && i < len(t.direct) && t.direct[i]
+}
+
 // Keys returns the set of workflow-direct NWO@Ref keys, reading each dep's
 // current (post-mutation) Key() from the supplied index-aligned slice.
 func (t DirectTracker) Keys(deps []dep.Dependency) map[string]bool {

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -275,6 +275,13 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	if opts.Tagger != nil {
 		for i := range deps {
 			dep := &deps[i]
+			// Transitive deps come from a composite's action.yml; their ref
+			// is the composite author's choice and never appears in our
+			// workflow YAML. Narrowing it is pure churn and can invent refs
+			// the composite never declared, so leave it verbatim.
+			if !directTracker.IsDirect(i) {
+				continue
+			}
 			owner, repo := dep.OwnerRepo()
 			if owner == "" {
 				continue
@@ -343,6 +350,17 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 		}
 	}
 
+	// Preserve transitive deps' declared refs across ReverseLookup. We still
+	// want the tag/branch metadata it populates (the lockfile write requires
+	// a branch), but the ref itself must stay exactly as the composite's
+	// action.yml declares it — we don't own it and must not rewrite it.
+	transitiveRefs := make(map[int]string)
+	for i := range deps {
+		if !directTracker.IsDirect(i) {
+			transitiveRefs[i] = deps[i].Ref
+		}
+	}
+
 	// ReverseLookup: SHA → containing tag/branch. Rewrites refs to canonical form.
 	normRewrites, err := opts.Resolver.ReverseLookup(ctx, deps)
 	if err != nil {
@@ -364,7 +382,17 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	for i, ref := range narrowedRefs {
 		deps[i].Ref = ref
 	}
+	// Restore transitive deps' declared refs and suppress any rewrite
+	// ReverseLookup produced for them — keyed by the declared NWO@ref.
+	transitiveRewriteKeys := make(map[string]bool, len(transitiveRefs))
+	for i, ref := range transitiveRefs {
+		deps[i].Ref = ref
+		transitiveRewriteKeys[deps[i].NWO+"@"+ref] = true
+	}
 	for k, v := range normRewrites {
+		if transitiveRewriteKeys[k] {
+			continue
+		}
 		if at := strings.Index(k, "@"); at > 0 {
 			nwo := strings.ToLower(k[:at])
 			if narrowedNWOs[nwo] {
@@ -579,7 +607,9 @@ func verifiedEntries(inventory []checks.InventoryEntry, path string) []Entry {
 
 // narrowVerifiedEntries upgrades already-recorded deps from imprecise refs
 // (main, v4, etc.) to full semver tags when possible. Returns rewrites for
-// the workflow YAML. Skipped when --no-narrow is set.
+// the workflow YAML. Skipped when --no-narrow is set. Only direct entries
+// are narrowed: a transitive dep's ref belongs to the composite that
+// declares it and never appears in our workflow YAML.
 func narrowVerifiedEntries(ctx context.Context, entries []Entry, opts PlanOptions) map[string]string {
 	if opts.NoNarrow || opts.Tagger == nil {
 		return nil
@@ -587,6 +617,9 @@ func narrowVerifiedEntries(ctx context.Context, entries []Entry, opts PlanOption
 	rewrites := make(map[string]string)
 	for i := range entries {
 		e := &entries[i]
+		if !e.Direct {
+			continue
+		}
 		owner, repo := splitNWO(e.NWO)
 		if owner == "" {
 			continue

--- a/internal/pin/plan_test.go
+++ b/internal/pin/plan_test.go
@@ -335,7 +335,14 @@ func TestPlanWorkflow_DoesNotNarrowTransitiveDeps(t *testing.T) {
 		}),
 	)
 
-	// Reverse-lookup stubs (branch + tag listing) for both repos.
+	// Reverse-lookup stubs for both repos: repo metadata (default branch),
+	// branch listing, and tag listing. Stubbing the repo-metadata call keeps
+	// DiscoverContaining on its representative path instead of the
+	// default-branch-unknown fallback.
+	reg.Register(
+		httpmock.REST("GET", `repos/comp/action$`),
+		httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
+	)
 	reg.Register(
 		httpmock.REST("GET", `repos/comp/action/branches`),
 		httpmock.JSONResponse([]any{
@@ -347,6 +354,10 @@ func TestPlanWorkflow_DoesNotNarrowTransitiveDeps(t *testing.T) {
 		httpmock.JSONResponse([]any{
 			map[string]any{"name": "v1.0.0", "commit": map[string]any{"sha": compSHA}},
 		}),
+	)
+	reg.Register(
+		httpmock.REST("GET", `repos/trans/dep$`),
+		httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
 	)
 	reg.Register(
 		httpmock.REST("GET", `repos/trans/dep/branches`),

--- a/internal/pin/plan_test.go
+++ b/internal/pin/plan_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/github/gh-actions-lock/internal/ghapi/httpmock"
 	"github.com/github/gh-actions-lock/internal/pinpool"
 	"github.com/github/gh-actions-lock/internal/resolve"
+	"github.com/github/gh-actions-lock/internal/tag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -286,4 +287,133 @@ func TestPlanWorkflow_AllResolutionsFail(t *testing.T) {
 		assert.Equal(t, Unresolved, e.Resolution, "expected %s to be Unresolved", e.NWO)
 		assert.Contains(t, e.Reason, "not found")
 	}
+}
+
+// TestPlanWorkflow_DoesNotNarrowTransitiveDeps verifies that a transitive
+// dependency discovered from a composite action's action.yml keeps the ref the
+// composite author declared, even when a narrower full-semver tag exists at the
+// same commit. We only own (and may narrow) refs that literally appear in a
+// workflow `uses:` line; rewriting a composite's internal refs is churn and can
+// invent refs the composite never declared.
+func TestPlanWorkflow_DoesNotNarrowTransitiveDeps(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	compSHA := "1111111111111111111111111111111111111111"
+	transSHA := "2222222222222222222222222222222222222222"
+
+	// Depth 0: the direct composite. Its action.yml uses trans/dep@v2.
+	reg.Register(
+		httpmock.GraphQLForRepo("comp", "action"),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"a0": map[string]any{
+					"nameWithOwner": "comp/action",
+					"object": map[string]any{
+						"oid": compSHA,
+						"file": map[string]any{"object": map[string]any{
+							"text": "name: Comp\nruns:\n  using: composite\n  steps:\n    - uses: trans/dep@v2\n",
+						}},
+					},
+				},
+			},
+		}),
+	)
+	// Depth 1: the transitive leaf.
+	reg.Register(
+		httpmock.GraphQLForRepo("trans", "dep"),
+		httpmock.JSONResponse(map[string]any{
+			"data": map[string]any{
+				"a0": map[string]any{
+					"nameWithOwner": "trans/dep",
+					"object": map[string]any{
+						"oid":  transSHA,
+						"file": map[string]any{"object": map[string]any{"text": "name: Trans\nruns:\n  using: node20\n"}},
+					},
+				},
+			},
+		}),
+	)
+
+	// Reverse-lookup stubs (branch + tag listing) for both repos.
+	reg.Register(
+		httpmock.REST("GET", `repos/comp/action/branches`),
+		httpmock.JSONResponse([]any{
+			map[string]any{"name": "main", "commit": map[string]any{"sha": compSHA}},
+		}),
+	)
+	reg.Register(
+		httpmock.REST("GET", `repos/comp/action/tags`),
+		httpmock.JSONResponse([]any{
+			map[string]any{"name": "v1.0.0", "commit": map[string]any{"sha": compSHA}},
+		}),
+	)
+	reg.Register(
+		httpmock.REST("GET", `repos/trans/dep/branches`),
+		httpmock.JSONResponse([]any{
+			map[string]any{"name": "main", "commit": map[string]any{"sha": transSHA}},
+		}),
+	)
+	// trans/dep publishes a narrower full-semver tag at the same commit. If
+	// narrowing were (wrongly) applied to this transitive dep, the Tagger would
+	// rewrite v2 -> v2.3.4. The gate must prevent that.
+	reg.Register(
+		httpmock.REST("GET", `repos/trans/dep/tags`),
+		httpmock.JSONResponse([]any{
+			map[string]any{"name": "v2", "commit": map[string]any{"sha": transSHA}},
+			map[string]any{"name": "v2.3.4", "commit": map[string]any{"sha": transSHA}},
+		}),
+	)
+
+	pool := pinpool.New(2, nil)
+	reachFn := func(_ context.Context, _, _, _, _ string) (resolve.ReachabilityStatus, string) {
+		return resolve.Reachable, "test stub"
+	}
+	resolver, err := resolve.New("github.com", pool, resolve.WithTransport(reg),
+		resolve.WithCheckReachabilityFunc(reachFn))
+	require.NoError(t, err)
+
+	wr := checks.WorkflowReport{
+		Path: ".github/workflows/test.yml",
+		Findings: []checks.Finding{
+			{
+				ActionRef:  &parserlock.ActionRef{Owner: "comp", Repo: "action", Ref: "v1.0.0"},
+				Category:   "unpinned",
+				Severity:   checks.SeverityWarning,
+				Confidence: checks.ConfidenceHigh,
+			},
+		},
+		ActionRefs: []parserlock.ActionRef{
+			{Owner: "comp", Repo: "action", Ref: "v1.0.0"},
+		},
+	}
+
+	opts := PlanOptions{
+		Resolver: resolver,
+		Pool:     pool,
+		// A real Tagger makes the narrowing path live; the gate, not the
+		// absence of a Tagger, is what must spare the transitive dep.
+		Tagger: tag.NewListerForTest(t, reg),
+	}
+
+	result, err := planWorkflow(context.Background(), wr, opts, func(string) {})
+	require.NoError(t, err)
+
+	byNWO := make(map[string]Entry, len(result.entries))
+	for _, e := range result.entries {
+		byNWO[e.NWO] = e
+	}
+
+	trans, ok := byNWO["trans/dep"]
+	require.True(t, ok, "transitive dep should be pinned")
+	assert.Equal(t, "v2", trans.Ref, "transitive ref must stay as the composite declared it")
+	assert.NotEqual(t, "v2.3.4", trans.Ref, "transitive dep must not be narrowed")
+	assert.Equal(t, transSHA, trans.SHA)
+	assert.False(t, trans.Direct, "transitive dep must not be marked Direct")
+	assert.Contains(t, trans.RequiredBy, "comp/action@v1.0.0")
+
+	comp, ok := byNWO["comp/action"]
+	require.True(t, ok, "direct composite should be pinned")
+	assert.Equal(t, "v1.0.0", comp.Ref)
+	assert.True(t, comp.Direct, "composite is a direct workflow use")
 }

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -820,6 +820,34 @@ scenarios:
         - expr: '.findings[0].dependency'
           contains: 'actions/checkout'
 
+  - name: transitive_major_ref_not_narrowed
+    category: narrowing
+    description: "Transitive dep of a composite keeps the major ref the composite declares (actions/setup-go@v5 stays v5, not narrowed to v5.x.y) — we don't own composite-internal refs"
+    needs_token: true
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions: ["cli/gh-extension-precompile@v2.1.0"]
+    expect:
+      exit: 0
+      lockfile_comment_matches: 'actions/setup-go@v5:'
+      lockfile_comment_excludes: 'actions/setup-go@v5\.\d+\.\d+'
+
+  - name: transitive_provenance_ref_not_narrowed
+    category: narrowing
+    description: "Second-hop transitive dep (actions/attest-build-provenance@v1, pulled in via cli/gh-extension-precompile) keeps its declared major ref — not narrowed to v1.x.y. This dep also declares a bare-SHA subpath internally, which must stay verbatim rather than being reverse-looked-up into a malformed ref."
+    needs_token: true
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions: ["cli/gh-extension-precompile@v2.1.0"]
+    expect:
+      exit: 0
+      lockfile_comment_matches: 'actions/attest-build-provenance@v1:'
+      lockfile_comment_excludes: 'actions/attest-build-provenance@v1\.\d+\.\d+'
+
   # ╔═════════════════════════════════════════════════════════════════════════╗
   # ║══════════════════════════════ onboarding ═══════════════════════════════║
   # ╚═════════════════════════════════════════════════════════════════════════╝


### PR DESCRIPTION
## Why

When a workflow uses a composite action, `gh actions-lock` was rewriting the refs of the composite's *internal* (transitive) dependencies, not just the actions that literally appear in the workflow YAML. Those refs belong to the composite author, so narrowing them is pure churn, and in some cases it invented refs the composite never declared.

Concretely, on a fresh regen of a repo that uses `cli/gh-extension-precompile@v2.1.0`:

- `actions/setup-go@v5` (declared by the composite) got narrowed to `v5.6.0`
- `actions/attest-build-provenance@v1` got narrowed to `v1.4.4`
- a bare-SHA subpath ref inside that chain was reverse-looked-up and, in an earlier code state, produced a malformed double-`@` pin like `actions/attest-build-provenance@predicate@1.1.4:sha1-...`

## Approach

Scope narrowing and ref rewriting to **direct** deps only. A dep is direct when its ref literally appears in a workflow `uses:` line; everything discovered from a composite's `action.yml` is transitive.

- Added `DirectTracker.IsDirect(i)` (index-aligned with the resolved deps) as the single source of truth for directness.
- In `planWorkflow`, gate the narrowing loop on `IsDirect(i)`, and preserve transitive deps' declared refs across `ReverseLookup`. ReverseLookup still runs on transitive deps because it populates the tag/branch metadata the lockfile write requires, but its ref rewrites are suppressed for them.
- Applied the same `Direct`-only gate in `narrowVerifiedEntries` for already-recorded entries.

## Tests

- Unit: `TestPlanWorkflow_DoesNotNarrowTransitiveDeps` builds a composite -> transitive graph where the transitive dep has a narrower full-semver tag at the same commit, and asserts the transitive ref is left alone. Verified it fails when the gate is removed.
- Catalog: two `narrowing` scenarios (`transitive_major_ref_not_narrowed`, `transitive_provenance_ref_not_narrowed`) drive the real `cli/gh-extension-precompile@v2.1.0` reproducer. Verified live that both pass on the fixed binary and fail on the pre-fix binary.

## Note for reviewers

There is a separate, intentionally-unfixed gap: an incremental run will not backfill a lockfile that is already missing its transitive closure. Fixing that would force network calls on the fast path, which we want to keep fast. `--rescan` (or deleting the lockfile) heals it. This PR does not touch that path.