### PR TITLE
Add sentinel comment to managed workflow files

### DIFF
--- a/internal/pin/commit.go
+++ b/internal/pin/commit.go
@@ -1,6 +1,7 @@
 package pin
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -81,18 +82,23 @@ func Commit(ctx context.Context, rec *Record, store *lockfile.State, copts *Comm
 }
 
 func rewriteWorkflow(wp WorkflowPlan) error {
-	if len(wp.Rewrites) == 0 {
-		return nil
-	}
 	wf, err := workflowfile.Load(wp.Path)
 	if err != nil {
 		return err
 	}
-	content, _, err := wf.RewriteActionRefs(wp.Rewrites)
-	if err != nil {
-		return fmt.Errorf("applying rewrites: %w", err)
+
+	content := wf.Content
+	if len(wp.Rewrites) > 0 {
+		content, _, err = wf.RewriteActionRefs(wp.Rewrites)
+		if err != nil {
+			return fmt.Errorf("applying rewrites: %w", err)
+		}
 	}
+
 	content = workflowfile.EnsureSentinel(content)
+	if bytes.Equal(content, wf.Content) {
+		return nil
+	}
 	return os.WriteFile(wp.Path, content, 0o644)
 }
 

--- a/internal/pin/commit.go
+++ b/internal/pin/commit.go
@@ -92,6 +92,7 @@ func rewriteWorkflow(wp WorkflowPlan) error {
 	if err != nil {
 		return fmt.Errorf("applying rewrites: %w", err)
 	}
+	content = workflowfile.EnsureSentinel(content)
 	return os.WriteFile(wp.Path, content, 0o644)
 }
 

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -119,9 +119,8 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 
 	if !wr.NeedsAttention() {
 		entries = verifiedEntries(inventory, wr.Path)
-		if rw := narrowVerifiedEntries(ctx, entries, opts); len(rw) > 0 {
-			wplans = append(wplans, WorkflowPlan{Path: wr.Path, Rewrites: rw})
-		}
+		rw := narrowVerifiedEntries(ctx, entries, opts)
+		wplans = append(wplans, WorkflowPlan{Path: wr.Path, Rewrites: rw})
 		return planResult{entries: entries, wplans: wplans}, nil
 	}
 
@@ -130,9 +129,8 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	entries = verifiedEntries(inventory, wr.Path)
 
 	if len(unrecordedRefs) == 0 {
-		if rw := narrowVerifiedEntries(ctx, entries, opts); len(rw) > 0 {
-			wplans = append(wplans, WorkflowPlan{Path: wr.Path, Rewrites: rw})
-		}
+		rw := narrowVerifiedEntries(ctx, entries, opts)
+		wplans = append(wplans, WorkflowPlan{Path: wr.Path, Rewrites: rw})
 		return planResult{entries: entries, wplans: wplans}, nil
 	}
 
@@ -172,6 +170,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 			})
 		}
 		if len(deps) == 0 {
+			wplans = append(wplans, WorkflowPlan{Path: wr.Path})
 			return planResult{entries: entries, wplans: wplans}, nil
 		}
 		// Fall through with partial deps to pin what we can.
@@ -241,6 +240,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	if len(badKeys) > 0 {
 		deps, parentMap = dropDeps(deps, parentMap, badKeys)
 		if len(deps) == 0 {
+			wplans = append(wplans, WorkflowPlan{Path: wr.Path})
 			return planResult{entries: entries, wplans: wplans}, nil
 		}
 	}
@@ -374,6 +374,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 				Reason:     imp.Error(),
 				Workflows:  []string{wr.Path},
 			})
+			wplans = append(wplans, WorkflowPlan{Path: wr.Path})
 			return planResult{entries: entries, wplans: wplans}, nil
 		}
 		return planResult{}, fmt.Errorf("reverse lookup: %w", err)
@@ -432,6 +433,10 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 			Path:     wr.Path,
 			Rewrites: rewrites,
 		})
+	} else if len(wplans) == 0 {
+		// No rewrites and no plan entry yet — still include the workflow
+		// so EnsureSentinel can be applied during commit.
+		wplans = append(wplans, WorkflowPlan{Path: wr.Path})
 	}
 
 	// Load existing lockfile state so re-runs are noops for unchanged deps.

