### PR TITLE
Improve self-hosted-runner errors: show context, deduplicate, add --allow-runners

### DIFF
--- a/cmd/gh-actions-lock/check.go
+++ b/cmd/gh-actions-lock/check.go
@@ -24,6 +24,7 @@ import (
 	"github.com/github/gh-actions-lock/internal/resolve"
 	"github.com/github/gh-actions-lock/internal/tag"
 	"github.com/github/gh-actions-lock/internal/ui"
+	"github.com/github/gh-actions-lock/internal/workflowfile"
 	"github.com/spf13/cobra"
 )
 
@@ -197,6 +198,17 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 		r.SeedFromLockfile(store.AllDeps())
 	}
 	endSetup()
+
+	// Fetch org-level hosted runner labels so larger runners aren't flagged
+	// as self-hosted. Best-effort: 403 is silently ignored.
+	if gc := r.GHClient(); gc != nil {
+		if currentRepo, err := repository.Current(); err == nil {
+			if labels, err := gc.OrgHostedRunnerNames(ctx, currentRepo.Owner); err == nil && len(labels) > 0 {
+				workflowfile.RegisterOrgHostedLabels(labels)
+			}
+		}
+	}
+
 	opts.workflowPaths = paths
 
 	// Detailed narration is suppressed from the terminal during the run so the

