### PR TITLE
Skip transitive deps in version-ref nudge

### DIFF
--- a/cmd/gh-actions-lock/check.go
+++ b/cmd/gh-actions-lock/check.go
@@ -430,6 +430,11 @@ func injectVersionRefFindings(report *checks.Report, record *pin.Record) {
 		if e.Resolution != pin.Pinned && e.Resolution != pin.Verified {
 			continue
 		}
+		// Transitive deps come from a composite's action.yml; the user
+		// cannot change their ref, so the nudge is not actionable.
+		if !e.Direct {
+			continue
+		}
 		sv, ok := parserlock.ParseSemVer(e.Ref)
 		if ok && sv.IsFull() {
 			continue

--- a/cmd/gh-actions-lock/pin_summary.go
+++ b/cmd/gh-actions-lock/pin_summary.go
@@ -424,6 +424,11 @@ func renderVersionRefNudge(console *ui.UI, record *pin.Record) {
 		if e.Resolution != pin.Pinned && e.Resolution != pin.Verified {
 			continue
 		}
+		// Transitive deps come from a composite's action.yml; the user
+		// cannot change their ref, so nudging about it is noise.
+		if !e.Direct {
+			continue
+		}
 		sv, ok := parserlock.ParseSemVer(e.Ref)
 		if ok && sv.IsFull() {
 			continue

--- a/cmd/gh-actions-lock/pin_summary_test.go
+++ b/cmd/gh-actions-lock/pin_summary_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/github/gh-actions-lock/internal/pin"
+	"github.com/github/gh-actions-lock/internal/pipeline/checks"
 	"github.com/github/gh-actions-lock/internal/resolve"
 	"github.com/github/gh-actions-lock/internal/ui"
 )
@@ -420,6 +421,86 @@ func TestRenderInvestigationAlerts_MixedIssuesFallbackHeader(t *testing.T) {
 	}
 	if !strings.Contains(out, "investigation") {
 		t.Errorf("expected investigation header for mixed issues, got:\n%s", out)
+	}
+}
+
+func TestRenderVersionRefNudge_SkipsTransitiveDeps(t *testing.T) {
+	record := &pin.Record{
+		Entries: []pin.Entry{
+			// Direct dep with imprecise ref → should appear in the nudge.
+			{NWO: "actions/checkout", Ref: "v6", SHA: "aaa", Resolution: pin.Pinned, Direct: true, Workflows: []string{"ci.yml"}},
+			// Transitive dep with imprecise ref → should NOT appear.
+			{NWO: "actions/setup-go", Ref: "v6", SHA: "bbb", Resolution: pin.Pinned, Direct: false, Workflows: []string{"ci.yml"}},
+			// Transitive dep pinned to a bare SHA → should NOT appear.
+			{NWO: "golangci/golangci-lint-action", Ref: "1e7e51e771db61008b38414a730f564565cf7c20", SHA: "1e7e51e771db61008b38414a730f564565cf7c20", Resolution: pin.Pinned, Direct: false, Workflows: []string{"ci.yml"}},
+			// Direct dep with full semver → should NOT appear (already precise).
+			{NWO: "actions/cache", Ref: "v4.2.1", SHA: "ccc", Resolution: pin.Pinned, Direct: true, Workflows: []string{"ci.yml"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	console := ui.NewPlain(&buf)
+	renderVersionRefNudge(console, record)
+	out := buf.String()
+
+	if !strings.Contains(out, "actions/checkout@v6") {
+		t.Errorf("expected direct imprecise dep in nudge, got:\n%s", out)
+	}
+	if strings.Contains(out, "actions/setup-go") {
+		t.Errorf("transitive dep should be excluded from nudge, got:\n%s", out)
+	}
+	if strings.Contains(out, "golangci/golangci-lint-action") {
+		t.Errorf("transitive dep should be excluded from nudge, got:\n%s", out)
+	}
+	if strings.Contains(out, "actions/cache") {
+		t.Errorf("full semver dep should be excluded from nudge, got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 action") {
+		t.Errorf("expected '1 action' count (only the direct imprecise dep), got:\n%s", out)
+	}
+}
+
+func TestRenderVersionRefNudge_AllTransitive_NoOutput(t *testing.T) {
+	record := &pin.Record{
+		Entries: []pin.Entry{
+			{NWO: "actions/checkout", Ref: "v6", SHA: "aaa", Resolution: pin.Pinned, Direct: false, Workflows: []string{"ci.yml"}},
+			{NWO: "actions/setup-go", Ref: "v6", SHA: "bbb", Resolution: pin.Verified, Direct: false, Workflows: []string{"ci.yml"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	console := ui.NewPlain(&buf)
+	renderVersionRefNudge(console, record)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no output when all imprecise deps are transitive, got:\n%s", buf.String())
+	}
+}
+
+func TestInjectVersionRefFindings_SkipsTransitiveDeps(t *testing.T) {
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{
+			{Path: "ci.yml"},
+		},
+	}
+	record := &pin.Record{
+		Entries: []pin.Entry{
+			{NWO: "actions/checkout", Ref: "v6", SHA: "aaa", Resolution: pin.Pinned, Direct: true, Workflows: []string{"ci.yml"}},
+			{NWO: "actions/setup-go", Ref: "v6", SHA: "bbb", Resolution: pin.Pinned, Direct: false, Workflows: []string{"ci.yml"}},
+		},
+	}
+
+	injectVersionRefFindings(report, record)
+
+	findings := report.Workflows[0].Findings
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (direct only), got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Detail, "actions/checkout@v6") {
+		t.Errorf("expected finding for direct dep, got: %s", findings[0].Detail)
+	}
+	if strings.Contains(findings[0].Detail, "actions/setup-go") {
+		t.Errorf("transitive dep should not produce a finding, got: %s", findings[0].Detail)
 	}
 }
 

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -834,6 +834,19 @@ scenarios:
       lockfile_comment_matches: 'actions/setup-go@v5:'
       lockfile_comment_excludes: 'actions/setup-go@v5\.\d+\.\d+'
 
+  - name: transitive_version_ref_nudge_suppressed
+    category: narrowing
+    description: "Transitive deps with imprecise refs do not trigger the version-ref nudge — user cannot change composite-internal refs"
+    needs_token: true
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions: ["cli/gh-extension-precompile@v2.1.0"]
+    expect:
+      exit: 0
+      output_excludes: ["pinned without a full semver tag"]
+
   - name: transitive_provenance_ref_not_narrowed
     category: narrowing
     description: "Second-hop transitive dep (actions/attest-build-provenance@v1, pulled in via cli/gh-extension-precompile) keeps its declared major ref — not narrowed to v1.x.y. This dep also declares a bare-SHA subpath internally, which must stay verbatim rather than being reverse-looked-up into a malformed ref."


### PR DESCRIPTION
The version-ref nudge ("N actions pinned without a full semver tag") was
surfacing transitive dependencies that the user has no control over. These
refs come from a composite action's `action.yml` -- the workflow author
can't change them, so the warning is not actionable and just creates noise.

Spotted on github/launch where `actions/checkout@v6`, `actions/setup-go@v6`,
and `golangci/golangci-lint-action@<sha>` were flagged, all pulled in
transitively by a composite action.

**Fix:** Filter both the terminal nudge (`renderVersionRefNudge`) and the
JSON finding injection (`injectVersionRefFindings`) to only include entries
where `e.Direct` is true. This matches the existing narrowing logic which
already skips transitive deps for the same reason.

**Tests:**
- Three new unit tests covering direct-only filtering, all-transitive
  suppression, and JSON finding injection
- New scenario catalog entry (`transitive_version_ref_nudge_suppressed`)
  using `cli/gh-extension-precompile@v2.1.0` to assert the nudge text
  doesn't appear when all imprecise refs are transitive