### PR TITLE
Block composite local paths and detect transitive ref-moved

### DIFF
--- a/internal/pipeline/checks/misleading.go
+++ b/internal/pipeline/checks/misleading.go
@@ -52,6 +52,15 @@ func checkMisleadingSha(ctx context.Context, pw ParsedWorkflow, r CheckResolver)
 // lockfile-tampering claim is stronger.
 func checkRefMovedAndForgery(ctx context.Context, pw ParsedWorkflow, depIndex map[string]lockedPin, r CheckResolver) []Finding {
 	var out []Finding
+
+	// Build a set of index keys already covered by direct refs so we don't
+	// double-check them when iterating transitive deps below.
+	directKeys := make(map[string]bool, len(pw.Refs))
+	for _, ref := range pw.Refs {
+		directKeys[parserlock.IndexKey(ref.Owner, ref.Repo, ref.Ref)] = true
+	}
+
+	// Check direct refs from the workflow file.
 	for _, ref := range pw.Refs {
 		if parserlock.IsFullSha(ref.Ref) {
 			continue
@@ -60,50 +69,72 @@ func checkRefMovedAndForgery(ctx context.Context, pw ParsedWorkflow, depIndex ma
 		if !ok {
 			continue
 		}
-		sha, ok := r.ResolveRef(ref.Owner, ref.Repo, ref.Ref)
-		if !ok || sha == "" {
-			continue
-		}
-		if strings.EqualFold(sha, pin.SHA()) {
-			continue
-		}
-		ancestry, ancestryDetail := r.CheckAncestry(ctx, ref.Owner, ref.Repo, pin.SHA(), sha)
-		f := newRefFinding(pw, ref, "", "", "")
-		f.ObservedSHA = sha
-		f.Dependency = synthDep(ref, pin.SHA())
-		switch ancestry {
-		case resolve.AncestryNotAncestor:
-			// Compare API gave an authoritative not-an-ancestor verdict.
-			// Forgery wins: don't double-flag with an observed-SHA
-			f.Category = LockfileForgery
-			f.Severity = SeverityError
-			f.Confidence = ConfidenceHigh
-			f.Detail = fmt.Sprintf("pinned %s is not an ancestor of %s — lockfile may have been tampered with", parserlock.ShortSHA(pin.SHA()), parserlock.ShortSHA(sha))
-			f.Remediation = "investigate immediately — verify the lockfile entry against upstream history"
-			out = append(out, f)
-		case resolve.AncestryUnknown:
-			// Compare API didn't reach a verdict — typically rate-limited
-			// even after CheckAncestry's bounded retry. Surface as its
-			// own category so consumers don't conflate inconclusive with
-			// benign, and append the resolver's detail so the operator
-			// sees why.
-			f.Category = AncestryUnknown
-			f.Severity = SeverityWarning
-			f.Confidence = ConfidenceMedium
-			f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s (ancestry check inconclusive%s)", ref.Ref, parserlock.ShortSHA(sha), parserlock.ShortSHA(pin.SHA()), suffixWith(ancestryDetail))
-			f.Remediation = "retry when the Compare API is available to classify this as ref-moved or lockfile-forgery"
-			out = append(out, f)
-		default:
-			// AncestryConfirmed: routine release.
-			f.Category = RefMoved
-			f.Severity = SeverityWarning
-			f.Confidence = ConfidenceHigh
-			f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s", ref.Ref, parserlock.ShortSHA(sha), parserlock.ShortSHA(pin.SHA()))
-			f.Remediation = "re-run `gh actions-lock` to refresh the lock entry"
+		if f, ok := checkOneRefMoved(ctx, pw, ref, pin, r); ok {
 			out = append(out, f)
 		}
 	}
+
+	// Check transitive deps (recorded in lockfile but not directly in the
+	// workflow). These can also drift when upstream releases new versions.
+	for indexKey, pin := range depIndex {
+		if directKeys[indexKey] {
+			continue
+		}
+		parsed, ok := parserlock.ParsePin(indexKey)
+		if !ok {
+			continue
+		}
+		if parserlock.IsFullSha(parsed.Ref) {
+			continue
+		}
+		ref := parserlock.ActionRef{
+			Owner: parsed.Owner,
+			Repo:  parsed.Repo,
+			Ref:   parsed.Ref,
+		}
+		if f, ok := checkOneRefMoved(ctx, pw, ref, pin, r); ok {
+			out = append(out, f)
+		}
+	}
+
 	return out
+}
+
+// checkOneRefMoved resolves a single ref and compares against the pinned SHA.
+// Returns a finding and true if there's a mismatch; false if the ref is current.
+func checkOneRefMoved(ctx context.Context, pw ParsedWorkflow, ref parserlock.ActionRef, pin lockedPin, r CheckResolver) (Finding, bool) {
+	sha, ok := r.ResolveRef(ref.Owner, ref.Repo, ref.Ref)
+	if !ok || sha == "" {
+		return Finding{}, false
+	}
+	if strings.EqualFold(sha, pin.SHA()) {
+		return Finding{}, false
+	}
+	ancestry, ancestryDetail := r.CheckAncestry(ctx, ref.Owner, ref.Repo, pin.SHA(), sha)
+	f := newRefFinding(pw, ref, "", "", "")
+	f.ObservedSHA = sha
+	f.Dependency = synthDep(ref, pin.SHA())
+	switch ancestry {
+	case resolve.AncestryNotAncestor:
+		f.Category = LockfileForgery
+		f.Severity = SeverityError
+		f.Confidence = ConfidenceHigh
+		f.Detail = fmt.Sprintf("pinned %s is not an ancestor of %s — lockfile may have been tampered with", parserlock.ShortSHA(pin.SHA()), parserlock.ShortSHA(sha))
+		f.Remediation = "investigate immediately — verify the lockfile entry against upstream history"
+	case resolve.AncestryUnknown:
+		f.Category = AncestryUnknown
+		f.Severity = SeverityWarning
+		f.Confidence = ConfidenceMedium
+		f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s (ancestry check inconclusive%s)", ref.Ref, parserlock.ShortSHA(sha), parserlock.ShortSHA(pin.SHA()), suffixWith(ancestryDetail))
+		f.Remediation = "retry when the Compare API is available to classify this as ref-moved or lockfile-forgery"
+	default:
+		f.Category = RefMoved
+		f.Severity = SeverityWarning
+		f.Confidence = ConfidenceHigh
+		f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s", ref.Ref, parserlock.ShortSHA(sha), parserlock.ShortSHA(pin.SHA()))
+		f.Remediation = "re-run `gh actions-lock` to refresh the lock entry"
+	}
+	return f, true
 }
 
 // suffixWith renders an optional detail as ": <detail>" for inline

--- a/internal/pipeline/checks/run_test.go
+++ b/internal/pipeline/checks/run_test.go
@@ -475,6 +475,64 @@ func TestRunChecks(t *testing.T) {
 			},
 			wantCategories: []Category{AncestryUnknown},
 		},
+		{
+			// Transitive dep ref-moved: actions/setup-go@v5 is in the
+			// lockfile (from a composite action) but NOT in the
+			// workflow's direct refs. Its upstream tag moved.
+			name: "transitive ref-moved: dep not in direct refs",
+			lockfile: map[string][]string{
+				wfPath: {
+					checkPinKey("actions", "checkout", "v4", shaCheckoutV4),
+					checkPinKey("actions", "setup-go", "v5", shaSetupGoV5),
+				},
+			},
+			workflowRefs: []parserlock.ActionRef{checkRef("actions", "checkout", "v4")},
+			resolver: &stubCheckResolver{
+				refs: map[stubRefKey]string{
+					{"actions", "checkout", "v4"}: shaCheckoutV4,
+					{"actions", "setup-go", "v5"}: shaCheckoutV3, // different SHA = moved
+				},
+				ancestry: map[stubAncestryKey]resolve.AncestryStatus{
+					{"actions", "setup-go", shaSetupGoV5, shaCheckoutV3}: resolve.AncestryConfirmed,
+				},
+			},
+			wantCategories: []Category{RefMoved, Stale},
+			extra: func(t *testing.T, got []Finding) {
+				for _, f := range got {
+					if f.Category == RefMoved {
+						if f.Dependency == nil || f.Dependency.SHA != shaSetupGoV5 {
+							t.Fatalf("expected transitive dep SHA %s, got %#v", shaSetupGoV5, got[0].Dependency)
+						}
+						return
+					}
+				}
+				t.Fatal("no ref-moved finding for transitive dep")
+			},
+		},
+		{
+			// Transitive dep not reported when it hasn't moved.
+			name: "transitive no finding: dep SHA matches upstream",
+			lockfile: map[string][]string{
+				wfPath: {
+					checkPinKey("actions", "checkout", "v4", shaCheckoutV4),
+					checkPinKey("actions", "setup-go", "v5", shaSetupGoV5),
+				},
+			},
+			workflowRefs: []parserlock.ActionRef{checkRef("actions", "checkout", "v4")},
+			resolver: &stubCheckResolver{
+				refs: map[stubRefKey]string{
+					{"actions", "checkout", "v4"}: shaCheckoutV4,
+					{"actions", "setup-go", "v5"}: shaSetupGoV5, // same = no drift
+				},
+			},
+			extra: func(t *testing.T, got []Finding) {
+				for _, f := range got {
+					if f.Category == RefMoved || f.Category == LockfileForgery || f.Category == AncestryUnknown {
+						t.Fatalf("unexpected ref-moved/forgery finding for current transitive dep: %#v", f)
+					}
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/pipeline/checks/run_test.go
+++ b/internal/pipeline/checks/run_test.go
@@ -501,7 +501,7 @@ func TestRunChecks(t *testing.T) {
 				for _, f := range got {
 					if f.Category == RefMoved {
 						if f.Dependency == nil || f.Dependency.SHA != shaSetupGoV5 {
-							t.Fatalf("expected transitive dep SHA %s, got %#v", shaSetupGoV5, got[0].Dependency)
+							t.Fatalf("expected transitive dep SHA %s, got %#v", shaSetupGoV5, f.Dependency)
 						}
 						return
 					}

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -67,6 +67,17 @@ func diagnoseOneParsed(ctx context.Context, pw checks.ParsedWorkflow, r *resolve
 		var resolveErr error
 		liveDeps, resolvedParents, resolveErr = r.ResolveAllRecursive(ctx, pw.Refs)
 		if resolveErr != nil {
+			if resolve.IsCompositeLocalPath(resolveErr) {
+				wr.Findings = append(wr.Findings, checks.Finding{
+					WorkflowPath: pw.Path,
+					Category:     checks.LocalAction,
+					Severity:     checks.SeverityError,
+					Confidence:   checks.ConfidenceHigh,
+					Detail:       fmt.Sprintf("a composite action uses local path actions whose transitive dependencies cannot be resolved: %s", resolveErr),
+					Remediation:  "the composite action must reference dependencies by owner/repo/path@ref instead of ./path",
+				})
+				return wr
+			}
 			// Low: we're surfacing the resolver failure itself, not a
 			// verdict about any specific dependency.
 			wr.Findings = append(wr.Findings, checks.Finding{

--- a/internal/resolve/discovery.go
+++ b/internal/resolve/discovery.go
@@ -13,6 +13,27 @@ import (
 	"github.com/github/gh-actions-lock/internal/pinpool"
 )
 
+// CompositeLocalPathError is returned when a remote composite action uses a
+// local path (./…) reference in its steps. We cannot resolve transitive
+// dependencies behind such references, so the workflow must be blocked.
+type CompositeLocalPathError struct {
+	// Parent is the NWO@Ref of the composite action containing the local path.
+	Parent string
+	// LocalPath is the ./… value found in the composite's steps.
+	LocalPath string
+}
+
+func (e *CompositeLocalPathError) Error() string {
+	return fmt.Sprintf("composite action %s uses local path %q which cannot be resolved for pinning", e.Parent, e.LocalPath)
+}
+
+// IsCompositeLocalPath reports whether err (or any error in its chain)
+// is a CompositeLocalPathError.
+func IsCompositeLocalPath(err error) bool {
+	var target *CompositeLocalPathError
+	return errors.As(err, &target)
+}
+
 // LatestRef returns the highest stable tag for an action repository.
 func (r *Resolver) LatestRef(ctx context.Context, owner, repo string) (string, error) {
 	key := ghapi.ForRepo(owner, repo)
@@ -147,6 +168,13 @@ func (r *Resolver) ResolveAllRecursive(ctx context.Context, refs []parserlock.Ac
 			// per tarball — same model the runner uses.
 			parentKey := deps[i].Key()
 			for _, use := range meta.NestedUses {
+				if strings.HasPrefix(use, "./") {
+					resolveErr = errors.Join(resolveErr, &CompositeLocalPathError{
+						Parent:    parentKey,
+						LocalPath: use,
+					})
+					continue
+				}
 				actionRef := parserlock.ParseActionRef(use)
 				if actionRef == nil {
 					continue

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -399,6 +399,38 @@ func TestResolveAllRecursiveTerminatesOnCycle(t *testing.T) {
 	}
 }
 
+func TestResolveAllRecursiveCompositeLocalPathError(t *testing.T) {
+	r := seedCache(&Resolver{
+		MaxRecursionDepth: DefaultMaxRecursionDepth,
+	}, map[ghapi.ActionRef]resolvedEntry{
+		ghapi.ForActionRef("owner", "composite", "", "v1"): {
+			dep:       dep.Dependency{NWO: "owner/composite", Ref: "v1", SHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			actionYML: "name: Composite\nruns:\n  using: composite\n  steps:\n    - uses: ./helper\n    - uses: actions/checkout@v6\n",
+		},
+		ghapi.ForActionRef("actions", "checkout", "", "v6"): {
+			dep:       dep.Dependency{NWO: "actions/checkout", Ref: "v6", SHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+			actionYML: "name: Checkout\nruns:\n  using: node20\n",
+		},
+	})
+
+	deps, _, err := r.ResolveAllRecursive(context.Background(), []parserlock.ActionRef{
+		{Owner: "owner", Repo: "composite", Ref: "v1"},
+	})
+	if err == nil {
+		t.Fatal("expected CompositeLocalPathError, got nil")
+	}
+	if !IsCompositeLocalPath(err) {
+		t.Fatalf("expected CompositeLocalPathError, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "./helper") {
+		t.Errorf("error should mention the local path, got: %v", err)
+	}
+	// Partial results should still be returned (checkout resolved).
+	if len(deps) < 2 {
+		t.Errorf("expected partial results with at least 2 deps, got %d", len(deps))
+	}
+}
+
 func TestNewAndLatestRef(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -428,6 +428,19 @@ scenarios:
       exit: 1
       output_contains: ["local path actions"]
 
+  - name: composite_local_path_blocked
+    category: workflow_parsing
+    description: "Remote composite using ./local-path internally — blocked because transitive deps are unresolvable"
+    needs_token: true
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions: ["nodeselector/actions-test-fixtures/composite-with-local-path@main"]
+    expect:
+      exit: 1
+      output_contains: ["local path actions", "composite"]
+
   - name: sub_path_action
     category: workflow_parsing
     description: "Sub-path action (actions/cache/restore@v4) handled"


### PR DESCRIPTION
When a remote composite action uses a local path reference (`./helper`), the BFS
in `ResolveAllRecursive` silently skipped it because `ParseActionRef` returns nil
for `./` prefixed uses. This meant transitive deps behind those local paths went
undetected -- no error, no warning, just a quiet gap in the lockfile.

Similarly, `checkRefMovedAndForgery` only iterated direct workflow refs (`pw.Refs`),
so transitive deps from composite actions were never checked for upstream drift.
A tag like `actions/setup-go@v6` could move to a new SHA and `--rescan` would
still report "All N workflows valid."

## Approach

**Composite local path blocking:**
- Added `CompositeLocalPathError` in `discovery.go` that fires when the BFS
  encounters a `./` prefixed uses in a remote composite's `NestedUses`
- `diagnoseOneParsed` catches this error and emits a `LocalAction` finding at
  error severity, short-circuiting further checks for that workflow
- Added a scenario test (`composite_local_path_blocked`) backed by a fixture in
  `nodeselector/actions-test-fixtures`

**Transitive ref-moved detection:**
- Refactored `checkRefMovedAndForgery` to extract per-ref logic into
  `checkOneRefMoved`, then call it for both direct refs and `depIndex` entries
  not already covered by a direct ref
- Added test cases for transitive ref-moved (positive and negative)

## Notes

- Ref-moved findings are `IsValid() -> true` (warning severity), so `--rescan`
  still reports valid. Terminal rendering intentionally swallows ref-moved warnings
  (line 288 of `terminal.go`) until an `update` subcommand exists. JSON output and
  resolution records do include them.