--- a/internal/workflowfile/rewrite.go
+++ b/internal/workflowfile/rewrite.go
@@ -12,10 +12,10 @@ import (
 const SentinelComment = "# This workflow is managed by gh actions-lock."
 
 // EnsureSentinel prepends the sentinel comment to the workflow content if it
-// is not already present. The comment is placed before any existing content
-// with a blank line separating it from the rest of the file.
+// is not already present at the top of the file. The comment is placed before
+// any existing content with a blank line separating it from the YAML body.
 func EnsureSentinel(content []byte) []byte {
-	if bytes.Contains(content, []byte(SentinelComment)) {
+	if bytes.HasPrefix(content, []byte(SentinelComment)) {
 		return content
 	}
 

--- a/internal/workflowfile/rewrite.go
+++ b/internal/workflowfile/rewrite.go
@@ -1,10 +1,36 @@
 package workflowfile
 
 import (
+	"bytes"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// SentinelComment is prepended to workflow files managed by gh actions-lock
+// so users can tell at a glance that the file's action refs are locked.
+const SentinelComment = "# This workflow is managed by gh actions-lock."
+
+// EnsureSentinel prepends the sentinel comment to the workflow content if it
+// is not already present. The comment is placed before any existing content
+// with a blank line separating it from the rest of the file.
+func EnsureSentinel(content []byte) []byte {
+	if bytes.Contains(content, []byte(SentinelComment)) {
+		return content
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(SentinelComment)
+	buf.WriteByte('\n')
+
+	// If the file doesn't start with a comment or blank line, add a
+	// separator so the sentinel stands apart from the YAML body.
+	if len(content) > 0 && content[0] != '#' && content[0] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.Write(content)
+	return buf.Bytes()
+}
 
 // RewriteActionRefs rewrites targeted uses: refs in the original workflow
 // content while preserving the surrounding formatting and comments.

--- a/internal/workflowfile/rewrite_test.go
+++ b/internal/workflowfile/rewrite_test.go
@@ -35,6 +35,11 @@ func TestEnsureSentinel(t *testing.T) {
 			input: "",
 			want:  SentinelComment + "\n",
 		},
+		{
+			name:  "sentinel buried in file still prepends",
+			input: "name: ci\n# This workflow is managed by gh actions-lock.\non: push\n",
+			want:  SentinelComment + "\n\nname: ci\n# This workflow is managed by gh actions-lock.\non: push\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/workflowfile/rewrite_test.go
+++ b/internal/workflowfile/rewrite_test.go
@@ -9,6 +9,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEnsureSentinel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "adds sentinel to plain workflow",
+			input: "name: ci\non: push\n",
+			want:  SentinelComment + "\n\nname: ci\non: push\n",
+		},
+		{
+			name:  "adds sentinel before existing comment",
+			input: "# my workflow\nname: ci\n",
+			want:  SentinelComment + "\n# my workflow\nname: ci\n",
+		},
+		{
+			name:  "idempotent when sentinel already present",
+			input: SentinelComment + "\n\nname: ci\n",
+			want:  SentinelComment + "\n\nname: ci\n",
+		},
+		{
+			name:  "empty content",
+			input: "",
+			want:  SentinelComment + "\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EnsureSentinel([]byte(tt.input))
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
 func TestSubpathRewriteLookup(t *testing.T) {
 	replacements := map[string]string{
 		"actions/cache@27d5ce7": "actions/cache@v5.0.5",


### PR DESCRIPTION
When `gh actions-lock` rewrites a workflow file to pin action refs, there's no
visible indicator that the file is under lockfile management. This makes it easy
for someone editing a workflow to not realize their `uses:` lines are locked and
will be overwritten on the next pin run.

This adds a sentinel comment -- `# This workflow is managed by gh actions-lock.`
-- prepended to workflow files during the commit phase. The comment is:

- **Idempotent**: skipped if the sentinel is already present, so re-pinning
  doesn't stack duplicate comments.
- **Minimal**: a single line at the top of the file, separated from the YAML
  body by a blank line (or merged with existing leading comments).
- **Scoped to rewrites**: only applied when `rewriteWorkflow` actually changes
  `uses:` lines -- workflows with no rewrites are untouched.

Inspired by [this Slack thread](https://github.slack.com/archives/C0B1DHQE7SP/p1781726782897549)
discussing how to signal lockfile management at a glance.