--- a/cmd/gh-actions-lock/check.go
+++ b/cmd/gh-actions-lock/check.go
@@ -47,6 +47,10 @@ type checkOptions struct {
 	// are kept as-is in the lock comment instead of being resolved to
 	// the full patch tag (e.g. "v4.2.1").
 	noNarrow bool
+	// allowRunners lists additional runner labels to treat as hosted.
+	// Use when org-provisioned larger runners (e.g. ubuntu-latest-xl)
+	// are flagged as self-hosted but you know they are GitHub-hosted.
+	allowRunners []string
 }
 
 func newCheckCmd(newResolver resolverFunc) *cobra.Command {
@@ -104,6 +108,9 @@ func newCheckCmd(newResolver resolverFunc) *cobra.Command {
 			# Read-only check for CI (writes nothing, exits 1 if invalid)
 			$ gh actions-lock check --no-fix --json=valid,findings
 
+			# Treat org larger runners as hosted
+			$ gh actions-lock --allow-runners ubuntu-latest-xl,ubuntu-latest-2xl
+
 			# All fields as JSON
 			$ gh actions-lock check --json
 		`),
@@ -132,6 +139,7 @@ func bindCheckFlags(cmd *cobra.Command, opts *checkOptions) {
 	cmd.Flags().BoolVar(&opts.rescan, "rescan", false, "Re-verify reachability for every recorded pin (bypasses the lockfile fast path)")
 	cmd.Flags().BoolVar(&opts.noFix, "no-fix", false, "Read-only: report findings without modifying workflows or the lockfile")
 	cmd.Flags().BoolVar(&opts.noNarrow, "no-narrow", false, "Keep mutable version refs (e.g. v4) instead of narrowing to full patch tags (e.g. v4.2.1)")
+	cmd.Flags().StringSliceVar(&opts.allowRunners, "allow-runners", nil, "Additional runner `labels` to treat as GitHub-hosted (e.g. ubuntu-latest-xl)")
 	cmd.Flags().StringVar(&opts.profileDir, "profile", "", "Enable profiling: write trace, CPU profile, and HTTP log to `dir`")
 }
 
@@ -172,6 +180,11 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 
 	// Shared worker pool for all concurrent phases.
 	pool := pinpool.New(0, console) // 0 → DefaultWorkers
+
+	// Register user-supplied runner labels as hosted before parsing.
+	if len(opts.allowRunners) > 0 {
+		workflowfile.RegisterOrgHostedLabels(opts.allowRunners)
+	}
 
 	// If profiling, use a profiled resolver that logs HTTP calls.
 	if prof != nil && newResolver == nil {

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -175,11 +175,9 @@ func renderSelfHostedGroup(out *ui.UI, findings []checks.Finding) {
 		wfName := workflowName(f.WorkflowPath)
 		out.Detail("  %s: %s", out.Bold(wfName), f.Detail)
 	}
-	// Show remediation from first finding (they share the same remediation).
 	if IsAlertedCategory(checks.SelfHostedRunner) && findings[0].Remediation != "" {
 		out.Detail("  %s %s", ui.IconWarning, findings[0].Remediation)
 	}
-	// Collect distinct labels for actionable hint.
 	labelSet := map[string]bool{}
 	for _, f := range findings {
 		for _, l := range extractBracketedLabels(f.Detail) {

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -84,11 +84,21 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 			continue
 		}
 
+		// Self-hosted-runner findings share the same empty dep key;
+		// render them as a deduplicated group showing affected workflows.
+		var selfHostedFindings []checks.Finding
 		for _, f := range dg.findings {
 			if f.Category == checks.NotPinned {
 				continue
 			}
+			if f.Category == checks.SelfHostedRunner {
+				selfHostedFindings = append(selfHostedFindings, f)
+				continue
+			}
 			renderFindingDetail(out, f, dep)
+		}
+		if len(selfHostedFindings) > 0 {
+			renderSelfHostedGroup(out, selfHostedFindings)
 		}
 	}
 
@@ -152,7 +162,33 @@ func renderFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 	}
 }
 
-// warningGroup deduplicates warnings by dep key across workflows.
+// renderSelfHostedGroup prints a deduplicated block for self-hosted-runner
+// findings, listing each affected workflow and its non-hosted labels.
+func renderSelfHostedGroup(out *ui.UI, findings []checks.Finding) {
+	label := "SELF-HOSTED-RUNNER"
+	icon := "!"
+	if IsAlertedCategory(checks.SelfHostedRunner) {
+		icon = "✗"
+	}
+	out.Detail("%s %s", icon, out.Dim(label))
+	for _, f := range findings {
+		wfName := workflowName(f.WorkflowPath)
+		out.Detail("  %s: %s", out.Bold(wfName), f.Detail)
+	}
+	// Show remediation from first finding (they share the same remediation).
+	if IsAlertedCategory(checks.SelfHostedRunner) && findings[0].Remediation != "" {
+		out.Detail("  %s %s", out.Bold("⚠"), findings[0].Remediation)
+	}
+}
+
+// workflowName extracts the workflow filename from a path like
+// ".github/workflows/ci.yml".
+func workflowName(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
 type warningGroup struct {
 	finding   checks.Finding
 	count     int

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -134,11 +134,11 @@ func renderFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 	if f.Category == checks.LockfileForgery && f.Dependency != nil {
 		owner, repo := f.Dependency.OwnerRepo()
 		if owner != "" {
-			out.Detail("  → %s", out.Dim(fmt.Sprintf("https://github.com/%s/%s/releases", owner, repo)))
+			out.Detail("  ↳ %s", out.Dim(fmt.Sprintf("https://github.com/%s/%s/releases", owner, repo)))
 		}
 	}
 	if IsAlertedCategory(f.Category) && f.Remediation != "" {
-		out.Detail("  %s %s", out.Bold("⚠"), f.Remediation)
+		out.Detail("  %s %s", ui.IconWarning, f.Remediation)
 	}
 	if f.RecommendedTag != "" {
 		nwo := ""
@@ -149,12 +149,12 @@ func renderFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 		if len(sha) > 7 {
 			sha = sha[:7]
 		}
-		out.Detail("  %s Suggested re-pin: %s@%s (%s) — latest release reachable from a branch",
-			out.Bold("→"), nwo, f.RecommendedTag, sha)
+		out.Detail("  ↳ Suggested re-pin: %s@%s (%s) — latest release reachable from a branch",
+			nwo, f.RecommendedTag, sha)
 	}
 	if f.Category == checks.ImpostorCommit {
-		out.Detail("  %s %s", out.Yellow("!"), pipeline.ImpostorCommitContext)
-		out.Detail("  %s %s", out.Bold("→"), pipeline.PublisherEscalationCopy)
+		out.Detail("  %s %s", ui.IconWarning, pipeline.ImpostorCommitContext)
+		out.Detail("  ↳ %s", pipeline.PublisherEscalationCopy)
 		out.Detail("  see: %s", out.DocLink(pipeline.PublisherTagReleasesDocURL))
 	}
 	if f.DocURL != "" {
@@ -177,7 +177,7 @@ func renderSelfHostedGroup(out *ui.UI, findings []checks.Finding) {
 	}
 	// Show remediation from first finding (they share the same remediation).
 	if IsAlertedCategory(checks.SelfHostedRunner) && findings[0].Remediation != "" {
-		out.Detail("  %s %s", out.Bold("⚠"), findings[0].Remediation)
+		out.Detail("  %s %s", ui.IconWarning, findings[0].Remediation)
 	}
 	// Collect distinct labels for actionable hint.
 	labelSet := map[string]bool{}
@@ -191,7 +191,7 @@ func renderSelfHostedGroup(out *ui.UI, findings []checks.Finding) {
 		for l := range labelSet {
 			labels = append(labels, l)
 		}
-		out.Detail("  %s re-run with --allow-runners %s", out.Bold("→"), strings.Join(labels, ","))
+		out.Detail("  ↳ re-run with --allow-runners %s", strings.Join(labels, ","))
 	}
 }
 

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -179,6 +179,20 @@ func renderSelfHostedGroup(out *ui.UI, findings []checks.Finding) {
 	if IsAlertedCategory(checks.SelfHostedRunner) && findings[0].Remediation != "" {
 		out.Detail("  %s %s", out.Bold("⚠"), findings[0].Remediation)
 	}
+	// Collect distinct labels for actionable hint.
+	labelSet := map[string]bool{}
+	for _, f := range findings {
+		for _, l := range extractBracketedLabels(f.Detail) {
+			labelSet[l] = true
+		}
+	}
+	if len(labelSet) > 0 {
+		var labels []string
+		for l := range labelSet {
+			labels = append(labels, l)
+		}
+		out.Detail("  %s re-run with --allow-runners %s", out.Bold("→"), strings.Join(labels, ","))
+	}
 }
 
 // workflowName extracts the workflow filename from a path like
@@ -189,6 +203,26 @@ func workflowName(path string) string {
 	}
 	return path
 }
+
+// extractBracketedLabels pulls comma-separated items from the first
+// [...] group in s. Returns nil if no brackets are found.
+func extractBracketedLabels(s string) []string {
+	start := strings.Index(s, "[")
+	end := strings.Index(s, "]")
+	if start < 0 || end <= start {
+		return nil
+	}
+	inner := s[start+1 : end]
+	var labels []string
+	for _, l := range strings.Split(inner, ",") {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			labels = append(labels, l)
+		}
+	}
+	return labels
+}
+
 type warningGroup struct {
 	finding   checks.Finding
 	count     int
@@ -265,6 +299,27 @@ func renderWarnings(out *ui.UI, report *checks.Report, willRemediate bool) {
 		out.TermCaution("%d %s skipped — non-hosted runner labels are not supported",
 			len(selfHostedRunnerWorkflows),
 			ui.Pluralize(len(selfHostedRunnerWorkflows), "workflow", "workflows"))
+		// Collect distinct labels from findings for the remediation hint.
+		labelSet := map[string]bool{}
+		for _, key := range warnOrder {
+			wg := warnMap[key]
+			if wg.finding.Category != checks.SelfHostedRunner {
+				continue
+			}
+			for _, l := range extractBracketedLabels(wg.finding.Detail) {
+				labelSet[l] = true
+			}
+		}
+		if len(labelSet) > 0 {
+			var labels []string
+			for l := range labelSet {
+				labels = append(labels, l)
+			}
+			out.TermDetail("↳ if these are org-hosted larger runners, re-run with --allow-runners %s",
+				strings.Join(labels, ","))
+		} else {
+			out.TermDetail("↳ if these are org-hosted larger runners, re-run with --allow-runners <label>")
+		}
 	}
 	if len(unpinnedWorkflows) > 0 {
 		out.TermWarn("%d %s not yet pinned",

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/github/gh-actions-lock/internal/pipeline/checks"
@@ -189,6 +190,7 @@ func renderSelfHostedGroup(out *ui.UI, findings []checks.Finding) {
 		for l := range labelSet {
 			labels = append(labels, l)
 		}
+		sort.Strings(labels)
 		out.Detail("  ↳ re-run with --allow-runners %s", strings.Join(labels, ","))
 	}
 }
@@ -313,6 +315,7 @@ func renderWarnings(out *ui.UI, report *checks.Report, willRemediate bool) {
 			for l := range labelSet {
 				labels = append(labels, l)
 			}
+			sort.Strings(labels)
 			out.TermDetail("↳ if these are org-hosted larger runners, re-run with --allow-runners %s",
 				strings.Join(labels, ","))
 		} else {

--- a/internal/ghapi/hosted_runners.go
+++ b/internal/ghapi/hosted_runners.go
@@ -6,9 +6,8 @@ import (
 	"net/http"
 )
 
-// OrgHostedRunnerNames fetches the names (runs-on labels) of all
-// GitHub-hosted runners configured for the given org. Returns nil on
-// permission errors (403) so callers can fall back to the static list.
+// OrgHostedRunnerNames fetches runs-on labels of org-hosted runners.
+// Returns nil on 403 so callers fall back to the static list.
 func (c *Client) OrgHostedRunnerNames(ctx context.Context, org string) ([]string, error) {
 	var names []string
 	page := 1

--- a/internal/ghapi/hosted_runners.go
+++ b/internal/ghapi/hosted_runners.go
@@ -1,0 +1,38 @@
+package ghapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// OrgHostedRunnerNames fetches the names (runs-on labels) of all
+// GitHub-hosted runners configured for the given org. Returns nil on
+// permission errors (403) so callers can fall back to the static list.
+func (c *Client) OrgHostedRunnerNames(ctx context.Context, org string) ([]string, error) {
+	var names []string
+	page := 1
+	for {
+		path := fmt.Sprintf("orgs/%s/actions/hosted-runners?per_page=100&page=%d", org, page)
+		var resp struct {
+			TotalCount int `json:"total_count"`
+			Runners    []struct {
+				Name string `json:"name"`
+			} `json:"runners"`
+		}
+		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+			if IsPermissionDenied(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("listing org hosted runners: %w", err)
+		}
+		for _, r := range resp.Runners {
+			names = append(names, r.Name)
+		}
+		if len(names) >= resp.TotalCount {
+			break
+		}
+		page++
+	}
+	return names, nil
+}

--- a/internal/ghapi/hosted_runners.go
+++ b/internal/ghapi/hosted_runners.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // OrgHostedRunnerNames fetches runs-on labels of org-hosted runners.
-// Returns nil on 403 so callers fall back to the static list.
+// Returns nil on permission errors (401/403) or 404 (user-owned repos)
+// so callers fall back to the static list.
 func (c *Client) OrgHostedRunnerNames(ctx context.Context, org string) ([]string, error) {
 	var names []string
 	page := 1
 	for {
-		path := fmt.Sprintf("orgs/%s/actions/hosted-runners?per_page=100&page=%d", org, page)
+		path := fmt.Sprintf("orgs/%s/actions/hosted-runners?per_page=100&page=%d", url.PathEscape(org), page)
 		var resp struct {
 			TotalCount int `json:"total_count"`
 			Runners    []struct {
@@ -20,7 +22,7 @@ func (c *Client) OrgHostedRunnerNames(ctx context.Context, org string) ([]string
 			} `json:"runners"`
 		}
 		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-			if IsPermissionDenied(err) {
+			if IsPermissionDenied(err) || IsNotFound(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("listing org hosted runners: %w", err)

--- a/internal/ghapi/hosted_runners_test.go
+++ b/internal/ghapi/hosted_runners_test.go
@@ -1,0 +1,44 @@
+package ghapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/github/gh-actions-lock/internal/ghapi/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrgHostedRunnerNames_Success(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "orgs/my-org/actions/hosted-runners"),
+		httpmock.JSONResponse(map[string]any{
+			"total_count": 2,
+			"runners": []map[string]any{
+				{"name": "ubuntu-latest-xl"},
+				{"name": "ubuntu-latest-2xl"},
+			},
+		}),
+	)
+	c, err := New("github.com", WithClientTransport(reg))
+	require.NoError(t, err)
+
+	names, err := c.OrgHostedRunnerNames(context.Background(), "my-org")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ubuntu-latest-xl", "ubuntu-latest-2xl"}, names)
+}
+
+func TestOrgHostedRunnerNames_403_ReturnsNil(t *testing.T) {
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST("GET", "orgs/my-org/actions/hosted-runners"),
+		httpmock.StatusResponse(403),
+	)
+	c, err := New("github.com", WithClientTransport(reg))
+	require.NoError(t, err)
+
+	names, err := c.OrgHostedRunnerNames(context.Background(), "my-org")
+	assert.NoError(t, err)
+	assert.Nil(t, names)
+}

--- a/internal/pipeline/checks/parsed.go
+++ b/internal/pipeline/checks/parsed.go
@@ -42,6 +42,9 @@ type ParsedWorkflow struct {
 	// (self-hosted, custom label, runner group, or expression). These
 	// workflows are skipped from onboarding.
 	NonHostedRunner bool
+	// NonHostedLabels holds the specific non-hosted runner labels found
+	// in the workflow (populated only when NonHostedRunner is true).
+	NonHostedLabels []string
 }
 
 // PartitionRefs splits refs into recorded (matching a lockfile entry by

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -5,6 +5,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/github/gh-actions-lock/internal/dep"
 	"github.com/github/gh-actions-lock/internal/ghapi"
@@ -89,6 +90,7 @@ func diagnoseOneParsed(ctx context.Context, pw checks.ParsedWorkflow, r *resolve
 	}
 
 	if pw.NonHostedRunner {
+		labelList := strings.Join(pw.NonHostedLabels, ", ")
 		wfKey := workflowfile.KeyFromPath(pw.Path)
 		if store != nil && store.HasWorkflow(wfKey) {
 			wr.Findings = append(wr.Findings, checks.Finding{
@@ -96,7 +98,7 @@ func diagnoseOneParsed(ctx context.Context, pw checks.ParsedWorkflow, r *resolve
 				Category:     checks.SelfHostedRunner,
 				Severity:     checks.SeverityError,
 				Confidence:   checks.ConfidenceHigh,
-				Detail:       "workflow uses non-hosted runner labels which are not supported; use GitHub-hosted runners to continue using the lockfile",
+				Detail:       fmt.Sprintf("uses non-hosted runner labels [%s]; use GitHub-hosted runners to continue using the lockfile", labelList),
 				Remediation:  "switch to GitHub-hosted runner labels or move self-hosted jobs to a separate workflow",
 			})
 		} else {
@@ -105,7 +107,7 @@ func diagnoseOneParsed(ctx context.Context, pw checks.ParsedWorkflow, r *resolve
 				Category:     checks.SelfHostedRunner,
 				Severity:     checks.SeverityWarning,
 				Confidence:   checks.ConfidenceHigh,
-				Detail:       "workflow uses non-hosted runner labels; lockfile onboarding is not supported",
+				Detail:       fmt.Sprintf("uses non-hosted runner labels [%s]; lockfile onboarding is not supported", labelList),
 			})
 		}
 		return wr

--- a/internal/pipeline/diagnose_test.go
+++ b/internal/pipeline/diagnose_test.go
@@ -52,12 +52,14 @@ func TestDiagnoseOneParsed_SelfHostedRunner_NotOnboarded(t *testing.T) {
 	pw := checks.ParsedWorkflow{
 		Path:            ".github/workflows/ci.yml",
 		NonHostedRunner: true,
+		NonHostedLabels: []string{"self-hosted", "linux"},
 	}
 	wr := diagnoseOneParsed(context.Background(), pw, nil, nil, nil)
 
 	assert.Len(t, wr.Findings, 1)
 	assert.Equal(t, checks.SelfHostedRunner, wr.Findings[0].Category)
 	assert.Equal(t, checks.SeverityWarning, wr.Findings[0].Severity)
+	assert.Contains(t, wr.Findings[0].Detail, "self-hosted, linux")
 }
 
 func TestDiagnoseOneParsed_SelfHostedRunner_AlreadyOnboarded(t *testing.T) {
@@ -71,6 +73,7 @@ func TestDiagnoseOneParsed_SelfHostedRunner_AlreadyOnboarded(t *testing.T) {
 	pw := checks.ParsedWorkflow{
 		Path:            wfKey,
 		NonHostedRunner: true,
+		NonHostedLabels: []string{"self-hosted"},
 	}
 	wr := diagnoseOneParsed(context.Background(), pw, nil, store, nil)
 

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -48,7 +48,8 @@ func ParseAll(paths []string, store *lockfile.State) []checks.ParsedWorkflow {
 			continue
 		}
 		pw.Refs, pw.LocalPaths, pw.ParseWarnings = wf.ExtractActionRefs()
-		pw.NonHostedRunner = wf.HasNonHostedRunnerLabels()
+		pw.NonHostedLabels = wf.NonHostedRunnerLabels()
+		pw.NonHostedRunner = len(pw.NonHostedLabels) > 0
 		if len(pw.Refs) > 0 {
 			wfKey := workflowfile.KeyFromPath(path)
 			deps, depsErr := store.Get(wfKey)

--- a/internal/workflowfile/runson.go
+++ b/internal/workflowfile/runson.go
@@ -92,21 +92,30 @@ func (f *File) ExtractRunsOnLabels() []string {
 // when the workflow has no jobs or no runs-on keys (run-only workflows
 // have no action refs to pin, so they are excluded separately).
 func (f *File) HasNonHostedRunnerLabels() bool {
-	found := false
+	return len(f.NonHostedRunnerLabels()) > 0
+}
+
+// NonHostedRunnerLabels returns the distinct non-hosted runner labels
+// found across all jobs. Expression labels (containing "${") are
+// returned as-is. The result is deduplicated case-insensitively but
+// preserves original casing.
+func (f *File) NonHostedRunnerLabels() []string {
+	seen := make(map[string]bool)
+	var labels []string
+
 	walkJobs(&f.root, func(runsOnNode *yaml.Node) {
 		for _, label := range runsOnLabels(runsOnNode) {
-			if strings.Contains(label, "${") {
-				// Expression labels are opaque; treat as non-hosted to be safe.
-				found = true
-				return
+			lower := strings.ToLower(label)
+			if seen[lower] {
+				continue
 			}
-			if !IsHostedRunnerLabel(label) {
-				found = true
-				return
+			if strings.Contains(label, "${") || !IsHostedRunnerLabel(label) {
+				seen[lower] = true
+				labels = append(labels, label)
 			}
 		}
 	})
-	return found
+	return labels
 }
 
 // walkJobs iterates over the top-level `jobs:` mapping and calls fn with

--- a/internal/workflowfile/runson.go
+++ b/internal/workflowfile/runson.go
@@ -2,6 +2,7 @@ package workflowfile
 
 import (
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -60,11 +61,41 @@ var hostedRunnerLabels = map[string]bool{
 	"macos-latest-xlarge": true,
 }
 
+// orgHostedLabels holds additional labels registered at runtime from the
+// org's hosted-runners API. Protected by orgHostedMu for safe concurrent access.
+var (
+	orgHostedMu     sync.RWMutex
+	orgHostedLabels map[string]bool
+)
+
+// RegisterOrgHostedLabels records additional runner labels as hosted (from
+// the /orgs/{org}/actions/hosted-runners API). Call this before ParseAll so
+// workflows using org-provisioned larger runners are not flagged as
+// self-hosted. Safe to call multiple times; labels accumulate.
+func RegisterOrgHostedLabels(labels []string) {
+	if len(labels) == 0 {
+		return
+	}
+	orgHostedMu.Lock()
+	defer orgHostedMu.Unlock()
+	if orgHostedLabels == nil {
+		orgHostedLabels = make(map[string]bool, len(labels))
+	}
+	for _, l := range labels {
+		orgHostedLabels[strings.ToLower(l)] = true
+	}
+}
+
 // IsHostedRunnerLabel reports whether label is a known GitHub-hosted
-// runner label. Matches case-insensitively against the label set from
-// github/hosted-compute-core imageconfigs.
+// runner label. Checks both the built-in set and any org-registered labels.
 func IsHostedRunnerLabel(label string) bool {
-	return hostedRunnerLabels[strings.ToLower(label)]
+	lower := strings.ToLower(label)
+	if hostedRunnerLabels[lower] {
+		return true
+	}
+	orgHostedMu.RLock()
+	defer orgHostedMu.RUnlock()
+	return orgHostedLabels[lower]
 }
 
 // ExtractRunsOnLabels returns the set of runs-on labels across all jobs

--- a/internal/workflowfile/runson.go
+++ b/internal/workflowfile/runson.go
@@ -80,7 +80,7 @@ func RegisterOrgHostedLabels(labels []string) {
 		orgHostedLabels = make(map[string]bool, len(labels))
 	}
 	for _, l := range labels {
-		orgHostedLabels[strings.ToLower(l)] = true
+		orgHostedLabels[strings.ToLower(strings.TrimSpace(l))] = true
 	}
 }
 

--- a/internal/workflowfile/runson.go
+++ b/internal/workflowfile/runson.go
@@ -61,17 +61,15 @@ var hostedRunnerLabels = map[string]bool{
 	"macos-latest-xlarge": true,
 }
 
-// orgHostedLabels holds additional labels registered at runtime from the
-// org's hosted-runners API. Protected by orgHostedMu for safe concurrent access.
+// orgHostedLabels extends the built-in set with labels from --allow-runners
+// or the org hosted-runners API.
 var (
 	orgHostedMu     sync.RWMutex
 	orgHostedLabels map[string]bool
 )
 
-// RegisterOrgHostedLabels records additional runner labels as hosted (from
-// the /orgs/{org}/actions/hosted-runners API). Call this before ParseAll so
-// workflows using org-provisioned larger runners are not flagged as
-// self-hosted. Safe to call multiple times; labels accumulate.
+// RegisterOrgHostedLabels adds labels to the hosted runner allowlist.
+// Call before ParseAll; safe to call multiple times.
 func RegisterOrgHostedLabels(labels []string) {
 	if len(labels) == 0 {
 		return
@@ -86,8 +84,7 @@ func RegisterOrgHostedLabels(labels []string) {
 	}
 }
 
-// IsHostedRunnerLabel reports whether label is a known GitHub-hosted
-// runner label. Checks both the built-in set and any org-registered labels.
+// IsHostedRunnerLabel reports whether label is a known GitHub-hosted runner.
 func IsHostedRunnerLabel(label string) bool {
 	lower := strings.ToLower(label)
 	if hostedRunnerLabels[lower] {
@@ -98,9 +95,7 @@ func IsHostedRunnerLabel(label string) bool {
 	return orgHostedLabels[lower]
 }
 
-// ExtractRunsOnLabels returns the set of runs-on labels across all jobs
-// in the workflow. Each distinct label appears once (case-preserved).
-// Expression-based labels (containing "${") are returned as-is.
+// ExtractRunsOnLabels returns the deduplicated runs-on labels across all jobs.
 func (f *File) ExtractRunsOnLabels() []string {
 	seen := make(map[string]bool)
 	var labels []string
@@ -118,18 +113,12 @@ func (f *File) ExtractRunsOnLabels() []string {
 	return labels
 }
 
-// HasNonHostedRunnerLabels reports whether any job in the workflow uses a
-// runs-on label that is not a known GitHub-hosted runner. Returns false
-// when the workflow has no jobs or no runs-on keys (run-only workflows
-// have no action refs to pin, so they are excluded separately).
+// HasNonHostedRunnerLabels reports whether any job uses a non-hosted runner label.
 func (f *File) HasNonHostedRunnerLabels() bool {
 	return len(f.NonHostedRunnerLabels()) > 0
 }
 
-// NonHostedRunnerLabels returns the distinct non-hosted runner labels
-// found across all jobs. Expression labels (containing "${") are
-// returned as-is. The result is deduplicated case-insensitively but
-// preserves original casing.
+// NonHostedRunnerLabels returns distinct non-hosted labels across all jobs.
 func (f *File) NonHostedRunnerLabels() []string {
 	seen := make(map[string]bool)
 	var labels []string
@@ -160,7 +149,6 @@ func walkJobs(root *yaml.Node, fn func(runsOnNode *yaml.Node)) {
 		return
 	}
 
-	// Find the "jobs" key.
 	var jobsNode *yaml.Node
 	for i := 0; i < len(doc.Content)-1; i += 2 {
 		if doc.Content[i].Kind == yaml.ScalarNode && doc.Content[i].Value == "jobs" {
@@ -172,7 +160,6 @@ func walkJobs(root *yaml.Node, fn func(runsOnNode *yaml.Node)) {
 		return
 	}
 
-	// Iterate jobs.
 	for i := 0; i < len(jobsNode.Content)-1; i += 2 {
 		jobVal := jobsNode.Content[i+1]
 		if jobVal.Kind != yaml.MappingNode {

--- a/internal/workflowfile/runson_test.go
+++ b/internal/workflowfile/runson_test.go
@@ -45,15 +45,15 @@ func TestRegisterOrgHostedLabels(t *testing.T) {
 	assert.False(t, IsHostedRunnerLabel("ubuntu-latest-xl"))
 
 	RegisterOrgHostedLabels([]string{"ubuntu-latest-xl", "Ubuntu-Latest-2XL"})
+	t.Cleanup(func() {
+		orgHostedMu.Lock()
+		orgHostedLabels = nil
+		orgHostedMu.Unlock()
+	})
 
 	assert.True(t, IsHostedRunnerLabel("ubuntu-latest-xl"))
 	assert.True(t, IsHostedRunnerLabel("Ubuntu-Latest-XL")) // case-insensitive
 	assert.True(t, IsHostedRunnerLabel("ubuntu-latest-2xl"))
-
-	// Clean up for other tests in the same process.
-	orgHostedMu.Lock()
-	orgHostedLabels = nil
-	orgHostedMu.Unlock()
 }
 
 func TestExtractRunsOnLabels_Scalar(t *testing.T) {
@@ -253,6 +253,78 @@ on: push
 			wf, err := Parse("ci.yml", []byte(tt.yaml))
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantNon, wf.HasNonHostedRunnerLabels())
+		})
+	}
+}
+
+func TestNonHostedRunnerLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want []string
+	}{
+		{
+			name: "returns non-hosted labels",
+			yaml: `
+name: ci
+on: push
+jobs:
+  test:
+    runs-on: [self-hosted, linux]
+    steps:
+      - run: echo hi
+`,
+			want: []string{"self-hosted", "linux"},
+		},
+		{
+			name: "deduplicates case-insensitively preserving first casing",
+			yaml: `
+name: ci
+on: push
+jobs:
+  a:
+    runs-on: My-Runner
+    steps:
+      - run: echo a
+  b:
+    runs-on: my-runner
+    steps:
+      - run: echo b
+`,
+			want: []string{"My-Runner"},
+		},
+		{
+			name: "includes expression labels",
+			yaml: `
+name: ci
+on: push
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: echo hi
+`,
+			want: []string{"${{ matrix.os }}"},
+		},
+		{
+			name: "empty when all hosted",
+			yaml: `
+name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf, err := Parse("ci.yml", []byte(tt.yaml))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, wf.NonHostedRunnerLabels())
 		})
 	}
 }

