### PR TITLE
relock: regenerate lockfile, fix test.yml permissions

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -7,9 +7,6 @@ workflows:
         - 'actions/checkout@v6.0.2'
         - 'cli/gh-extension-precompile@v2.1.0'
         - 'github/setup-goproxy@v1.1.0'
-    '.github/workflows/relock.yml':
-        - 'actions/checkout@v6.0.2'
-        - 'github/gh-actions-lock@main'
     '.github/workflows/sync-early-access-release.yml':
         - 'actions/checkout@v6.0.2'
     '.github/workflows/test.yml':
@@ -66,9 +63,12 @@ dependencies:
             - 'actions/setup-go@v5'
     'github/gh-actions-lock@main':
         ref: 'main'
-        commit: 'sha1-da8ddbe47a719ba4dd60cde61bb96c4301b98e61'
+        commit: 'sha1-6a5ff0d2d272de25b8db0223191fd13fc0b11aab'
         owner_id: 9919
         repo_id: 1217640442
+        uses:
+            - 'actions/setup-go@v5'
+            - 'github/setup-goproxy@v1.1.0'
     'github/setup-goproxy@v1.1.0':
         ref: 'v1.1.0'
         commit: 'sha1-5e60e1074d42316dfe2949ebf9a92bf77b24645b'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5.0.1
       - uses: github/gh-actions-lock/actions/lint@main


### PR DESCRIPTION
Regenerated lockfile from scratch after PR #65 removed `relock.yml` and changed action references.

Changes:
- `test.yml`: uses `github/gh-actions-lock/actions/lint@main` (lockable, no local action)
- `test.yml`: added `id-token: write` for goproxy OIDC in the lint job
- Lockfile regenerated — removes stale `relock.yml` entry, properly tracks `gh-actions-lock@main` for `test.yml`