### PR TITLE
lint action: build from source with goproxy

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -65,7 +65,7 @@ dependencies:
             - 'actions/setup-go@v5'
     'github/gh-actions-lock@main':
         ref: 'main'
-        commit: 'sha1-592be5e0bff8d8cc3a624138d255606596cebc7f'
+        commit: 'sha1-419a59e0d36ec15d649200df42e3092fa0c117b7'
         owner_id: 9919
         repo_id: 1217640442
     'github/setup-goproxy@v1.1.0':

--- a/actions/lint/action.yml
+++ b/actions/lint/action.yml
@@ -10,18 +10,29 @@ inputs:
     description: Comma-separated finding categories to treat as warnings instead of errors (e.g. "local-action")
     required: false
     default: ""
+  token:
+    description: GitHub token used by gh actions-lock for API calls. Defaults to github.token.
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
   steps:
-    - name: Install gh-actions-lock
+    - name: OIDC Setup for goproxy
+      uses: github/setup-goproxy@v1.1.0
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: ${{ github.action_path }}/../../go.mod
+
+    - name: Build gh-actions-lock
       shell: bash
-      run: gh extension install github/gh-actions-lock
-      env:
-        GH_TOKEN: ${{ github.token }}
+      run: |
+        cd "${{ github.action_path }}/../.."
+        go build -o "$RUNNER_TEMP/gh-actions-lock" ./cmd/gh-actions-lock
 
     - name: Check lockfile is in sync
       shell: bash
-      run: ${{ github.action_path }}/../../script/lockfile-lint.sh "gh actions-lock" "${{ inputs.ignore-categories }}" ${{ inputs.extra-flags }}
+      run: ${{ github.action_path }}/../../script/lockfile-lint.sh "$RUNNER_TEMP/gh-actions-lock" "${{ inputs.ignore-categories }}" ${{ inputs.extra-flags }}
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
Build gh-actions-lock from source instead of `gh extension install`. Avoids cross-repo token issues since the action source is already checked out when referenced as `github/gh-actions-lock/actions/lint@main`. Hack until this repo is public.

Changes:
- Replace `gh extension install` with `go build` from the checked-out source
- Add `github/setup-goproxy` for private Go dependency access
- Add `token` input for API calls (defaults to `github.token`)
- Add `ignore-categories` input (from PR #63)