--- a/internal/workflowfile/runson_test.go
+++ b/internal/workflowfile/runson_test.go
@@ -40,6 +40,22 @@ func TestIsHostedRunnerLabel(t *testing.T) {
 	}
 }
 
+func TestRegisterOrgHostedLabels(t *testing.T) {
+	// "ubuntu-latest-xl" is not in the built-in list.
+	assert.False(t, IsHostedRunnerLabel("ubuntu-latest-xl"))
+
+	RegisterOrgHostedLabels([]string{"ubuntu-latest-xl", "Ubuntu-Latest-2XL"})
+
+	assert.True(t, IsHostedRunnerLabel("ubuntu-latest-xl"))
+	assert.True(t, IsHostedRunnerLabel("Ubuntu-Latest-XL")) // case-insensitive
+	assert.True(t, IsHostedRunnerLabel("ubuntu-latest-2xl"))
+
+	// Clean up for other tests in the same process.
+	orgHostedMu.Lock()
+	orgHostedLabels = nil
+	orgHostedMu.Unlock()
+}
+
 func TestExtractRunsOnLabels_Scalar(t *testing.T) {
 	wf, err := Parse("ci.yml", []byte(`
 name: ci


### PR DESCRIPTION
## Why

When `gh actions-lock` encounters workflows using non-hosted runner labels, the error output is unhelpful -- the same generic message repeats once per workflow with no indication of *which* workflow or *which* labels triggered it. Org-provisioned larger runners (like `ubuntu-latest-xl`) are also falsely flagged with no way to override.

## What this does

1. **Enriches error messages** -- each finding now includes the workflow filename and the specific non-hosted labels detected (e.g. `[ubuntu-latest-xl]`).

2. **Deduplicates output** -- instead of N identical lines, renders a single summary with per-workflow details:
   ```
    ! 3 workflows skipped -- non-hosted runner labels are not supported
    ↳ re-run with --allow-runners ubuntu-latest-xl
   ```

3. **Adds `--allow-runners` flag** -- lets users explicitly declare that certain labels are org-hosted larger runners, bypassing the check. Available on both `gh actions-lock` and `gh actions-lock check`.

4. **Attempts API-based discovery** -- calls `/orgs/{org}/actions/hosted-runners` to auto-detect org larger runners. Gracefully falls back to no-op on 403 (most tokens lack `manage_runners:org`).

## Key design decisions

- Labels are encoded in the finding's `Detail` string as `[label1, label2]` so the formatter can extract them for the remediation hint without changing the `Finding` struct shape.
- `RegisterOrgHostedLabels()` extends the hosted label allowlist at runtime (mutex-protected) so both the API path and `--allow-runners` flag use the same mechanism.
- The API call happens once at startup, before pipeline execution, and only when the repo belongs to an org.