### PR TITLE
Filter matrix expressions from runner label warnings

### DIFF
--- a/cmd/gh-actions-lock/format/json.go
+++ b/cmd/gh-actions-lock/format/json.go
@@ -21,7 +21,7 @@ func skipFindingInJSON(f checks.Finding) bool {
 	if f.Category == checks.Valid && f.Severity == checks.SeverityOK {
 		return true
 	}
-	if (f.Category == checks.LocalAction || f.Category == checks.SelfHostedRunner) && f.Severity != checks.SeverityError {
+	if (f.Category == checks.LocalAction || f.Category == checks.SelfHostedRunner || f.Category == checks.ExpressionRunner) && f.Severity != checks.SeverityError {
 		return true
 	}
 	return false

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -227,7 +227,7 @@ func extractBracketedLabels(s string) []string {
 
 // isExpression reports whether s is a GitHub Actions template expression.
 func isExpression(s string) bool {
-	return strings.Contains(s, "${{")
+	return strings.Contains(s, "${")
 }
 
 type warningGroup struct {

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -108,7 +108,7 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 		checks.LockfileForgery,
 		checks.RefChanged, checks.NotPinned, checks.OnboardingRequired,
 		checks.LocalAction,
-		checks.SelfHostedRunner,
+		checks.SelfHostedRunner, checks.ExpressionRunner,
 		checks.Stale, checks.MisleadingSHA, checks.ImpostorCommit,
 	} {
 		if n, ok := catCounts[cat]; ok {
@@ -266,7 +266,7 @@ func renderWarnings(out *ui.UI, report *checks.Report, willRemediate bool) {
 	}
 
 	// Triage warnings into buckets.
-	var unpinnedWorkflows, localActionWorkflows, selfHostedRunnerWorkflows, bareSHADeps, otherDetailWarnings []string
+	var unpinnedWorkflows, localActionWorkflows, selfHostedRunnerWorkflows, expressionRunnerWorkflows, bareSHADeps, otherDetailWarnings []string
 	for _, key := range warnOrder {
 		wg := warnMap[key]
 		f := wg.finding
@@ -275,6 +275,8 @@ func renderWarnings(out *ui.UI, report *checks.Report, willRemediate bool) {
 			localActionWorkflows = append(localActionWorkflows, f.WorkflowPath)
 		case f.Category == checks.SelfHostedRunner:
 			selfHostedRunnerWorkflows = append(selfHostedRunnerWorkflows, f.WorkflowPath)
+		case f.Category == checks.ExpressionRunner:
+			expressionRunnerWorkflows = append(expressionRunnerWorkflows, f.WorkflowPath)
 		case f.Category == checks.NotPinned && f.ActionRef == nil:
 			unpinnedWorkflows = append(unpinnedWorkflows, f.WorkflowPath)
 		case f.Category == checks.ShaAsRef:
@@ -328,6 +330,18 @@ func renderWarnings(out *ui.UI, report *checks.Report, willRemediate bool) {
 		} else {
 			out.TermDetail("↳ if these are org-hosted larger runners, re-run with --allow-runners <label>")
 		}
+	}
+	if len(expressionRunnerWorkflows) > 0 {
+		out.TermCaution("%d %s skipped — runs-on uses expressions that can't be resolved statically",
+			len(expressionRunnerWorkflows),
+			ui.Pluralize(len(expressionRunnerWorkflows), "workflow", "workflows"))
+		var wfNames []string
+		for _, p := range expressionRunnerWorkflows {
+			wfNames = append(wfNames, workflowName(p))
+		}
+		sort.Strings(wfNames)
+		out.TermDetail("↳ %s — if the matrix resolves to hosted runners, pin manually",
+			strings.Join(wfNames, ", "))
 	}
 	if len(unpinnedWorkflows) > 0 {
 		out.TermWarn("%d %s not yet pinned",

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -206,6 +206,8 @@ func workflowName(path string) string {
 
 // extractBracketedLabels pulls comma-separated items from the first
 // [...] group in s. Returns nil if no brackets are found.
+// Template expressions like ${{ matrix.os }} are excluded — they can't
+// be passed as literal --allow-runners values.
 func extractBracketedLabels(s string) []string {
 	start := strings.Index(s, "[")
 	end := strings.Index(s, "]")
@@ -216,11 +218,16 @@ func extractBracketedLabels(s string) []string {
 	var labels []string
 	for _, l := range strings.Split(inner, ",") {
 		l = strings.TrimSpace(l)
-		if l != "" {
+		if l != "" && !isExpression(l) {
 			labels = append(labels, l)
 		}
 	}
 	return labels
+}
+
+// isExpression reports whether s is a GitHub Actions template expression.
+func isExpression(s string) bool {
+	return strings.Contains(s, "${{")
 }
 
 type warningGroup struct {

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -327,6 +327,84 @@ func TestPresentResults_ParseWarningsSurface(t *testing.T) {
 	}
 }
 
+// TestPresentResults_SelfHostedRunnerHintExcludesExpressions verifies that
+// template expressions like ${{ matrix.os }} are excluded from the
+// --allow-runners remediation hint shown for self-hosted-runner warnings.
+func TestPresentResults_SelfHostedRunnerHintExcludesExpressions(t *testing.T) {
+	u, buf := newTestUI()
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{{
+			Path: ".github/workflows/ci.yml",
+			Findings: []checks.Finding{
+				{
+					WorkflowPath: ".github/workflows/ci.yml",
+					Category:     checks.SelfHostedRunner,
+					Severity:     checks.SeverityWarning,
+					Confidence:   checks.ConfidenceHigh,
+					Detail:       "non-hosted runner labels [${{ matrix.os }}, internal-runner]",
+				},
+			},
+		}},
+	}
+	PresentResults(u, report, true, false)
+
+	got := buf.String()
+	if strings.Contains(got, "matrix.os") {
+		t.Errorf("--allow-runners hint should not contain matrix expressions:\n%s", got)
+	}
+	if !strings.Contains(got, "internal-runner") {
+		t.Errorf("--allow-runners hint should contain literal labels:\n%s", got)
+	}
+}
+
+func TestExtractBracketedLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want []string
+	}{
+		{
+			name: "plain labels",
+			s:    "non-hosted runner labels [internal-runner, ubuntu-22.04-32core]",
+			want: []string{"internal-runner", "ubuntu-22.04-32core"},
+		},
+		{
+			name: "matrix expression filtered",
+			s:    "non-hosted runner labels [${{ matrix.os }}, internal-runner]",
+			want: []string{"internal-runner"},
+		},
+		{
+			name: "only expressions returns nil",
+			s:    "non-hosted runner labels [${{ matrix.os }}]",
+			want: nil,
+		},
+		{
+			name: "no brackets",
+			s:    "no brackets here",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractBracketedLabels(tt.s)
+			if len(tt.want) == 0 {
+				if len(got) != 0 {
+					t.Errorf("got %v, want nil/empty", got)
+				}
+			} else {
+				if len(got) != len(tt.want) {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+				for i := range tt.want {
+					if got[i] != tt.want[i] {
+						t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+					}
+				}
+			}
+		})
+	}
+}
+
 // TestPresentResults_RepoFindingsSurface guards repo-level warnings
 // (e.g. non-immutable releases) reach the terminal.
 func TestPresentResults_RepoFindingsSurface(t *testing.T) {

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -357,6 +357,58 @@ func TestPresentResults_SelfHostedRunnerHintExcludesExpressions(t *testing.T) {
 	}
 }
 
+// TestPresentResults_ExpressionRunnerWarning verifies that expression-only
+// workflows get their own distinct warning with workflow names and guidance.
+func TestPresentResults_ExpressionRunnerWarning(t *testing.T) {
+	u, buf := newTestUI()
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{
+			{
+				Path: ".github/workflows/ci.yaml",
+				Findings: []checks.Finding{{
+					WorkflowPath: ".github/workflows/ci.yaml",
+					Category:     checks.ExpressionRunner,
+					Severity:     checks.SeverityWarning,
+					Confidence:   checks.ConfidenceHigh,
+					Detail:       "runs-on uses expressions [${{ matrix.os }}] that can't be resolved statically",
+				}},
+			},
+			{
+				Path: ".github/workflows/maccloud-unified.yml",
+				Findings: []checks.Finding{{
+					WorkflowPath: ".github/workflows/maccloud-unified.yml",
+					Category:     checks.ExpressionRunner,
+					Severity:     checks.SeverityWarning,
+					Confidence:   checks.ConfidenceHigh,
+					Detail:       "runs-on uses expressions [${{ matrix.runner }}] that can't be resolved statically",
+				}},
+			},
+		},
+	}
+	PresentResults(u, report, true, false)
+
+	got := buf.String()
+	if !strings.Contains(got, "2 workflows skipped") {
+		t.Errorf("should show count of expression-runner workflows:\n%s", got)
+	}
+	if !strings.Contains(got, "expressions that can't be resolved statically") {
+		t.Errorf("should show expression-specific message:\n%s", got)
+	}
+	if !strings.Contains(got, "ci.yaml") {
+		t.Errorf("should list affected workflow names:\n%s", got)
+	}
+	if !strings.Contains(got, "maccloud-unified.yml") {
+		t.Errorf("should list affected workflow names:\n%s", got)
+	}
+	if !strings.Contains(got, "pin manually") {
+		t.Errorf("should show manual pinning guidance:\n%s", got)
+	}
+	// Should NOT show the --allow-runners hint (that's for real non-hosted labels).
+	if strings.Contains(got, "--allow-runners") {
+		t.Errorf("expression-runner warning should not suggest --allow-runners:\n%s", got)
+	}
+}
+
 func TestExtractBracketedLabels(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/pipeline/checks/category.go
+++ b/internal/pipeline/checks/category.go
@@ -70,10 +70,15 @@ const (
 	// skipped.
 	LocalAction Category = "local-action"
 	// SelfHostedRunner means at least one job in the workflow uses a
-	// non-GitHub-hosted runner label (self-hosted, custom label, runner
-	// group, or expression-based runs-on). Lockfile onboarding is limited
-	// to workflows that run entirely on GitHub-hosted runners.
+	// non-GitHub-hosted runner label (self-hosted, custom label, or runner
+	// group). Lockfile onboarding is limited to workflows that run
+	// entirely on GitHub-hosted runners.
 	SelfHostedRunner Category = "self-hosted-runner"
+	// ExpressionRunner means the workflow's runs-on uses a template
+	// expression (e.g. ${{ matrix.os }}) that can't be resolved
+	// statically. The workflow is skipped because we can't verify
+	// the labels at parse time.
+	ExpressionRunner Category = "expression-runner"
 )
 
 // IsInconclusive reports whether c represents a diagnostic that

--- a/internal/pipeline/checks/finding.go
+++ b/internal/pipeline/checks/finding.go
@@ -78,7 +78,7 @@ func (r *WorkflowReport) NeedsAttention() bool {
 			continue
 		}
 		switch f.Category {
-		case Valid, RunOnly, LocalAction, SelfHostedRunner, MisleadingSHA, RefMoved, VersionRef:
+		case Valid, RunOnly, LocalAction, SelfHostedRunner, ExpressionRunner, MisleadingSHA, RefMoved, VersionRef:
 			continue
 		default:
 			return true
@@ -107,7 +107,7 @@ func (f *Finding) IsValid() bool {
 		return true
 	}
 	switch f.Category {
-	case Valid, RunOnly, LocalAction, SelfHostedRunner, ShaAsRef, RefMoved, VersionRef, OnboardingRequired:
+	case Valid, RunOnly, LocalAction, SelfHostedRunner, ExpressionRunner, ShaAsRef, RefMoved, VersionRef, OnboardingRequired:
 		return true
 	case NotPinned:
 		return f.ActionRef == nil // workflow-level is a warning
@@ -128,7 +128,7 @@ func (f *Finding) IsWarning() bool {
 	case f.Category == SelfHostedRunner:
 		return f.Severity != SeverityError
 	case f.Category == ExpressionRunner:
-		return true
+		return f.Severity != SeverityError
 	case f.Category.IsInconclusive():
 		return true
 	case f.Category == NotPinned && f.ActionRef == nil:

--- a/internal/pipeline/checks/finding.go
+++ b/internal/pipeline/checks/finding.go
@@ -127,6 +127,8 @@ func (f *Finding) IsWarning() bool {
 		return f.Severity != SeverityError
 	case f.Category == SelfHostedRunner:
 		return f.Severity != SeverityError
+	case f.Category == ExpressionRunner:
+		return true
 	case f.Category.IsInconclusive():
 		return true
 	case f.Category == NotPinned && f.ActionRef == nil:

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -90,7 +90,30 @@ func diagnoseOneParsed(ctx context.Context, pw checks.ParsedWorkflow, r *resolve
 	}
 
 	if pw.NonHostedRunner {
-		labelList := strings.Join(pw.NonHostedLabels, ", ")
+		// Split labels into expressions vs literal non-hosted labels.
+		var exprLabels, literalLabels []string
+		for _, l := range pw.NonHostedLabels {
+			if strings.Contains(l, "${{") {
+				exprLabels = append(exprLabels, l)
+			} else {
+				literalLabels = append(literalLabels, l)
+			}
+		}
+
+		// If all non-hosted labels are expressions, use ExpressionRunner.
+		if len(literalLabels) == 0 {
+			wr.Findings = append(wr.Findings, checks.Finding{
+				WorkflowPath: pw.Path,
+				Category:     checks.ExpressionRunner,
+				Severity:     checks.SeverityWarning,
+				Confidence:   checks.ConfidenceHigh,
+				Detail:       fmt.Sprintf("runs-on uses expressions [%s] that can't be resolved statically", strings.Join(exprLabels, ", ")),
+			})
+			return wr
+		}
+
+		// Otherwise report as self-hosted (include only literal labels in detail).
+		labelList := strings.Join(literalLabels, ", ")
 		wfKey := workflowfile.KeyFromPath(pw.Path)
 		if store != nil && store.HasWorkflow(wfKey) {
 			wr.Findings = append(wr.Findings, checks.Finding{

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -93,7 +93,7 @@ func diagnoseOneParsed(ctx context.Context, pw checks.ParsedWorkflow, r *resolve
 		// Split labels into expressions vs literal non-hosted labels.
 		var exprLabels, literalLabels []string
 		for _, l := range pw.NonHostedLabels {
-			if strings.Contains(l, "${{") {
+			if strings.Contains(l, "${") {
 				exprLabels = append(exprLabels, l)
 			} else {
 				literalLabels = append(literalLabels, l)


### PR DESCRIPTION
When `runs-on` uses a template expression like `${{ matrix.os }}`, the tool
previously lumped it into the self-hosted-runner bucket. This was confusing:
the `--allow-runners` hint would print raw `${{ matrix.os }}` as a label to
pass, and users couldn't tell whether a workflow was skipped because it uses
a real custom runner vs. a dynamic expression that might resolve to a hosted
runner at runtime.

**Changes:**

- `extractBracketedLabels` now filters out `${{ }}` expressions so the
  `--allow-runners` hint only shows actionable literal labels
- New `ExpressionRunner` category splits expression-based `runs-on` into its
  own warning with distinct messaging and guidance:
  ```
  ! 1 workflow skipped -- runs-on uses expressions that can't be resolved statically
   ↳ build-fluent-bit.yml -- if the matrix resolves to hosted runners, pin manually
  ```
- JSON output filter updated to suppress expression-runner warnings (same
  treatment as local-action and self-hosted-runner)
- `IsWarning()` extended to recognize the new category

The self-hosted-runner warning is now reserved for literal non-hosted labels
only, keeping the `--allow-runners` remediation hint clean and actionable.