### PR TITLE
Add OSPO-standard sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ Lock your workflow dependencies.
 > lockfile format, command flags, and behavior may change without notice between
 > releases. Use it, file issues, and expect rough edges.
 
-## Install
+## Background
+
+gh-actions-lock is part of GitHub's Workflow Dependency Pinning effort. It gives repositories a lockfile that pins every workflow dependency to a verified commit, so what runs on the runner is exactly what you locked. Development is ongoing and behavior may still change.
+
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) to get started.
+
+## Requirements
+
+Requires the [`gh` CLI](https://cli.github.com/). Install it first, then install the extension:
 
 ```bash
 gh extension install github/gh-actions-lock
@@ -37,4 +45,16 @@ Finally, locked actions must have a branch that the commit being locked exists w
 
 There are currently eligibility limitations for workflows that can be onboarded to lockfiles:
 - Workflows in the lockfile cannot use local-path actions, these will be skipped for onboarding. This is also a short-term gap.
+
+## License
+
+This project is licensed under the terms of the MIT open source license. See [LICENSE](./LICENSE) for the full terms.
+
+## Maintainers
+
+gh-actions-lock is maintained by @github/actions-dispatch-reviewers. See [CODEOWNERS](./CODEOWNERS).
+
+## Support
+
+Support is best-effort and community-based. Please file bugs and feature requests as [GitHub issues](https://github.com/github/gh-actions-lock/issues). See [SUPPORT.md](./SUPPORT.md) for details.
 


### PR DESCRIPTION
Adds the section structure from the OSPO README template ahead of the open-source release, without removing any existing content.

## What changed

- **Background** — new section on purpose/roadmap with an explicit contribution ask linking [CONTRIBUTING.md](./CONTRIBUTING.md).
- **Requirements** — clarifies the `gh` CLI prerequisite (formerly the bare "Install" section).
- **License** — new section pointing to [LICENSE](./LICENSE) (MIT).
- **Maintainers** — new section pointing to @github/actions-dispatch-reviewers via [CODEOWNERS](./CODEOWNERS).
- **Support** — new section linking [SUPPORT.md](./SUPPORT.md).

Existing **Usage**, **How it works**, **Limitations**, and the **Public preview** callout are unchanged. All README links point to public resources only.

Part of OSPO release github/open-source-releases#711.