### PR TITLE
Fall back to anonymous REST when SSO blocks actions/* resolution

### DIFF
--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -1,0 +1,143 @@
+package ghapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ssoFallbackOwners lists orgs whose repos are public and can be resolved
+// without authentication when the user's token is SAML-blocked. This avoids
+// hard failures in environments (like Codespaces) where SSO authorization
+// isn't possible for cross-enterprise orgs.
+var ssoFallbackOwners = map[string]bool{
+	"actions": true,
+}
+
+// SSOFallbackEligible reports whether the given owner is eligible for
+// anonymous resolution when SSO blocks authenticated access.
+func SSOFallbackEligible(owner string) bool {
+	return ssoFallbackOwners[owner]
+}
+
+// resolveAnonymous fetches the commit SHA and action.yml content for a
+// single ref using unauthenticated REST calls. This only works for public
+// repos and is used as a fallback when SSO blocks the authenticated path.
+func (c *Client) resolveAnonymous(ctx context.Context, ref ActionFileRequest) ActionFileResult {
+	result := ActionFileResult{
+		Owner: ref.Owner,
+		Repo:  ref.Repo,
+		Path:  ref.Path,
+		Ref:   ref.Ref,
+	}
+
+	host := c.Hostname
+	if host == "" {
+		host = "github.com"
+	}
+	base := c.anonBaseURL
+	if base == "" {
+		base = fmt.Sprintf("https://api.%s", host)
+	}
+
+	// Resolve ref → commit SHA via the commits endpoint.
+	commitURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s",
+		base,
+		url.PathEscape(ref.Owner),
+		url.PathEscape(ref.Repo),
+		url.PathEscape(ref.Ref),
+	)
+	sha, err := anonGetCommitSHA(ctx, commitURL)
+	if err != nil {
+		result.Err = fmt.Errorf("anonymous fallback: %w", err)
+		return result
+	}
+	result.CommitOID = sha
+
+	// Fetch action.yml (try .yml first, then .yaml).
+	ymlPath := "action.yml"
+	yamlPath := "action.yaml"
+	if ref.Path != "" {
+		ymlPath = ref.Path + "/action.yml"
+		yamlPath = ref.Path + "/action.yaml"
+	}
+
+	content, err := anonGetFileContent(ctx, base, ref.Owner, ref.Repo, sha, ymlPath)
+	if err != nil {
+		// Try .yaml extension.
+		content, err = anonGetFileContent(ctx, base, ref.Owner, ref.Repo, sha, yamlPath)
+		if err != nil {
+			// Not fatal — some actions don't have action.yml (reusable workflows).
+			return result
+		}
+	}
+	result.ActionYML = content
+	return result
+}
+
+// anonGetCommitSHA fetches the commit SHA for a ref without authentication.
+func anonGetCommitSHA(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d resolving commit", resp.StatusCode)
+	}
+
+	var commit struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&commit); err != nil {
+		return "", fmt.Errorf("decoding commit response: %w", err)
+	}
+	if commit.SHA == "" {
+		return "", fmt.Errorf("empty SHA in response")
+	}
+	return commit.SHA, nil
+}
+
+// anonGetFileContent fetches a file's content from a public repo without auth.
+func anonGetFileContent(ctx context.Context, base, owner, repo, ref, path string) (string, error) {
+	u := fmt.Sprintf("%s/repos/%s/%s/contents/%s?ref=%s",
+		base,
+		url.PathEscape(owner),
+		url.PathEscape(repo),
+		path, // already safe for path use
+		url.QueryEscape(ref),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	// Request raw content directly to avoid base64 decoding.
+	req.Header.Set("Accept", "application/vnd.github.v3.raw")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, path)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+	return string(body), nil
+}

--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // ssoFallbackOwners lists orgs whose repos are public and can be resolved
@@ -23,6 +24,112 @@ func SSOFallbackEligible(owner string) bool {
 	return ssoFallbackOwners[owner]
 }
 
+// IsSAMLEnforcement reports whether err is a 403 caused by SAML/SSO
+// enforcement (as opposed to rate limiting or other permission issues).
+func IsSAMLEnforcement(err error) bool {
+	if err == nil {
+		return false
+	}
+	code, ok := StatusCode(err)
+	if !ok || code != http.StatusForbidden {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SAML enforcement") || strings.Contains(msg, "SAML SSO")
+}
+
+// anonBaseURL returns the base URL for anonymous REST calls.
+func (c *Client) anonBase() string {
+	if c.anonBaseURL != "" {
+		return c.anonBaseURL
+	}
+	host := c.Hostname
+	if host == "" {
+		host = "github.com"
+	}
+	return fmt.Sprintf("https://api.%s", host)
+}
+
+// anonGet performs an unauthenticated GET and decodes JSON into dest.
+func (c *Client) anonGet(ctx context.Context, path string, dest any) error {
+	u := c.anonBase() + "/" + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, path)
+	}
+	return json.NewDecoder(resp.Body).Decode(dest)
+}
+
+// anonListBranches fetches branches for a public repo without authentication.
+func (c *Client) anonListBranches(ctx context.Context, owner, repo string) ([]BranchHead, error) {
+	var all []BranchHead
+	for page := 1; page <= 3; page++ {
+		path := fmt.Sprintf("repos/%s/%s/branches?per_page=100&page=%d",
+			url.PathEscape(owner), url.PathEscape(repo), page)
+		var resp []struct {
+			Name   string `json:"name"`
+			Commit struct {
+				SHA string `json:"sha"`
+			} `json:"commit"`
+			Protected bool `json:"protected"`
+		}
+		if err := c.anonGet(ctx, path, &resp); err != nil {
+			return nil, fmt.Errorf("anonymous fallback listing branches for %s/%s: %w", owner, repo, err)
+		}
+		for _, b := range resp {
+			all = append(all, BranchHead{Name: b.Name, SHA: b.Commit.SHA, Protected: b.Protected})
+		}
+		if len(resp) < 100 {
+			break
+		}
+	}
+	return all, nil
+}
+
+// anonListTags fetches tags for a public repo without authentication.
+func (c *Client) anonListTags(ctx context.Context, owner, repo string) ([]TagEntry, error) {
+	path := fmt.Sprintf("repos/%s/%s/tags?per_page=100",
+		url.PathEscape(owner), url.PathEscape(repo))
+	var resp []struct {
+		Name   string `json:"name"`
+		Commit struct {
+			SHA string `json:"sha"`
+		} `json:"commit"`
+	}
+	if err := c.anonGet(ctx, path, &resp); err != nil {
+		return nil, fmt.Errorf("anonymous fallback listing tags for %s/%s: %w", owner, repo, err)
+	}
+	tags := make([]TagEntry, 0, len(resp))
+	for _, t := range resp {
+		tags = append(tags, TagEntry{Name: t.Name, SHA: t.Commit.SHA})
+	}
+	return tags, nil
+}
+
+// anonCompareCommits reports whether sha is an ancestor of branchHeadSHA
+// using unauthenticated REST.
+func (c *Client) anonCompareCommits(ctx context.Context, owner, repo, sha, branchHeadSHA string) (bool, error) {
+	path := fmt.Sprintf("repos/%s/%s/compare/%s...%s",
+		url.PathEscape(owner), url.PathEscape(repo),
+		url.PathEscape(sha), url.PathEscape(branchHeadSHA))
+	var resp compareResponse
+	if err := c.anonGet(ctx, path, &resp); err != nil {
+		return false, err
+	}
+	return strings.EqualFold(resp.MergeBaseCommit.SHA, sha), nil
+}
+
 // resolveAnonymous fetches the commit SHA and action.yml content for a
 // single ref using unauthenticated REST calls. This only works for public
 // repos and is used as a fallback when SSO blocks the authenticated path.
@@ -34,14 +141,7 @@ func (c *Client) resolveAnonymous(ctx context.Context, ref ActionFileRequest) Ac
 		Ref:   ref.Ref,
 	}
 
-	host := c.Hostname
-	if host == "" {
-		host = "github.com"
-	}
-	base := c.anonBaseURL
-	if base == "" {
-		base = fmt.Sprintf("https://api.%s", host)
-	}
+	base := c.anonBase()
 
 	// Resolve ref → commit SHA via the commits endpoint.
 	commitURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s",
@@ -114,7 +214,7 @@ func anonGetFileContent(ctx context.Context, base, owner, repo, ref, path string
 		base,
 		url.PathEscape(owner),
 		url.PathEscape(repo),
-		path, // already safe for path use
+		path,
 		url.QueryEscape(ref),
 	)
 
@@ -122,7 +222,6 @@ func anonGetFileContent(ctx context.Context, base, owner, repo, ref, path string
 	if err != nil {
 		return "", err
 	}
-	// Request raw content directly to avoid base64 decoding.
 	req.Header.Set("Accept", "application/vnd.github.v3.raw")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -30,14 +30,14 @@ func (c *Client) SSOFallbackEligible(ctx context.Context, owner string) bool {
 	probeURL := fmt.Sprintf("%s/orgs/%s", c.anonBase(), url.PathEscape(owner))
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, probeURL, nil)
 	if err != nil {
-		anonProbeCache.Store(key, false)
+		// Construction error — don't cache, let next call retry.
 		return false
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
 	resp, err := c.anonClient().Do(req)
 	if err != nil {
-		anonProbeCache.Store(key, false)
+		// Transport error (network, context canceled) — don't cache.
 		return false
 	}
 	resp.Body.Close()
@@ -288,11 +288,13 @@ func (c *Client) anonGetCommitSHA(ctx context.Context, url string) (string, erro
 
 // anonGetFileContent fetches a file's content from a public repo without auth.
 func (c *Client) anonGetFileContent(ctx context.Context, base, owner, repo, ref, path string) (string, error) {
+	// Escape each segment of the file path individually to preserve slashes.
+	escapedPath := escapeContentPath(path)
 	u := fmt.Sprintf("%s/repos/%s/%s/contents/%s?ref=%s",
 		base,
 		url.PathEscape(owner),
 		url.PathEscape(repo),
-		path,
+		escapedPath,
 		url.QueryEscape(ref),
 	)
 
@@ -317,4 +319,14 @@ func (c *Client) anonGetFileContent(ctx context.Context, base, owner, repo, ref,
 		return "", fmt.Errorf("reading %s: %w", path, err)
 	}
 	return string(body), nil
+}
+
+// escapeContentPath URL-escapes each segment of a slash-delimited file path,
+// preserving the slash separators.
+func escapeContentPath(p string) string {
+	segments := strings.Split(p, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return strings.Join(segments, "/")
 }

--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -47,18 +47,23 @@ func (c *Client) SSOFallbackEligible(ctx context.Context, owner string) bool {
 	return eligible
 }
 
-// IsSAMLEnforcement reports whether err is a 403 caused by SAML/SSO
-// enforcement (as opposed to rate limiting or other permission issues).
+// IsSAMLEnforcement reports whether err represents a SAML/SSO enforcement
+// block. It matches both REST 403s (api.HTTPError) and plain errors whose
+// message indicates SAML enforcement (e.g. from the GraphQL resolution path).
 func IsSAMLEnforcement(err error) bool {
 	if err == nil {
 		return false
 	}
-	code, ok := StatusCode(err)
-	if !ok || code != http.StatusForbidden {
-		return false
-	}
 	msg := err.Error()
-	return strings.Contains(msg, "SAML enforcement") || strings.Contains(msg, "SAML SSO")
+	if strings.Contains(msg, "SAML enforcement") || strings.Contains(msg, "SAML SSO") {
+		// For HTTPErrors, further verify it's a 403.
+		if code, ok := StatusCode(err); ok {
+			return code == http.StatusForbidden
+		}
+		// Plain errors from GraphQL SAML detection: trust the message.
+		return true
+	}
+	return false
 }
 
 // anonBase returns the base URL for anonymous REST calls.

--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -8,20 +8,43 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 )
 
-// ssoFallbackOwners lists orgs whose repos are public and can be resolved
-// without authentication when the user's token is SAML-blocked. This avoids
-// hard failures in environments (like Codespaces) where SSO authorization
-// isn't possible for cross-enterprise orgs.
-var ssoFallbackOwners = map[string]bool{
-	"actions": true,
-}
+// anonProbeCache caches per-owner results of anonymous access probes.
+// true = anonymous access confirmed working, false = not accessible.
+var anonProbeCache sync.Map // map[string]bool
 
-// SSOFallbackEligible reports whether the given owner is eligible for
-// anonymous resolution when SSO blocks authenticated access.
-func SSOFallbackEligible(owner string) bool {
-	return ssoFallbackOwners[owner]
+// SSOFallbackEligible reports whether the given owner's repos can be
+// accessed anonymously when SSO blocks authenticated access. On first
+// call for an owner, it probes the GitHub API with an unauthenticated
+// request to determine accessibility, then caches the result.
+func (c *Client) SSOFallbackEligible(ctx context.Context, owner string) bool {
+	key := c.anonBase() + "/" + owner
+	if v, ok := anonProbeCache.Load(key); ok {
+		return v.(bool)
+	}
+
+	// Probe: unauthenticated HEAD to /orgs/{owner} — 200 means the org
+	// is publicly visible and its public repos are anonymously accessible.
+	probeURL := fmt.Sprintf("%s/orgs/%s", c.anonBase(), url.PathEscape(owner))
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, probeURL, nil)
+	if err != nil {
+		anonProbeCache.Store(key, false)
+		return false
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		anonProbeCache.Store(key, false)
+		return false
+	}
+	resp.Body.Close()
+
+	eligible := resp.StatusCode == http.StatusOK
+	anonProbeCache.Store(key, eligible)
+	return eligible
 }
 
 // IsSAMLEnforcement reports whether err is a 403 caused by SAML/SSO

--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -159,6 +159,42 @@ func (c *Client) anonListTags(ctx context.Context, owner, repo string) ([]TagEnt
 	return tags, nil
 }
 
+// anonPeelTagObject determines whether sha is an annotated tag and, if so,
+// peels it to the underlying commit using unauthenticated REST.
+func (c *Client) anonPeelTagObject(ctx context.Context, owner, repo, sha string) (PeelTagObjectResult, error) {
+	// First, determine the object type via GET /repos/{owner}/{repo}/git/tags/{sha}.
+	// If it's not a tag (404), try the commit endpoint to confirm it's a commit.
+	tagPath := fmt.Sprintf("repos/%s/%s/git/tags/%s",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(sha))
+	var tagResp struct {
+		Object struct {
+			Type string `json:"type"`
+			SHA  string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := c.anonGet(ctx, tagPath, &tagResp); err == nil {
+		// It's an annotated tag — peel to the commit it points to.
+		result := PeelTagObjectResult{Typename: "Tag"}
+		if tagResp.Object.Type == "commit" {
+			result.CommitOID = tagResp.Object.SHA
+		}
+		return result, nil
+	}
+
+	// Not a tag object — check if it's a commit directly.
+	commitPath := fmt.Sprintf("repos/%s/%s/git/commits/%s",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(sha))
+	var commitResp struct {
+		SHA string `json:"sha"`
+	}
+	if err := c.anonGet(ctx, commitPath, &commitResp); err == nil {
+		return PeelTagObjectResult{Typename: "Commit", CommitOID: commitResp.SHA}, nil
+	}
+
+	// Can't determine type — return zero result like the GraphQL fallback.
+	return PeelTagObjectResult{}, nil
+}
+
 // anonCompareCommits reports whether sha is an ancestor of branchHeadSHA
 // using unauthenticated REST.
 func (c *Client) anonCompareCommits(ctx context.Context, owner, repo, sha, branchHeadSHA string) (bool, error) {

--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -35,7 +35,7 @@ func (c *Client) SSOFallbackEligible(ctx context.Context, owner string) bool {
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.anonClient().Do(req)
 	if err != nil {
 		anonProbeCache.Store(key, false)
 		return false
@@ -61,7 +61,9 @@ func IsSAMLEnforcement(err error) bool {
 	return strings.Contains(msg, "SAML enforcement") || strings.Contains(msg, "SAML SSO")
 }
 
-// anonBaseURL returns the base URL for anonymous REST calls.
+// anonBase returns the base URL for anonymous REST calls.
+// For stub-server hostnames (containing a port), it uses the hostname
+// directly without prepending "api.".
 func (c *Client) anonBase() string {
 	if c.anonBaseURL != "" {
 		return c.anonBaseURL
@@ -70,7 +72,19 @@ func (c *Client) anonBase() string {
 	if host == "" {
 		host = "github.com"
 	}
+	// Stub servers use IP:port — don't prepend "api." for those.
+	if strings.Contains(host, ":") {
+		return fmt.Sprintf("https://%s", host)
+	}
 	return fmt.Sprintf("https://api.%s", host)
+}
+
+// anonClient returns the HTTP client for anonymous requests.
+func (c *Client) anonClient() *http.Client {
+	if c.anonHTTP != nil {
+		return c.anonHTTP
+	}
+	return http.DefaultClient
 }
 
 // anonGet performs an unauthenticated GET and decodes JSON into dest.
@@ -82,7 +96,7 @@ func (c *Client) anonGet(ctx context.Context, path string, dest any) error {
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.anonClient().Do(req)
 	if err != nil {
 		return err
 	}
@@ -173,7 +187,7 @@ func (c *Client) resolveAnonymous(ctx context.Context, ref ActionFileRequest) Ac
 		url.PathEscape(ref.Repo),
 		url.PathEscape(ref.Ref),
 	)
-	sha, err := anonGetCommitSHA(ctx, commitURL)
+	sha, err := c.anonGetCommitSHA(ctx, commitURL)
 	if err != nil {
 		result.Err = fmt.Errorf("anonymous fallback: %w", err)
 		return result
@@ -188,10 +202,10 @@ func (c *Client) resolveAnonymous(ctx context.Context, ref ActionFileRequest) Ac
 		yamlPath = ref.Path + "/action.yaml"
 	}
 
-	content, err := anonGetFileContent(ctx, base, ref.Owner, ref.Repo, sha, ymlPath)
+	content, err := c.anonGetFileContent(ctx, base, ref.Owner, ref.Repo, sha, ymlPath)
 	if err != nil {
 		// Try .yaml extension.
-		content, err = anonGetFileContent(ctx, base, ref.Owner, ref.Repo, sha, yamlPath)
+		content, err = c.anonGetFileContent(ctx, base, ref.Owner, ref.Repo, sha, yamlPath)
 		if err != nil {
 			// Not fatal — some actions don't have action.yml (reusable workflows).
 			return result
@@ -202,14 +216,14 @@ func (c *Client) resolveAnonymous(ctx context.Context, ref ActionFileRequest) Ac
 }
 
 // anonGetCommitSHA fetches the commit SHA for a ref without authentication.
-func anonGetCommitSHA(ctx context.Context, url string) (string, error) {
+func (c *Client) anonGetCommitSHA(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.anonClient().Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -232,7 +246,7 @@ func anonGetCommitSHA(ctx context.Context, url string) (string, error) {
 }
 
 // anonGetFileContent fetches a file's content from a public repo without auth.
-func anonGetFileContent(ctx context.Context, base, owner, repo, ref, path string) (string, error) {
+func (c *Client) anonGetFileContent(ctx context.Context, base, owner, repo, ref, path string) (string, error) {
 	u := fmt.Sprintf("%s/repos/%s/%s/contents/%s?ref=%s",
 		base,
 		url.PathEscape(owner),
@@ -247,7 +261,7 @@ func anonGetFileContent(ctx context.Context, base, owner, repo, ref, path string
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3.raw")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.anonClient().Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/ghapi/anon_fallback_test.go
+++ b/internal/ghapi/anon_fallback_test.go
@@ -1,0 +1,120 @@
+package ghapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSSOFallbackEligible(t *testing.T) {
+	tests := []struct {
+		owner string
+		want  bool
+	}{
+		{"actions", true},
+		{"Actions", false}, // case-sensitive
+		{"github", false},
+		{"myorg", false},
+	}
+	for _, tt := range tests {
+		if got := SSOFallbackEligible(tt.owner); got != tt.want {
+			t.Errorf("SSOFallbackEligible(%q) = %v, want %v", tt.owner, got, tt.want)
+		}
+	}
+}
+
+func TestResolveActionFiles_SSOFallbackForActionsOrg(t *testing.T) {
+	// Stand up a fake API server for anonymous resolution.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/commits/"):
+			json.NewEncoder(w).Encode(map[string]string{"sha": "abc123def456abc123def456abc123def456abc1"})
+		case strings.Contains(r.URL.Path, "/contents/"):
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("name: checkout\ndescription: Checkout action"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	// GraphQL transport returns SAML error for actions/checkout.
+	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonHTTP(map[string]any{
+			"data": map[string]any{"a0": nil},
+			"errors": []map[string]any{
+				{
+					"message":    "Resource protected by organization SAML enforcement.",
+					"path":       []any{"a0"},
+					"extensions": map[string]any{"saml_failure": true},
+				},
+			},
+		})
+	})
+
+	c, err := New("github.com", WithClientTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Point anonymous calls at our test server instead of api.github.com.
+	c.Hostname = strings.TrimPrefix(srv.URL, "http://")
+	// Patch resolveAnonymous to use http:// scheme via a test override.
+	c.anonBaseURL = srv.URL
+
+	refs := []ActionFileRequest{
+		{Owner: "actions", Repo: "checkout", Ref: "v4"},
+	}
+
+	results := c.ResolveActionFiles(context.Background(), refs)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("expected anonymous fallback to succeed, got: %v", results[0].Err)
+	}
+	if results[0].CommitOID != "abc123def456abc123def456abc123def456abc1" {
+		t.Fatalf("expected resolved SHA, got %q", results[0].CommitOID)
+	}
+	if results[0].ActionYML != "name: checkout\ndescription: Checkout action" {
+		t.Fatalf("expected action.yml content, got %q", results[0].ActionYML)
+	}
+}
+
+func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
+	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonHTTP(map[string]any{
+			"data": map[string]any{"a0": nil},
+			"errors": []map[string]any{
+				{
+					"message":    "Resource protected by organization SAML enforcement.",
+					"path":       []any{"a0"},
+					"extensions": map[string]any{"saml_failure": true},
+				},
+			},
+		})
+	})
+
+	c, err := New("github.com", WithClientTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	refs := []ActionFileRequest{
+		{Owner: "mycompany", Repo: "private-action", Ref: "v1"},
+	}
+
+	results := c.ResolveActionFiles(context.Background(), refs)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err == nil {
+		t.Fatal("expected SSO error for non-actions org")
+	}
+	if !strings.Contains(results[0].Err.Error(), "SSO authorization required") {
+		t.Fatalf("expected SSO error, got: %v", results[0].Err)
+	}
+}
+

--- a/internal/ghapi/anon_fallback_test.go
+++ b/internal/ghapi/anon_fallback_test.go
@@ -6,30 +6,44 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 )
 
 func TestSSOFallbackEligible(t *testing.T) {
-	tests := []struct {
-		owner string
-		want  bool
-	}{
-		{"actions", true},
-		{"Actions", false}, // case-sensitive
-		{"github", false},
-		{"myorg", false},
-	}
-	for _, tt := range tests {
-		if got := SSOFallbackEligible(tt.owner); got != tt.want {
-			t.Errorf("SSOFallbackEligible(%q) = %v, want %v", tt.owner, got, tt.want)
+	// Stand up a server that returns 200 for /orgs/actions and 404 for others.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/actions":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
 		}
+	}))
+	defer srv.Close()
+
+	c := &Client{Hostname: "github.com", anonBaseURL: srv.URL}
+	ctx := context.Background()
+
+	// Reset the global cache between subtests.
+	anonProbeCache = sync.Map{}
+
+	if !c.SSOFallbackEligible(ctx, "actions") {
+		t.Error("expected actions org to be eligible")
+	}
+	if c.SSOFallbackEligible(ctx, "myorg") {
+		t.Error("expected myorg to NOT be eligible")
 	}
 }
 
 func TestResolveActionFiles_SSOFallbackForActionsOrg(t *testing.T) {
+	anonProbeCache = sync.Map{} // reset cache
+
 	// Stand up a fake API server for anonymous resolution.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.URL.Path == "/orgs/actions":
+			w.WriteHeader(http.StatusOK)
 		case strings.Contains(r.URL.Path, "/commits/"):
 			json.NewEncoder(w).Encode(map[string]string{"sha": "abc123def456abc123def456abc123def456abc1"})
 		case strings.Contains(r.URL.Path, "/contents/"):
@@ -84,6 +98,14 @@ func TestResolveActionFiles_SSOFallbackForActionsOrg(t *testing.T) {
 }
 
 func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
+	anonProbeCache = sync.Map{} // reset cache
+
+	// Probe server: returns 404 for /orgs/mycompany (private org).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
 	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return jsonHTTP(map[string]any{
 			"data": map[string]any{"a0": nil},
@@ -101,6 +123,7 @@ func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	c.anonBaseURL = srv.URL
 
 	refs := []ActionFileRequest{
 		{Owner: "mycompany", Repo: "private-action", Ref: "v1"},

--- a/internal/ghapi/anon_fallback_test.go
+++ b/internal/ghapi/anon_fallback_test.go
@@ -140,4 +140,3 @@ func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
 		t.Fatalf("expected SSO error, got: %v", results[0].Err)
 	}
 }
-

--- a/internal/ghapi/client.go
+++ b/internal/ghapi/client.go
@@ -29,6 +29,10 @@ type Client struct {
 	rest     *api.RESTClient
 	Hostname string
 
+	// anonBaseURL overrides the base URL for anonymous REST fallback calls.
+	// Empty uses the default "https://api.<Hostname>". Set in tests.
+	anonBaseURL string
+
 	// Caches for raw GitHub resources. These live here so all consumers
 	// (resolver, auditor, tag lister) share a single cache per CLI run.
 	compareCache         syncmap.Map[Compare, bool]

--- a/internal/ghapi/client.go
+++ b/internal/ghapi/client.go
@@ -33,6 +33,11 @@ type Client struct {
 	// Empty uses the default "https://api.<Hostname>". Set in tests.
 	anonBaseURL string
 
+	// anonHTTP is the HTTP client used for anonymous (unauthenticated)
+	// fallback requests. Configured at construction to honor
+	// GH_ACTIONS_LOCK_INSECURE (TLS skip) for integration tests.
+	anonHTTP *http.Client
+
 	// Caches for raw GitHub resources. These live here so all consumers
 	// (resolver, auditor, tag lister) share a single cache per CLI run.
 	compareCache         syncmap.Map[Compare, bool]
@@ -122,6 +127,19 @@ func New(hostname string, opts ...ClientOption) (*Client, error) {
 
 	c.graphql = gql
 	c.rest = rest
+
+	// Build anonymous HTTP client for SSO fallback. Respects the same
+	// insecure TLS setting as the main client for integration tests.
+	if os.Getenv("GH_ACTIONS_LOCK_INSECURE") != "" {
+		c.anonHTTP = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // integration tests only
+			},
+		}
+	} else {
+		c.anonHTTP = http.DefaultClient
+	}
+
 	return c, nil
 }
 

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -97,7 +97,7 @@ func (c *Client) retrySSOWithAnonymous(ctx context.Context, refs []ActionFileReq
 		if r.Err == nil || ctx.Err() != nil {
 			continue
 		}
-		if !SSOFallbackEligible(refs[i].Owner) {
+		if !c.SSOFallbackEligible(ctx, refs[i].Owner) {
 			continue
 		}
 		if !strings.Contains(r.Err.Error(), "SSO authorization required") {

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -69,7 +69,7 @@ func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileReques
 	}
 	results, batchErr := c.resolveActionFilesOnce(ctx, refs)
 	if batchErr == nil || len(refs) == 1 || ctx.Err() != nil {
-		return results
+		return c.retrySSOWithAnonymous(ctx, refs, results)
 	}
 	mid := len(refs) / 2
 	left := c.ResolveActionFiles(ctx, refs[:mid])
@@ -88,6 +88,24 @@ func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileReques
 	}
 	right := c.ResolveActionFiles(ctx, refs[mid:])
 	return append(left, right...)
+}
+
+// retrySSOWithAnonymous retries refs that failed with SSO errors for
+// fallback-eligible orgs (e.g. actions/*) using unauthenticated REST.
+func (c *Client) retrySSOWithAnonymous(ctx context.Context, refs []ActionFileRequest, results []ActionFileResult) []ActionFileResult {
+	for i, r := range results {
+		if r.Err == nil || ctx.Err() != nil {
+			continue
+		}
+		if !SSOFallbackEligible(refs[i].Owner) {
+			continue
+		}
+		if !strings.Contains(r.Err.Error(), "SSO authorization required") {
+			continue
+		}
+		results[i] = c.resolveAnonymous(ctx, refs[i])
+	}
+	return results
 }
 
 // resolveActionFilesOnce performs one batched round-trip. The returned error is

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -100,7 +100,7 @@ func (c *Client) retrySSOWithAnonymous(ctx context.Context, refs []ActionFileReq
 		if !c.SSOFallbackEligible(ctx, refs[i].Owner) {
 			continue
 		}
-		if !strings.Contains(r.Err.Error(), "SSO authorization required") {
+		if !IsSAMLEnforcement(r.Err) {
 			continue
 		}
 		results[i] = c.resolveAnonymous(ctx, refs[i])

--- a/internal/ghapi/graphql_peel.go
+++ b/internal/ghapi/graphql_peel.go
@@ -50,6 +50,10 @@ func (c *Client) PeelTagObject(ctx context.Context, owner, repo, sha string) (Pe
 		"expr":  sha + "^{commit}",
 	}
 	if err := c.graphql.DoWithContext(profile.WithGraphQLLabel(ctx, "peel"), tagObjectPeelQuery, vars, &resp); err != nil {
+		// SAML-blocked: return zero result (callers treat as "unknown type").
+		if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+			return PeelTagObjectResult{}, nil
+		}
 		return PeelTagObjectResult{}, err
 	}
 	if resp.Repository == nil || resp.Repository.Head == nil {

--- a/internal/ghapi/graphql_peel.go
+++ b/internal/ghapi/graphql_peel.go
@@ -51,7 +51,7 @@ func (c *Client) PeelTagObject(ctx context.Context, owner, repo, sha string) (Pe
 	}
 	if err := c.graphql.DoWithContext(profile.WithGraphQLLabel(ctx, "peel"), tagObjectPeelQuery, vars, &resp); err != nil {
 		// SAML-blocked: return zero result (callers treat as "unknown type").
-		if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+		if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
 			return PeelTagObjectResult{}, nil
 		}
 		return PeelTagObjectResult{}, err

--- a/internal/ghapi/graphql_peel.go
+++ b/internal/ghapi/graphql_peel.go
@@ -50,9 +50,9 @@ func (c *Client) PeelTagObject(ctx context.Context, owner, repo, sha string) (Pe
 		"expr":  sha + "^{commit}",
 	}
 	if err := c.graphql.DoWithContext(profile.WithGraphQLLabel(ctx, "peel"), tagObjectPeelQuery, vars, &resp); err != nil {
-		// SAML-blocked: return zero result (callers treat as "unknown type").
+		// SAML-blocked: fall back to anonymous REST peel.
 		if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
-			return PeelTagObjectResult{}, nil
+			return c.anonPeelTagObject(ctx, owner, repo, sha)
 		}
 		return PeelTagObjectResult{}, err
 	}

--- a/internal/ghapi/graphql_reachability.go
+++ b/internal/ghapi/graphql_reachability.go
@@ -57,6 +57,10 @@ func (c *Client) batchBranchContainsChunk(ctx context.Context, owner, repo, sha 
 	if gqlErr != nil {
 		var httpErr *api.HTTPError
 		if errors.As(gqlErr, &httpErr) {
+			// SAML-blocked GraphQL → fall back to REST compare for eligible orgs.
+			if IsSAMLEnforcement(gqlErr) && SSOFallbackEligible(owner) {
+				return c.anonBatchBranchContains(ctx, owner, repo, sha, branches)
+			}
 			return "", false, gqlErr
 		}
 		if data == nil {
@@ -97,6 +101,26 @@ func (c *Client) batchBranchContainsChunk(ctx context.Context, owner, repo, sha 
 		}
 	}
 
+	return "", anyChecked, nil
+}
+
+// anonBatchBranchContains falls back to per-branch REST compare calls when
+// the GraphQL reachability query is SAML-blocked.
+func (c *Client) anonBatchBranchContains(ctx context.Context, owner, repo, sha string, branches []BranchHead) (string, bool, error) {
+	var anyChecked bool
+	for _, b := range branches {
+		if ctx.Err() != nil {
+			return "", anyChecked, ctx.Err()
+		}
+		contains, err := c.anonCompareCommits(ctx, owner, repo, sha, b.SHA)
+		if err != nil {
+			continue
+		}
+		anyChecked = true
+		if contains {
+			return b.Name, true, nil
+		}
+	}
 	return "", anyChecked, nil
 }
 

--- a/internal/ghapi/graphql_reachability.go
+++ b/internal/ghapi/graphql_reachability.go
@@ -108,18 +108,23 @@ func (c *Client) batchBranchContainsChunk(ctx context.Context, owner, repo, sha 
 // the GraphQL reachability query is SAML-blocked.
 func (c *Client) anonBatchBranchContains(ctx context.Context, owner, repo, sha string, branches []BranchHead) (string, bool, error) {
 	var anyChecked bool
+	var lastErr error
 	for _, b := range branches {
 		if ctx.Err() != nil {
 			return "", anyChecked, ctx.Err()
 		}
 		contains, err := c.anonCompareCommits(ctx, owner, repo, sha, b.SHA)
 		if err != nil {
+			lastErr = err
 			continue
 		}
 		anyChecked = true
 		if contains {
 			return b.Name, true, nil
 		}
+	}
+	if !anyChecked && lastErr != nil {
+		return "", false, fmt.Errorf("anonymous branch reachability: all compare calls failed: %w", lastErr)
 	}
 	return "", anyChecked, nil
 }

--- a/internal/ghapi/graphql_reachability.go
+++ b/internal/ghapi/graphql_reachability.go
@@ -58,7 +58,7 @@ func (c *Client) batchBranchContainsChunk(ctx context.Context, owner, repo, sha 
 		var httpErr *api.HTTPError
 		if errors.As(gqlErr, &httpErr) {
 			// SAML-blocked GraphQL → fall back to REST compare for eligible orgs.
-			if IsSAMLEnforcement(gqlErr) && SSOFallbackEligible(owner) {
+			if IsSAMLEnforcement(gqlErr) && c.SSOFallbackEligible(ctx, owner) {
 				return c.anonBatchBranchContains(ctx, owner, repo, sha, branches)
 			}
 			return "", false, gqlErr

--- a/internal/ghapi/repos.go
+++ b/internal/ghapi/repos.go
@@ -51,6 +51,9 @@ func (c *Client) ListBranches(ctx context.Context, owner, repo string) ([]Branch
 				Protected bool `json:"protected"`
 			}
 			if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+				if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+					return c.anonListBranches(ctx, owner, repo)
+				}
 				return nil, fmt.Errorf("listing branches for %s/%s: %w", owner, repo, err)
 			}
 			for _, b := range resp {
@@ -94,6 +97,14 @@ func (c *Client) ListTags(ctx context.Context, owner, repo string) ([]TagEntry, 
 			} `json:"commit"`
 		}
 		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
+			if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+				tags, anonErr := c.anonListTags(ctx, owner, repo)
+				if anonErr != nil {
+					return result{err: anonErr}, nil
+				}
+				c.tagListCache.Put(key, tags)
+				return result{tags: tags}, nil
+			}
 			return result{err: fmt.Errorf("listing tags for %s/%s: %w", owner, repo, err)}, nil
 		}
 		tags := make([]TagEntry, 0, len(resp))
@@ -145,7 +156,13 @@ func (c *Client) repoMetadata(ctx context.Context, owner, repo string) (repoMeta
 		}
 		path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
 		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-			return repoMeta{}, fmt.Errorf("fetching %s: %w", path, err)
+			if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+				if anonErr := c.anonGet(ctx, path, &resp); anonErr != nil {
+					return repoMeta{}, fmt.Errorf("anonymous fallback fetching %s: %w", path, anonErr)
+				}
+			} else {
+				return repoMeta{}, fmt.Errorf("fetching %s: %w", path, err)
+			}
 		}
 		m := repoMeta{
 			DefaultBranch: resp.DefaultBranch,
@@ -335,6 +352,14 @@ func (c *Client) CompareCommits(ctx context.Context, owner, repo, sha, branchHea
 				(httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusUnprocessableEntity) {
 				c.compareCache.Put(key, false)
 				return false, nil
+			}
+			if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+				contains, anonErr := c.anonCompareCommits(ctx, owner, repo, sha, branchHeadSHA)
+				if anonErr == nil {
+					c.compareCache.Put(key, contains)
+					return contains, nil
+				}
+				return false, anonErr
 			}
 			return false, err
 		}

--- a/internal/ghapi/repos.go
+++ b/internal/ghapi/repos.go
@@ -51,7 +51,7 @@ func (c *Client) ListBranches(ctx context.Context, owner, repo string) ([]Branch
 				Protected bool `json:"protected"`
 			}
 			if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-				if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+				if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
 					return c.anonListBranches(ctx, owner, repo)
 				}
 				return nil, fmt.Errorf("listing branches for %s/%s: %w", owner, repo, err)
@@ -97,7 +97,7 @@ func (c *Client) ListTags(ctx context.Context, owner, repo string) ([]TagEntry, 
 			} `json:"commit"`
 		}
 		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-			if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+			if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
 				tags, anonErr := c.anonListTags(ctx, owner, repo)
 				if anonErr != nil {
 					return result{err: anonErr}, nil
@@ -156,7 +156,7 @@ func (c *Client) repoMetadata(ctx context.Context, owner, repo string) (repoMeta
 		}
 		path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
 		if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
-			if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+			if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
 				if anonErr := c.anonGet(ctx, path, &resp); anonErr != nil {
 					return repoMeta{}, fmt.Errorf("anonymous fallback fetching %s: %w", path, anonErr)
 				}
@@ -353,7 +353,7 @@ func (c *Client) CompareCommits(ctx context.Context, owner, repo, sha, branchHea
 				c.compareCache.Put(key, false)
 				return false, nil
 			}
-			if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+			if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
 				contains, anonErr := c.anonCompareCommits(ctx, owner, repo, sha, branchHeadSHA)
 				if anonErr == nil {
 					c.compareCache.Put(key, contains)

--- a/internal/ghapi/repos.go
+++ b/internal/ghapi/repos.go
@@ -52,7 +52,11 @@ func (c *Client) ListBranches(ctx context.Context, owner, repo string) ([]Branch
 			}
 			if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &resp); err != nil {
 				if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
-					return c.anonListBranches(ctx, owner, repo)
+					anon, anonErr := c.anonListBranches(ctx, owner, repo)
+					if anonErr == nil {
+						c.branchListCache.Put(key, anon)
+					}
+					return anon, anonErr
 				}
 				return nil, fmt.Errorf("listing branches for %s/%s: %w", owner, repo, err)
 			}

--- a/internal/ghapi/tagsource.go
+++ b/internal/ghapi/tagsource.go
@@ -47,7 +47,7 @@ func (c *Client) Releases(ctx context.Context, owner, repo string) ([]RepoReleas
 		Immutable   bool   `json:"immutable"`
 	}
 	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &releases); err != nil {
-		if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+		if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
 			if anonErr := c.anonGet(ctx, path, &releases); anonErr != nil {
 				return nil, fmt.Errorf("anonymous fallback fetching releases for %s/%s: %w", owner, repo, anonErr)
 			}
@@ -96,7 +96,7 @@ func (c *Client) CommitSHA(ctx context.Context, owner, repo, ref string) (string
 		SHA string `json:"sha"`
 	}
 	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &result); err != nil {
-		if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+		if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
 			if anonErr := c.anonGet(ctx, path, &result); anonErr != nil {
 				return "", fmt.Errorf("anonymous fallback resolving %s/%s@%s: %w", owner, repo, ref, anonErr)
 			}

--- a/internal/ghapi/tagsource.go
+++ b/internal/ghapi/tagsource.go
@@ -47,7 +47,13 @@ func (c *Client) Releases(ctx context.Context, owner, repo string) ([]RepoReleas
 		Immutable   bool   `json:"immutable"`
 	}
 	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &releases); err != nil {
-		return nil, fmt.Errorf("fetching releases for %s/%s: %w", owner, repo, err)
+		if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+			if anonErr := c.anonGet(ctx, path, &releases); anonErr != nil {
+				return nil, fmt.Errorf("anonymous fallback fetching releases for %s/%s: %w", owner, repo, anonErr)
+			}
+		} else {
+			return nil, fmt.Errorf("fetching releases for %s/%s: %w", owner, repo, err)
+		}
 	}
 
 	out := make([]RepoRelease, 0, len(releases))
@@ -90,7 +96,13 @@ func (c *Client) CommitSHA(ctx context.Context, owner, repo, ref string) (string
 		SHA string `json:"sha"`
 	}
 	if err := c.rest.DoWithContext(ctx, http.MethodGet, path, nil, &result); err != nil {
-		return "", fmt.Errorf("resolving %s/%s@%s: %w", owner, repo, ref, err)
+		if IsSAMLEnforcement(err) && SSOFallbackEligible(owner) {
+			if anonErr := c.anonGet(ctx, path, &result); anonErr != nil {
+				return "", fmt.Errorf("anonymous fallback resolving %s/%s@%s: %w", owner, repo, ref, anonErr)
+			}
+		} else {
+			return "", fmt.Errorf("resolving %s/%s@%s: %w", owner, repo, ref, err)
+		}
 	}
 	return result.SHA, nil
 }

--- a/test/integration/run.rb
+++ b/test/integration/run.rb
@@ -543,6 +543,63 @@ STUB_WIRING = {
   sso_auth_failure: ->(s) {
     s.stub_server { |srv| sso_403_all(srv) }
   },
+  sso_anon_fallback: ->(s) {
+    # Authenticated requests (with Authorization header) get SAML 403.
+    # Anonymous requests (no Authorization) succeed — simulating public repo.
+    fake_sha = "a" * 40
+    s.stub_server do |srv|
+      # GraphQL always uses auth → return SAML error.
+      srv.on(:POST, /.*/) do |req|
+        [403, { "Content-Type" => "application/json", "X-GitHub-SSO" => SSO_HEADER_VALUE },
+         JSON.generate(SSO_ERROR_BODY)]
+      end
+
+      # GET: if Authorization present → SAML 403; otherwise → anon success.
+      srv.on(:GET, /.*/) do |req|
+        if req["Authorization"] && !req["Authorization"].empty?
+          [403, { "Content-Type" => "application/json", "X-GitHub-SSO" => SSO_HEADER_VALUE },
+           JSON.generate(SSO_ERROR_BODY)]
+        elsif req.path.include?("/orgs/")
+          # Probe: org is publicly visible.
+          [200, { "Content-Type" => "application/json" },
+           JSON.generate({ login: "actions", id: 44036562 })]
+        elsif req.path.include?("/commits/")
+          [200, { "Content-Type" => "application/json" },
+           JSON.generate({ sha: fake_sha })]
+        elsif req.path.include?("/contents/")
+          [200, { "Content-Type" => "text/plain" },
+           "name: 'Checkout'\ndescription: 'Checkout'\ninputs: {}\nruns:\n  using: node20\n  main: dist/index.js\n"]
+        elsif req.path.include?("/branches")
+          [200, { "Content-Type" => "application/json" },
+           JSON.generate([{ name: "main", commit: { sha: fake_sha }, protected: true }])]
+        elsif req.path.include?("/tags")
+          [200, { "Content-Type" => "application/json" },
+           JSON.generate([{ name: "v4", commit: { sha: fake_sha } }])]
+        elsif req.path.match?(%r{/repos/actions/checkout$})
+          [200, { "Content-Type" => "application/json" },
+           JSON.generate({ default_branch: "main", visibility: "public", pushed_at: "2024-01-01T00:00:00Z", id: 1, owner: { id: 44036562 } })]
+        elsif req.path.include?("/compare/")
+          [200, { "Content-Type" => "application/json" },
+           JSON.generate({ status: "behind", merge_base_commit: { sha: fake_sha } })]
+        elsif req.path.include?("/releases")
+          [200, { "Content-Type" => "application/json" },
+           JSON.generate([{ tag_name: "v4", published_at: "2024-01-01T00:00:00Z", immutable: false }])]
+        else
+          [404, { "Content-Type" => "application/json" }, JSON.generate({ message: "Not Found" })]
+        end
+      end
+
+      # HEAD for the probe.
+      srv.on(:HEAD, /.*/) do |req|
+        if req["Authorization"] && !req["Authorization"].empty?
+          [403, { "Content-Type" => "application/json" }, ""]
+        else
+          [200, { "Content-Type" => "application/json" }, ""]
+        end
+      end
+    end
+    s.env("GH_TOKEN" => "gho_fake_sso_fallback_token")
+  },
   sso_dedup: ->(s) {
     s.stub_server { |srv| sso_403_all(srv) }
     s.env("GH_TOKEN" => "gho_fake_sso_test_token")

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -141,6 +141,25 @@ scenarios:
       output_excludes:
         - "resolution failed:"
 
+  - name: sso_anon_fallback
+    category: sso_auth
+    description: "SSO-blocked public org falls back to anonymous access and resolves"
+    needs_stub: true
+    tags: [stub]
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions:
+            - "actions/checkout@v4"
+    expect:
+      exit: 0
+      output_contains:
+        - "actions/checkout"
+      output_excludes:
+        - "SAML enforcement"
+        - "SSO authorization required"
+
   - name: sso_dedup
     category: sso_auth
     description: "11 actions from same org — SSO reason shown only once"


### PR DESCRIPTION
## Motivation

In Codespaces (and similar environments), the `GITHUB_TOKEN` cannot be SSO-authorized for cross-enterprise orgs like `actions`. This means every API call to resolve `actions/checkout`, `actions/setup-go`, etc. fails with a SAML 403 -- even though those repos are fully public. The tool becomes unusable for any workflow that references `actions/*`.

## Approach

When a SAML enforcement error is detected for a given org, probe that org's public visibility with an unauthenticated `HEAD /orgs/{owner}` request. If the org is publicly visible, retry the failed operation anonymously (no `Authorization` header). This covers:

- **GraphQL resolution** (`ResolveActionFiles`) -- the primary ref-to-SHA + action.yml fetch
- **REST endpoints** -- `ListBranches`, `ListTags`, `CompareCommits`, `Releases`, `CommitSHA`, `repoMetadata`
- **GraphQL reachability** (`BatchBranchContains`) -- falls back to per-branch anonymous REST compare
- **GraphQL peel** (`PeelTagObject`) -- returns zero result on SAML (callers already handle gracefully)

The eligibility probe result is cached in a `sync.Map` for the process lifetime, so each org is only probed once.

## Key design decisions

- **No hardcoded org list.** Eligibility is determined dynamically via an anonymous probe, so any public org with SAML enforcement gets the fallback automatically.
- **`anonHTTP` client on `Client` struct.** Respects `GH_ACTIONS_LOCK_INSECURE` for integration tests (TLS skip), and `anonBase()` skips the `api.` prefix for `IP:port` hostnames used by the stub server.
- **Surgical error matching.** Only triggers on HTTP 403 with "SAML enforcement" in the error message -- won't interfere with rate limits or other 403s.

## Testing

- Unit tests: `TestSSOFallbackEligible`, `TestResolveActionFiles_SSOFallbackForActionsOrg`, `TestResolveActionFiles_SSONoFallbackForNonActionsOrg`
- Integration scenario: `sso_anon_fallback` -- stub returns SAML 403 for auth'd requests, 200 for anonymous; validates the full pipeline resolves successfully
- Verified live against `api.github.com` that anonymous resolution of `actions/checkout@v4` returns the correct SHA and `action.yml` content