### PR TITLE
Re-verify locked pins on the default run, and surface verify failures

### DIFF
--- a/actions/lint/action.yml
+++ b/actions/lint/action.yml
@@ -1,5 +1,5 @@
 name: Lint actions.lock
-description: Check that actions.lock is in sync with workflow files
+description: Check that actions.lock is in sync with workflows and every pin still resolves upstream
 
 inputs:
   extra-flags:

--- a/cmd/gh-actions-lock/command_test.go
+++ b/cmd/gh-actions-lock/command_test.go
@@ -261,15 +261,15 @@ jobs:
 // Lockfile Forgery Detection Tests
 //
 // These tests verify that the ancestry check promotes ref-moved to
-// lockfile-integrity when the pinned SHA is not an ancestor of the live SHA.
+// unreachable-pin when the pinned SHA is not an ancestor of the live SHA.
 // This detects cases where someone manually injected a SHA into the lockfile
 // that was never part of the ref's legitimate history.
 // ==========================================================================
 
-// TestCheck_LockfileIntegrity_NotAncestor verifies that when the Compare API
+// TestCheck_UnreachablePin_NotAncestor verifies that when the Compare API
 // shows the pinned SHA is NOT an ancestor of the live SHA, the finding is
-// promoted from ref-moved to lockfile-integrity.
-func TestCheck_LockfileIntegrity_NotAncestor(t *testing.T) {
+// promoted from ref-moved to unreachable-pin.
+func TestCheck_UnreachablePin_NotAncestor(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
@@ -325,14 +325,14 @@ jobs:
 	for _, f := range payload.Findings {
 		categories[f.Category] = true
 	}
-	assert.True(t, categories["lockfile-integrity"], "should detect lockfile forgery: %+v", payload.Findings)
+	assert.True(t, categories["unreachable-pin"], "should detect lockfile forgery: %+v", payload.Findings)
 	assert.False(t, categories["ref-moved"], "should NOT have ref-moved (promoted to forgery): %+v", payload.Findings)
 }
 
-// TestCheck_LockfileIntegrity_LegitAncestor verifies that when the Compare API
+// TestCheck_UnreachablePin_LegitAncestor verifies that when the Compare API
 // confirms the pinned SHA IS an ancestor of the live SHA, the finding stays
 // as ref-moved (legitimate tag movement, not forgery).
-func TestCheck_LockfileIntegrity_LegitAncestor(t *testing.T) {
+func TestCheck_UnreachablePin_LegitAncestor(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
@@ -388,14 +388,14 @@ jobs:
 		categories[f.Category] = true
 	}
 	assert.True(t, categories["ref-moved"], "should keep as ref-moved for legit ancestor: %+v", payload.Findings)
-	assert.False(t, categories["lockfile-integrity"], "should NOT have lockfile-integrity: %+v", payload.Findings)
+	assert.False(t, categories["unreachable-pin"], "should NOT have unreachable-pin: %+v", payload.Findings)
 }
 
-// TestCheck_LockfileIntegrity_RateLimited verifies that when the ancestry
+// TestCheck_UnreachablePin_RateLimited verifies that when the ancestry
 // check is rate-limited, the finding surfaces as ancestry-unknown — not
 // ref-moved (which would imply a benign-but-known move) and not
-// lockfile-integrity (which requires an authoritative not-ancestor answer).
-func TestCheck_LockfileIntegrity_RateLimited(t *testing.T) {
+// unreachable-pin (which requires an authoritative not-ancestor answer).
+func TestCheck_UnreachablePin_RateLimited(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
@@ -446,7 +446,7 @@ jobs:
 		categories[f.Category] = true
 	}
 	assert.True(t, categories["ancestry-unknown"], "should classify as ancestry-unknown when rate limited: %+v", payload.Findings)
-	assert.False(t, categories["lockfile-integrity"], "should NOT have lockfile-integrity when rate limited: %+v", payload.Findings)
+	assert.False(t, categories["unreachable-pin"], "should NOT have unreachable-pin when rate limited: %+v", payload.Findings)
 	assert.False(t, categories["ref-moved"], "should NOT downgrade to ref-moved when rate limited: %+v", payload.Findings)
 	assert.False(t, categories["valid"], "rate-limited ancestry must not regress to CategoryValid: %+v", payload.Findings)
 

--- a/cmd/gh-actions-lock/command_test.go
+++ b/cmd/gh-actions-lock/command_test.go
@@ -261,15 +261,15 @@ jobs:
 // Lockfile Forgery Detection Tests
 //
 // These tests verify that the ancestry check promotes ref-moved to
-// lockfile-forgery when the pinned SHA is not an ancestor of the live SHA.
+// lockfile-integrity when the pinned SHA is not an ancestor of the live SHA.
 // This detects cases where someone manually injected a SHA into the lockfile
 // that was never part of the ref's legitimate history.
 // ==========================================================================
 
-// TestCheck_LockfileForgery_NotAncestor verifies that when the Compare API
+// TestCheck_LockfileIntegrity_NotAncestor verifies that when the Compare API
 // shows the pinned SHA is NOT an ancestor of the live SHA, the finding is
-// promoted from ref-moved to lockfile-forgery.
-func TestCheck_LockfileForgery_NotAncestor(t *testing.T) {
+// promoted from ref-moved to lockfile-integrity.
+func TestCheck_LockfileIntegrity_NotAncestor(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
@@ -325,14 +325,14 @@ jobs:
 	for _, f := range payload.Findings {
 		categories[f.Category] = true
 	}
-	assert.True(t, categories["lockfile-forgery"], "should detect lockfile forgery: %+v", payload.Findings)
+	assert.True(t, categories["lockfile-integrity"], "should detect lockfile forgery: %+v", payload.Findings)
 	assert.False(t, categories["ref-moved"], "should NOT have ref-moved (promoted to forgery): %+v", payload.Findings)
 }
 
-// TestCheck_LockfileForgery_LegitAncestor verifies that when the Compare API
+// TestCheck_LockfileIntegrity_LegitAncestor verifies that when the Compare API
 // confirms the pinned SHA IS an ancestor of the live SHA, the finding stays
 // as ref-moved (legitimate tag movement, not forgery).
-func TestCheck_LockfileForgery_LegitAncestor(t *testing.T) {
+func TestCheck_LockfileIntegrity_LegitAncestor(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
@@ -388,14 +388,14 @@ jobs:
 		categories[f.Category] = true
 	}
 	assert.True(t, categories["ref-moved"], "should keep as ref-moved for legit ancestor: %+v", payload.Findings)
-	assert.False(t, categories["lockfile-forgery"], "should NOT have lockfile-forgery: %+v", payload.Findings)
+	assert.False(t, categories["lockfile-integrity"], "should NOT have lockfile-integrity: %+v", payload.Findings)
 }
 
-// TestCheck_LockfileForgery_RateLimited verifies that when the ancestry
+// TestCheck_LockfileIntegrity_RateLimited verifies that when the ancestry
 // check is rate-limited, the finding surfaces as ancestry-unknown — not
 // ref-moved (which would imply a benign-but-known move) and not
-// lockfile-forgery (which requires an authoritative not-ancestor answer).
-func TestCheck_LockfileForgery_RateLimited(t *testing.T) {
+// lockfile-integrity (which requires an authoritative not-ancestor answer).
+func TestCheck_LockfileIntegrity_RateLimited(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
@@ -446,7 +446,7 @@ jobs:
 		categories[f.Category] = true
 	}
 	assert.True(t, categories["ancestry-unknown"], "should classify as ancestry-unknown when rate limited: %+v", payload.Findings)
-	assert.False(t, categories["lockfile-forgery"], "should NOT have lockfile-forgery when rate limited: %+v", payload.Findings)
+	assert.False(t, categories["lockfile-integrity"], "should NOT have lockfile-integrity when rate limited: %+v", payload.Findings)
 	assert.False(t, categories["ref-moved"], "should NOT downgrade to ref-moved when rate limited: %+v", payload.Findings)
 	assert.False(t, categories["valid"], "rate-limited ancestry must not regress to CategoryValid: %+v", payload.Findings)
 

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -107,7 +107,7 @@ func PresentReadOnlyFailures(out *ui.UI, report *checks.Report) (hasFixable bool
 		g := groups[key]
 		out.TermBlank()
 		for _, f := range g.findings {
-			if !IsAlertedCategory(f.Category) {
+			if IsAutoFixable(f.Category) {
 				hasFixable = true
 			}
 			renderTermFindingDetail(out, f, key)
@@ -130,6 +130,12 @@ func renderTermFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 	}
 	out.TermDetail("%s %s %s", icon, out.TermDim(label), dep)
 	out.TermDetail("  %s", f.Detail)
+	if f.Category == checks.UnreachablePin && f.Dependency != nil {
+		owner, repo := f.Dependency.OwnerRepo()
+		if owner != "" {
+			out.TermDetail("  ↳ %s", out.TermDim(fmt.Sprintf("https://github.com/%s/%s/releases", owner, repo)))
+		}
+	}
 	if IsAlertedCategory(f.Category) && f.Remediation != "" {
 		out.TermDetail("  %s %s", ui.IconWarning, f.Remediation)
 	}
@@ -401,6 +407,20 @@ func renderWarnings(out *ui.UI, report *checks.Report, willRemediate bool) {
 func IsAlertedCategory(c checks.Category) bool {
 	switch c {
 	case checks.UnreachablePin, checks.MisleadingSHA, checks.OnboardingRequired:
+		return true
+	}
+	return false
+}
+
+// IsAutoFixable reports whether a plain `gh actions-lock` run (no --no-fix)
+// re-pins the finding without operator intervention. Only structural drift
+// qualifies: a missing, changed, or orphaned lock entry. Integrity failures
+// (unreachable-pin, misleading-sha) need investigation or --accept-moved, and
+// local-path actions aren't supported at all — so none of those should
+// trigger the "Re-run without --no-fix to apply fixes" hint.
+func IsAutoFixable(c checks.Category) bool {
+	switch c {
+	case checks.NotPinned, checks.RefChanged, checks.Stale:
 		return true
 	}
 	return false

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -151,7 +151,7 @@ func renderTermFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 }
 
 // categoryLabel returns a human-readable label for a finding category,
-// e.g. "lockfile-forgery" -> "Lockfile forgery". Falls back to a
+// e.g. "lockfile-integrity" -> "Lockfile integrity". Falls back to a
 // hyphen-to-space title for unmapped categories so new slugs still read
 // cleanly.
 func categoryLabel(c checks.Category) string {
@@ -162,8 +162,8 @@ func categoryLabel(c checks.Category) string {
 		return "Ref changed"
 	case checks.MisleadingSHA:
 		return "Misleading SHA"
-	case checks.LockfileForgery:
-		return "Lockfile forgery"
+	case checks.LockfileIntegrity:
+		return "Lockfile integrity"
 	case checks.Stale:
 		return "Unused lockfile entry"
 	}
@@ -225,7 +225,7 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 
 	parts := []string{}
 	for _, cat := range []checks.Category{
-		checks.LockfileForgery,
+		checks.LockfileIntegrity,
 		checks.RefChanged, checks.NotPinned, checks.OnboardingRequired,
 		checks.LocalAction,
 		checks.Stale, checks.MisleadingSHA,
@@ -251,7 +251,7 @@ func renderFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 	}
 	out.Detail("%s %s %s", icon, out.Dim(label), dep)
 	out.Detail("  %s", f.Detail)
-	if f.Category == checks.LockfileForgery && f.Dependency != nil {
+	if f.Category == checks.LockfileIntegrity && f.Dependency != nil {
 		owner, repo := f.Dependency.OwnerRepo()
 		if owner != "" {
 			out.Detail("  ↳ %s", out.Dim(fmt.Sprintf("https://github.com/%s/%s/releases", owner, repo)))
@@ -400,7 +400,7 @@ func renderWarnings(out *ui.UI, report *checks.Report, willRemediate bool) {
 // remediator should not re-print it in non-interactive mode).
 func IsAlertedCategory(c checks.Category) bool {
 	switch c {
-	case checks.LockfileForgery, checks.MisleadingSHA, checks.OnboardingRequired:
+	case checks.LockfileIntegrity, checks.MisleadingSHA, checks.OnboardingRequired:
 		return true
 	}
 	return false

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -123,7 +123,7 @@ func PresentReadOnlyFailures(out *ui.UI, report *checks.Report) (hasFixable bool
 // prints a single non-valid finding to the terminal (bypassing the
 // narration log) so read-only modes surface the same detail as fix mode.
 func renderTermFindingDetail(out *ui.UI, f checks.Finding, dep string) {
-	label := strings.ToUpper(string(f.Category))
+	label := categoryLabel(f.Category)
 	icon := "!"
 	if IsAlertedCategory(f.Category) {
 		icon = "✗"
@@ -142,12 +142,32 @@ func renderTermFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 		if len(sha) > 7 {
 			sha = sha[:7]
 		}
-		out.TermDetail("  ↳ Suggested re-pin: %s@%s (%s) — latest release reachable from a branch",
+		out.TermDetail("  ↳ Suggested pin: %s@%s (%s) — newest release currently on that branch",
 			nwo, f.RecommendedTag, sha)
 	}
 	if f.DocURL != "" {
-		out.TermDetail("  see: %s", out.TermDim(out.TermLink("docs", f.DocURL)))
+		out.TermDetail("  see: %s", out.TermDim(out.TermLink("how to fix this", f.DocURL)))
 	}
+}
+
+// categoryLabel returns a human-readable label for a finding category,
+// e.g. "lockfile-forgery" -> "Lockfile forgery". Falls back to a
+// hyphen-to-space title for unmapped categories so new slugs still read
+// cleanly.
+func categoryLabel(c checks.Category) string {
+	switch c {
+	case checks.NotPinned:
+		return "Not pinned"
+	case checks.RefChanged:
+		return "Ref changed"
+	case checks.MisleadingSHA:
+		return "Misleading SHA"
+	case checks.LockfileForgery:
+		return "Lockfile forgery"
+	case checks.Stale:
+		return "Unused lockfile entry"
+	}
+	return strings.ReplaceAll(string(c), "-", " ")
 }
 
 // renderErrorFindings groups error-level findings by dependency and prints

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -151,7 +151,7 @@ func renderTermFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 }
 
 // categoryLabel returns a human-readable label for a finding category,
-// e.g. "lockfile-integrity" -> "Lockfile integrity". Falls back to a
+// e.g. "unreachable-pin" -> "Unreachable pin". Falls back to a
 // hyphen-to-space title for unmapped categories so new slugs still read
 // cleanly.
 func categoryLabel(c checks.Category) string {
@@ -162,8 +162,8 @@ func categoryLabel(c checks.Category) string {
 		return "Ref changed"
 	case checks.MisleadingSHA:
 		return "Misleading SHA"
-	case checks.LockfileIntegrity:
-		return "Lockfile integrity"
+	case checks.UnreachablePin:
+		return "Unreachable pin"
 	case checks.Stale:
 		return "Unused lockfile entry"
 	}
@@ -225,7 +225,7 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 
 	parts := []string{}
 	for _, cat := range []checks.Category{
-		checks.LockfileIntegrity,
+		checks.UnreachablePin,
 		checks.RefChanged, checks.NotPinned, checks.OnboardingRequired,
 		checks.LocalAction,
 		checks.Stale, checks.MisleadingSHA,
@@ -251,7 +251,7 @@ func renderFindingDetail(out *ui.UI, f checks.Finding, dep string) {
 	}
 	out.Detail("%s %s %s", icon, out.Dim(label), dep)
 	out.Detail("  %s", f.Detail)
-	if f.Category == checks.LockfileIntegrity && f.Dependency != nil {
+	if f.Category == checks.UnreachablePin && f.Dependency != nil {
 		owner, repo := f.Dependency.OwnerRepo()
 		if owner != "" {
 			out.Detail("  ↳ %s", out.Dim(fmt.Sprintf("https://github.com/%s/%s/releases", owner, repo)))
@@ -400,7 +400,7 @@ func renderWarnings(out *ui.UI, report *checks.Report, willRemediate bool) {
 // remediator should not re-print it in non-interactive mode).
 func IsAlertedCategory(c checks.Category) bool {
 	switch c {
-	case checks.LockfileIntegrity, checks.MisleadingSHA, checks.OnboardingRequired:
+	case checks.UnreachablePin, checks.MisleadingSHA, checks.OnboardingRequired:
 		return true
 	}
 	return false

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -47,6 +47,109 @@ func PresentResults(out *ui.UI, report *checks.Report, valid bool, willRemediate
 	renderWarnings(out, report, willRemediate)
 }
 
+// PresentReadOnlyFailures renders error-level findings directly to the
+// terminal for read-only modes (--no-fix / --verify). Those modes return
+// before the fix-mode summary (renderPinSummary) runs, so the error block
+// that renderErrorFindings emits via the narration helpers is discarded
+// when the log sink is io.Discard. This uses the Term* family instead so
+// failures actually reach the operator.
+//
+// It reports whether any failing finding is auto-fixable (i.e. not an
+// investigation-only category) so the caller can decide whether the
+// "re-run to fix" hint is honest.
+func PresentReadOnlyFailures(out *ui.UI, report *checks.Report) (hasFixable bool) {
+	type depGroup struct {
+		findings  []checks.Finding
+		workflows []string
+		seenWF    map[string]bool
+	}
+	var order []string
+	groups := map[string]*depGroup{}
+	var failedCount, checked int
+
+	for i := range report.Workflows {
+		wr := &report.Workflows[i]
+		checked++
+		if wr.IsValid() {
+			continue
+		}
+		failedCount++
+		for _, f := range wr.Findings {
+			if f.IsValid() {
+				continue
+			}
+			key := f.DepKey()
+			if key == "" {
+				key = wr.Path
+			}
+			g, ok := groups[key]
+			if !ok {
+				g = &depGroup{seenWF: map[string]bool{}}
+				groups[key] = g
+				order = append(order, key)
+			}
+			g.findings = append(g.findings, f)
+			if wr.Path != "" && !g.seenWF[wr.Path] {
+				g.seenWF[wr.Path] = true
+				g.workflows = append(g.workflows, wr.Path)
+			}
+		}
+	}
+
+	if len(order) == 0 {
+		return false
+	}
+
+	out.TermBlank()
+	out.TermError("%d of %d %s failed verification",
+		failedCount, checked, ui.Pluralize(checked, "workflow", "workflows"))
+	for _, key := range order {
+		g := groups[key]
+		out.TermBlank()
+		for _, f := range g.findings {
+			if !IsAlertedCategory(f.Category) {
+				hasFixable = true
+			}
+			renderTermFindingDetail(out, f, key)
+		}
+		for _, wf := range g.workflows {
+			out.TermDetail("  ↳ %s", out.TermDim(wf))
+		}
+	}
+	return hasFixable
+}
+
+// renderTermFindingDetail is the Term* twin of renderFindingDetail: it
+// prints a single non-valid finding to the terminal (bypassing the
+// narration log) so read-only modes surface the same detail as fix mode.
+func renderTermFindingDetail(out *ui.UI, f checks.Finding, dep string) {
+	label := strings.ToUpper(string(f.Category))
+	icon := "!"
+	if IsAlertedCategory(f.Category) {
+		icon = "✗"
+	}
+	out.TermDetail("%s %s %s", icon, out.TermDim(label), dep)
+	out.TermDetail("  %s", f.Detail)
+	if IsAlertedCategory(f.Category) && f.Remediation != "" {
+		out.TermDetail("  %s %s", ui.IconWarning, f.Remediation)
+	}
+	if f.RecommendedTag != "" {
+		nwo := ""
+		if f.Dependency != nil {
+			nwo = f.Dependency.NWO
+		}
+		sha := f.RecommendedSHA
+		if len(sha) > 7 {
+			sha = sha[:7]
+		}
+		out.TermDetail("  ↳ Suggested re-pin: %s@%s (%s) — latest release reachable from a branch",
+			nwo, f.RecommendedTag, sha)
+	}
+	if f.DocURL != "" {
+		out.TermDetail("  see: %s", out.TermDim(out.TermLink("docs", f.DocURL)))
+	}
+}
+
 // renderErrorFindings groups error-level findings by dependency and prints
 // per-dep detail lines followed by a category-count summary.
 func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked int, exclude map[checks.Category]bool) {

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -544,3 +544,56 @@ func TestPresentReadOnlyFailures_ValidReportSilent(t *testing.T) {
 		t.Errorf("valid report should produce no output, got:\n%s", got)
 	}
 }
+
+// TestPresentReadOnlyFailures_LocalActionNotFixable guards the inference bug
+// where hasFixable was derived from !IsAlertedCategory: local-action is an
+// error the tool can't auto-remediate, so the "Re-run without --no-fix" hint
+// must not be offered for it.
+func TestPresentReadOnlyFailures_LocalActionNotFixable(t *testing.T) {
+	u, buf := newTestUI()
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{{
+			Path: ".github/workflows/ci.yml",
+			Findings: []checks.Finding{{
+				WorkflowPath: ".github/workflows/ci.yml",
+				Category:     checks.LocalAction,
+				Severity:     checks.SeverityError,
+				Confidence:   checks.ConfidenceHigh,
+				Detail:       "local action ./my-action",
+			}},
+		}},
+	}
+
+	hasFixable := PresentReadOnlyFailures(u, report)
+	if got := buf.String(); !strings.Contains(got, "local action ./my-action") {
+		t.Errorf("expected local-action detail in output:\n%s", got)
+	}
+	if hasFixable {
+		t.Errorf("local-action is not auto-fixable; hasFixable should be false")
+	}
+}
+
+// TestPresentReadOnlyFailures_UnreachablePinShowsReleases verifies the
+// read-only renderer includes the upstream releases link for an
+// unreachable-pin finding, matching the detailed (fix-mode) renderer.
+func TestPresentReadOnlyFailures_UnreachablePinShowsReleases(t *testing.T) {
+	u, buf := newTestUI()
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{{
+			Path: ".github/workflows/ci.yml",
+			Findings: []checks.Finding{{
+				WorkflowPath: ".github/workflows/ci.yml",
+				Category:     checks.UnreachablePin,
+				Severity:     checks.SeverityError,
+				Confidence:   checks.ConfidenceHigh,
+				Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "main", SHA: "aaaa"},
+				Detail:       "pinned aaaa is not an ancestor of bbbb",
+			}},
+		}},
+	}
+
+	PresentReadOnlyFailures(u, report)
+	if got := buf.String(); !strings.Contains(got, "https://github.com/octo/action/releases") {
+		t.Errorf("expected upstream releases link in read-only output:\n%s", got)
+	}
+}

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -475,7 +475,7 @@ func TestPresentReadOnlyFailures_ForgeryReachesTerminal(t *testing.T) {
 
 	for _, want := range []string{
 		"1 of 1 workflow failed",
-		"LOCKFILE-FORGERY",
+		"Lockfile forgery",
 		"octo/action@main",
 		"pinned aaaa is not an ancestor of bbbb",
 		"investigate immediately",

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -439,3 +439,108 @@ func TestPresentResults_RepoFindingsSurface(t *testing.T) {
 		t.Errorf("RepoFindings DocURL missing from terminal output:\n%s", got)
 	}
 }
+
+// TestPresentReadOnlyFailures_ForgeryReachesTerminal is the regression guard
+// for the --verify/--no-fix output bug: an error-level finding must reach the
+// terminal even when the narration log sinks to io.Discard. PresentResults
+// alone routes the error block through the discarded log, so read-only modes
+// exited non-zero showing nothing about which workflow failed.
+func TestPresentReadOnlyFailures_ForgeryReachesTerminal(t *testing.T) {
+	u, buf := newTestUI()
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{{
+			Path: ".github/workflows/ci.yml",
+			Findings: []checks.Finding{{
+				WorkflowPath: ".github/workflows/ci.yml",
+				Category:     checks.LockfileForgery,
+				Severity:     checks.SeverityError,
+				Confidence:   checks.ConfidenceHigh,
+				Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "main", SHA: "aaaa"},
+				Detail:       "pinned aaaa is not an ancestor of bbbb",
+				Remediation:  "investigate immediately",
+				DocURL:       "https://example.com/docs",
+			}},
+		}},
+	}
+
+	// Prove the pre-fix behavior: PresentResults leaves the error block in
+	// the discarded log, so nothing surfaces.
+	PresentResults(u, report, false, false)
+	if strings.Contains(buf.String(), "LOCKFILE-FORGERY") {
+		t.Fatalf("guard invalid: PresentResults unexpectedly surfaced the error block:\n%s", buf.String())
+	}
+
+	hasFixable := PresentReadOnlyFailures(u, report)
+	got := buf.String()
+
+	for _, want := range []string{
+		"1 of 1 workflow failed",
+		"LOCKFILE-FORGERY",
+		"octo/action@main",
+		"pinned aaaa is not an ancestor of bbbb",
+		"investigate immediately",
+		".github/workflows/ci.yml",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PresentReadOnlyFailures output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+	if hasFixable {
+		t.Errorf("forgery is investigation-only; hasFixable should be false")
+	}
+}
+
+// TestPresentReadOnlyFailures_FixableReported verifies an auto-fixable
+// error-level finding (a directly-used unpinned action) surfaces and reports
+// hasFixable=true so the caller can honestly print the re-run hint.
+func TestPresentReadOnlyFailures_FixableReported(t *testing.T) {
+	u, buf := newTestUI()
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{{
+			Path: ".github/workflows/ci.yml",
+			Findings: []checks.Finding{{
+				WorkflowPath: ".github/workflows/ci.yml",
+				Category:     checks.NotPinned,
+				Severity:     checks.SeverityError,
+				Confidence:   checks.ConfidenceHigh,
+				ActionRef:    &parserlock.ActionRef{Owner: "actions", Repo: "checkout", Ref: "v4"},
+				Dependency:   &dep.Dependency{NWO: "actions/checkout", Ref: "v4"},
+				Detail:       "no lockfile entry",
+			}},
+		}},
+	}
+
+	hasFixable := PresentReadOnlyFailures(u, report)
+	got := buf.String()
+
+	if !strings.Contains(got, "actions/checkout@v4") {
+		t.Errorf("expected failing dep in output:\n%s", got)
+	}
+	if !hasFixable {
+		t.Errorf("not-pinned is auto-fixable; hasFixable should be true")
+	}
+}
+
+// TestPresentReadOnlyFailures_ValidReportSilent verifies a clean report
+// produces no output and reports nothing fixable.
+func TestPresentReadOnlyFailures_ValidReportSilent(t *testing.T) {
+	u, buf := newTestUI()
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{{
+			Path: ".github/workflows/ci.yml",
+			Findings: []checks.Finding{{
+				WorkflowPath: ".github/workflows/ci.yml",
+				Category:     checks.Valid,
+				Severity:     checks.SeverityOK,
+				Confidence:   checks.ConfidenceHigh,
+			}},
+		}},
+	}
+
+	if hasFixable := PresentReadOnlyFailures(u, report); hasFixable {
+		t.Errorf("valid report should report nothing fixable")
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("valid report should produce no output, got:\n%s", got)
+	}
+}

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -330,7 +330,7 @@ func TestPresentResults_ParseWarningsSurface(t *testing.T) {
 // TestPresentResults_ExcludeCategoriesSkipsImpostor verifies that excluded
 // categories are not rendered in the error findings block. This prevents
 // duplication when renderInvestigationAlerts already surfaced the same
-// findings (e.g. lockfile-integrity).
+// findings (e.g. unreachable-pin).
 func TestPresentResults_ExcludeCategoriesSkipsImpostor(t *testing.T) {
 	var buf bytes.Buffer
 	u := ui.NewPlain(&buf)
@@ -341,7 +341,7 @@ func TestPresentResults_ExcludeCategoriesSkipsImpostor(t *testing.T) {
 				Findings: []checks.Finding{
 					{
 						WorkflowPath: ".github/workflows/ci.yml",
-						Category:     checks.LockfileIntegrity,
+						Category:     checks.UnreachablePin,
 						Severity:     checks.SeverityError,
 						Confidence:   checks.ConfidenceHigh,
 						Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "v1", SHA: "aaaa"},
@@ -360,17 +360,17 @@ func TestPresentResults_ExcludeCategoriesSkipsImpostor(t *testing.T) {
 		},
 	}
 
-	PresentResults(u, report, false, false, checks.LockfileIntegrity)
+	PresentResults(u, report, false, false, checks.UnreachablePin)
 	got := buf.String()
 
-	if strings.Contains(got, "LOCKFILE-INTEGRITY") {
-		t.Errorf("excluded lockfile-integrity should not appear:\n%s", got)
+	if strings.Contains(got, "UNREACHABLE-PIN") {
+		t.Errorf("excluded unreachable-pin should not appear:\n%s", got)
 	}
 	if strings.Contains(got, "lockfile entry was not a prior state") {
 		t.Errorf("excluded forgery detail should not appear:\n%s", got)
 	}
 	// The summary line should not count the excluded category.
-	if strings.Contains(got, "lockfile-integrity") {
+	if strings.Contains(got, "unreachable-pin") {
 		t.Errorf("excluded category should not appear in summary:\n%s", got)
 	}
 }
@@ -387,7 +387,7 @@ func TestPresentResults_ExcludeKeepsOtherFindings(t *testing.T) {
 				Findings: []checks.Finding{
 					{
 						WorkflowPath: ".github/workflows/ci.yml",
-						Category:     checks.LockfileIntegrity,
+						Category:     checks.UnreachablePin,
 						Severity:     checks.SeverityError,
 						Confidence:   checks.ConfidenceHigh,
 						Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "v1", SHA: "aaaa"},
@@ -405,11 +405,11 @@ func TestPresentResults_ExcludeKeepsOtherFindings(t *testing.T) {
 		},
 	}
 
-	PresentResults(u, report, false, false, checks.LockfileIntegrity)
+	PresentResults(u, report, false, false, checks.UnreachablePin)
 	got := buf.String()
 
-	if strings.Contains(got, "LOCKFILE-INTEGRITY") {
-		t.Errorf("excluded lockfile-integrity should not appear:\n%s", got)
+	if strings.Contains(got, "UNREACHABLE-PIN") {
+		t.Errorf("excluded unreachable-pin should not appear:\n%s", got)
 	}
 	if !strings.Contains(got, "LOCAL-ACTION") {
 		t.Errorf("non-excluded local-action should still appear:\n%s", got)
@@ -452,7 +452,7 @@ func TestPresentReadOnlyFailures_ForgeryReachesTerminal(t *testing.T) {
 			Path: ".github/workflows/ci.yml",
 			Findings: []checks.Finding{{
 				WorkflowPath: ".github/workflows/ci.yml",
-				Category:     checks.LockfileIntegrity,
+				Category:     checks.UnreachablePin,
 				Severity:     checks.SeverityError,
 				Confidence:   checks.ConfidenceHigh,
 				Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "main", SHA: "aaaa"},
@@ -466,7 +466,7 @@ func TestPresentReadOnlyFailures_ForgeryReachesTerminal(t *testing.T) {
 	// Prove the pre-fix behavior: PresentResults leaves the error block in
 	// the discarded log, so nothing surfaces.
 	PresentResults(u, report, false, false)
-	if strings.Contains(buf.String(), "LOCKFILE-INTEGRITY") {
+	if strings.Contains(buf.String(), "UNREACHABLE-PIN") {
 		t.Fatalf("guard invalid: PresentResults unexpectedly surfaced the error block:\n%s", buf.String())
 	}
 
@@ -475,7 +475,7 @@ func TestPresentReadOnlyFailures_ForgeryReachesTerminal(t *testing.T) {
 
 	for _, want := range []string{
 		"1 of 1 workflow failed",
-		"Lockfile integrity",
+		"Unreachable pin",
 		"octo/action@main",
 		"pinned aaaa is not an ancestor of bbbb",
 		"investigate immediately",

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -330,7 +330,7 @@ func TestPresentResults_ParseWarningsSurface(t *testing.T) {
 // TestPresentResults_ExcludeCategoriesSkipsImpostor verifies that excluded
 // categories are not rendered in the error findings block. This prevents
 // duplication when renderInvestigationAlerts already surfaced the same
-// findings (e.g. lockfile-forgery).
+// findings (e.g. lockfile-integrity).
 func TestPresentResults_ExcludeCategoriesSkipsImpostor(t *testing.T) {
 	var buf bytes.Buffer
 	u := ui.NewPlain(&buf)
@@ -341,7 +341,7 @@ func TestPresentResults_ExcludeCategoriesSkipsImpostor(t *testing.T) {
 				Findings: []checks.Finding{
 					{
 						WorkflowPath: ".github/workflows/ci.yml",
-						Category:     checks.LockfileForgery,
+						Category:     checks.LockfileIntegrity,
 						Severity:     checks.SeverityError,
 						Confidence:   checks.ConfidenceHigh,
 						Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "v1", SHA: "aaaa"},
@@ -360,17 +360,17 @@ func TestPresentResults_ExcludeCategoriesSkipsImpostor(t *testing.T) {
 		},
 	}
 
-	PresentResults(u, report, false, false, checks.LockfileForgery)
+	PresentResults(u, report, false, false, checks.LockfileIntegrity)
 	got := buf.String()
 
-	if strings.Contains(got, "LOCKFILE-FORGERY") {
-		t.Errorf("excluded lockfile-forgery should not appear:\n%s", got)
+	if strings.Contains(got, "LOCKFILE-INTEGRITY") {
+		t.Errorf("excluded lockfile-integrity should not appear:\n%s", got)
 	}
 	if strings.Contains(got, "lockfile entry was not a prior state") {
 		t.Errorf("excluded forgery detail should not appear:\n%s", got)
 	}
 	// The summary line should not count the excluded category.
-	if strings.Contains(got, "lockfile-forgery") {
+	if strings.Contains(got, "lockfile-integrity") {
 		t.Errorf("excluded category should not appear in summary:\n%s", got)
 	}
 }
@@ -387,7 +387,7 @@ func TestPresentResults_ExcludeKeepsOtherFindings(t *testing.T) {
 				Findings: []checks.Finding{
 					{
 						WorkflowPath: ".github/workflows/ci.yml",
-						Category:     checks.LockfileForgery,
+						Category:     checks.LockfileIntegrity,
 						Severity:     checks.SeverityError,
 						Confidence:   checks.ConfidenceHigh,
 						Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "v1", SHA: "aaaa"},
@@ -405,11 +405,11 @@ func TestPresentResults_ExcludeKeepsOtherFindings(t *testing.T) {
 		},
 	}
 
-	PresentResults(u, report, false, false, checks.LockfileForgery)
+	PresentResults(u, report, false, false, checks.LockfileIntegrity)
 	got := buf.String()
 
-	if strings.Contains(got, "LOCKFILE-FORGERY") {
-		t.Errorf("excluded lockfile-forgery should not appear:\n%s", got)
+	if strings.Contains(got, "LOCKFILE-INTEGRITY") {
+		t.Errorf("excluded lockfile-integrity should not appear:\n%s", got)
 	}
 	if !strings.Contains(got, "LOCAL-ACTION") {
 		t.Errorf("non-excluded local-action should still appear:\n%s", got)
@@ -452,7 +452,7 @@ func TestPresentReadOnlyFailures_ForgeryReachesTerminal(t *testing.T) {
 			Path: ".github/workflows/ci.yml",
 			Findings: []checks.Finding{{
 				WorkflowPath: ".github/workflows/ci.yml",
-				Category:     checks.LockfileForgery,
+				Category:     checks.LockfileIntegrity,
 				Severity:     checks.SeverityError,
 				Confidence:   checks.ConfidenceHigh,
 				Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "main", SHA: "aaaa"},
@@ -466,7 +466,7 @@ func TestPresentReadOnlyFailures_ForgeryReachesTerminal(t *testing.T) {
 	// Prove the pre-fix behavior: PresentResults leaves the error block in
 	// the discarded log, so nothing surfaces.
 	PresentResults(u, report, false, false)
-	if strings.Contains(buf.String(), "LOCKFILE-FORGERY") {
+	if strings.Contains(buf.String(), "LOCKFILE-INTEGRITY") {
 		t.Fatalf("guard invalid: PresentResults unexpectedly surfaced the error block:\n%s", buf.String())
 	}
 
@@ -475,7 +475,7 @@ func TestPresentReadOnlyFailures_ForgeryReachesTerminal(t *testing.T) {
 
 	for _, want := range []string{
 		"1 of 1 workflow failed",
-		"Lockfile forgery",
+		"Lockfile integrity",
 		"octo/action@main",
 		"pinned aaaa is not an ancestor of bbbb",
 		"investigate immediately",

--- a/cmd/gh-actions-lock/pin_summary.go
+++ b/cmd/gh-actions-lock/pin_summary.go
@@ -16,7 +16,7 @@ import (
 // reportHasUnfixableErrors returns true when the report contains error-
 // severity findings that the autofix cannot resolve. Pinning resolves
 // not-pinned findings, so those are expected in the pre-fix report and
-// don't count. LocalAction and LockfileIntegrity errors are unfixable --
+// don't count. LocalAction and UnreachablePin errors are unfixable --
 // the workflow or lockfile must be investigated.
 func reportHasUnfixableErrors(report *checks.Report, acceptMoved bool) bool {
 	for _, wr := range report.Workflows {
@@ -27,7 +27,7 @@ func reportHasUnfixableErrors(report *checks.Report, acceptMoved bool) bool {
 			switch f.Category {
 			case checks.LocalAction:
 				return true
-			case checks.LockfileIntegrity:
+			case checks.UnreachablePin:
 				if !acceptMoved {
 					return true
 				}
@@ -40,7 +40,7 @@ func reportHasUnfixableErrors(report *checks.Report, acceptMoved bool) bool {
 // reportHasNonInvestigatedUnfixableErrors is like reportHasUnfixableErrors
 // but only matches categories that renderInvestigationAlerts does NOT
 // handle (LocalAction). Use this to gate the PresentResults call so
-// lockfile-integrity findings don't trigger a redundant (and stale) error
+// unreachable-pin findings don't trigger a redundant (and stale) error
 // summary.
 func reportHasNonInvestigatedUnfixableErrors(report *checks.Report) bool {
 	for _, wr := range report.Workflows {
@@ -133,13 +133,13 @@ func renderPinSummary(ctx context.Context, console *ui.UI, record *pin.Record, r
 	// findings surface on the terminal.
 	//
 	// Only trigger for categories NOT already rendered by
-	// renderInvestigationAlerts (which handles lockfile-integrity).
+	// renderInvestigationAlerts (which handles unreachable-pin).
 	// Without this gate PresentResults would also emit a stale summary
 	// line counting pre-fix not-pinned findings.
 	if reportHasNonInvestigatedUnfixableErrors(report) {
 		console.SetLog(nil)
 		format.PresentResults(console, report, false, false,
-			checks.LockfileIntegrity)
+			checks.UnreachablePin)
 	}
 
 	if len(investigated) > 0 || len(unresolvedEntries) > 0 || hasUnfixable {

--- a/cmd/gh-actions-lock/pin_summary.go
+++ b/cmd/gh-actions-lock/pin_summary.go
@@ -109,8 +109,13 @@ func renderPinSummary(ctx context.Context, console *ui.UI, record *pin.Record, r
 		console.TermBlank()
 		console.TermSuccess("All %d %s valid", total, ui.Pluralize(total, "workflow", "workflows"))
 		if skippedRescan > 0 {
-			console.TermDetail("Trusted lockfile for %d already-pinned %s; run `gh actions-lock --rescan` to re-verify reachability.",
-				skippedRescan, ui.Pluralize(skippedRescan, "workflow", "workflows"))
+			// Immutable pins were re-verified above; only mutable refs
+			// (branch/partial-version, which legitimately move) were
+			// trusted without a live check. Keep the nudge scoped to them
+			// so it doesn't contradict "valid".
+			console.TermDetail("%d mutable %s trusted without a live check — branch or partial-version pins (e.g. v4, main) that can move; run `gh actions-lock --rescan` to re-verify %s.",
+				skippedRescan, ui.Pluralize(skippedRescan, "ref", "refs"),
+				ui.Pluralize(skippedRescan, "it", "them"))
 		}
 		return nil
 	}

--- a/cmd/gh-actions-lock/pin_summary.go
+++ b/cmd/gh-actions-lock/pin_summary.go
@@ -16,7 +16,7 @@ import (
 // reportHasUnfixableErrors returns true when the report contains error-
 // severity findings that the autofix cannot resolve. Pinning resolves
 // not-pinned findings, so those are expected in the pre-fix report and
-// don't count. LocalAction and LockfileForgery errors are unfixable --
+// don't count. LocalAction and LockfileIntegrity errors are unfixable --
 // the workflow or lockfile must be investigated.
 func reportHasUnfixableErrors(report *checks.Report, acceptMoved bool) bool {
 	for _, wr := range report.Workflows {
@@ -27,7 +27,7 @@ func reportHasUnfixableErrors(report *checks.Report, acceptMoved bool) bool {
 			switch f.Category {
 			case checks.LocalAction:
 				return true
-			case checks.LockfileForgery:
+			case checks.LockfileIntegrity:
 				if !acceptMoved {
 					return true
 				}
@@ -40,7 +40,7 @@ func reportHasUnfixableErrors(report *checks.Report, acceptMoved bool) bool {
 // reportHasNonInvestigatedUnfixableErrors is like reportHasUnfixableErrors
 // but only matches categories that renderInvestigationAlerts does NOT
 // handle (LocalAction). Use this to gate the PresentResults call so
-// lockfile-forgery findings don't trigger a redundant (and stale) error
+// lockfile-integrity findings don't trigger a redundant (and stale) error
 // summary.
 func reportHasNonInvestigatedUnfixableErrors(report *checks.Report) bool {
 	for _, wr := range report.Workflows {
@@ -133,13 +133,13 @@ func renderPinSummary(ctx context.Context, console *ui.UI, record *pin.Record, r
 	// findings surface on the terminal.
 	//
 	// Only trigger for categories NOT already rendered by
-	// renderInvestigationAlerts (which handles lockfile-forgery).
+	// renderInvestigationAlerts (which handles lockfile-integrity).
 	// Without this gate PresentResults would also emit a stale summary
 	// line counting pre-fix not-pinned findings.
 	if reportHasNonInvestigatedUnfixableErrors(report) {
 		console.SetLog(nil)
 		format.PresentResults(console, report, false, false,
-			checks.LockfileForgery)
+			checks.LockfileIntegrity)
 	}
 
 	if len(investigated) > 0 || len(unresolvedEntries) > 0 || hasUnfixable {

--- a/cmd/gh-actions-lock/pin_summary.go
+++ b/cmd/gh-actions-lock/pin_summary.go
@@ -108,11 +108,13 @@ func renderPinSummary(ctx context.Context, console *ui.UI, record *pin.Record, r
 	if allClean && !hasUnfixable && onboardingRefused == 0 && !hasInconclusive {
 		console.TermBlank()
 		console.TermSuccess("All %d %s valid", total, ui.Pluralize(total, "workflow", "workflows"))
-		if skippedRescan > 0 {
-			// Immutable pins were re-verified above; only mutable refs
-			// (branch/partial-version, which legitimately move) were
-			// trusted without a live check. Keep the nudge scoped to them
-			// so it doesn't contradict "valid".
+		if noNarrow && skippedRescan > 0 {
+			// Mutable refs (v4, main) were trusted without a live check.
+			// With narrowing on, the version-ref nudge above already tells
+			// the user to pin precisely — which also buys live
+			// re-verification — so we don't add a competing --rescan line.
+			// Under --no-narrow that nudge is suppressed, so this is the
+			// only place the trust gap and its escape hatch surface.
 			console.TermDetail("%d mutable %s trusted without a live check — branch or partial-version pins (e.g. v4, main) that can move; run `gh actions-lock --rescan` to re-verify %s.",
 				skippedRescan, ui.Pluralize(skippedRescan, "ref", "refs"),
 				ui.Pluralize(skippedRescan, "it", "them"))

--- a/cmd/gh-actions-lock/run.go
+++ b/cmd/gh-actions-lock/run.go
@@ -51,7 +51,7 @@ type checkOptions struct {
 	// removed in the next minor release.
 	allowRunners    []string
 	allowAllRunners bool
-	// acceptMoved re-resolves deps flagged as lockfile-integrity or
+	// acceptMoved re-resolves deps flagged as unreachable-pin or
 	// ref-moved: prunes the stale lockfile entry and re-pins to the
 	// current live SHA.
 	acceptMoved bool
@@ -78,7 +78,7 @@ func bindCheckFlags(cmd *cobra.Command, opts *checkOptions) {
 			"far more likely to resolve to exactly one commit for its entire lifetime.")
 	cmd.Flags().StringSliceVar(&opts.allowRunners, "allow-runners", nil, "Deprecated no-op: runner restrictions have been removed")
 	cmd.Flags().BoolVarP(&opts.allowAllRunners, "allow-all-runners", "A", false, "Deprecated no-op: runner restrictions have been removed")
-	cmd.Flags().BoolVar(&opts.acceptMoved, "accept-moved", false, "Re-resolve deps flagged as ref-moved or lockfile-integrity to their current live SHA")
+	cmd.Flags().BoolVar(&opts.acceptMoved, "accept-moved", false, "Re-resolve deps flagged as ref-moved or unreachable-pin to their current live SHA")
 	cmd.Flags().BoolVar(&opts.verify, "verify", false, "Full re-verification of every pin (equivalent to --rescan --no-fix)")
 	cmd.Flags().BoolVar(&opts.verifyLocal, "verify-local", false,
 		"Offline lockfile coverage check: verify every action ref has a lockfile entry.\n"+

--- a/cmd/gh-actions-lock/run.go
+++ b/cmd/gh-actions-lock/run.go
@@ -284,7 +284,10 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 		}
 		if !valid {
 			if opts.jsonFields == "" {
-				console.TermDetail("Re-run without --no-fix to apply fixes.")
+				hasFixable := format.PresentReadOnlyFailures(console, report)
+				if hasFixable {
+					console.TermDetail("Re-run without --no-fix to apply fixes.")
+				}
 			}
 			return errSilent
 		}

--- a/cmd/gh-actions-lock/run.go
+++ b/cmd/gh-actions-lock/run.go
@@ -51,7 +51,7 @@ type checkOptions struct {
 	// removed in the next minor release.
 	allowRunners    []string
 	allowAllRunners bool
-	// acceptMoved re-resolves deps flagged as lockfile-forgery or
+	// acceptMoved re-resolves deps flagged as lockfile-integrity or
 	// ref-moved: prunes the stale lockfile entry and re-pins to the
 	// current live SHA.
 	acceptMoved bool
@@ -78,7 +78,7 @@ func bindCheckFlags(cmd *cobra.Command, opts *checkOptions) {
 			"far more likely to resolve to exactly one commit for its entire lifetime.")
 	cmd.Flags().StringSliceVar(&opts.allowRunners, "allow-runners", nil, "Deprecated no-op: runner restrictions have been removed")
 	cmd.Flags().BoolVarP(&opts.allowAllRunners, "allow-all-runners", "A", false, "Deprecated no-op: runner restrictions have been removed")
-	cmd.Flags().BoolVar(&opts.acceptMoved, "accept-moved", false, "Re-resolve deps flagged as ref-moved or lockfile-forgery to their current live SHA")
+	cmd.Flags().BoolVar(&opts.acceptMoved, "accept-moved", false, "Re-resolve deps flagged as ref-moved or lockfile-integrity to their current live SHA")
 	cmd.Flags().BoolVar(&opts.verify, "verify", false, "Full re-verification of every pin (equivalent to --rescan --no-fix)")
 	cmd.Flags().BoolVar(&opts.verifyLocal, "verify-local", false,
 		"Offline lockfile coverage check: verify every action ref has a lockfile entry.\n"+

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -30,7 +30,7 @@ type PlanOptions struct {
 	// patch tags (v4.2.1). Bare-SHA reverse lookup still applies.
 	NoNarrow bool
 
-	// AcceptMoved treats ref-moved and lockfile-forgery findings as
+	// AcceptMoved treats ref-moved and lockfile-integrity findings as
 	// resolvable: affected deps are pruned from the inventory and
 	// re-resolved to their current live SHA.
 	AcceptMoved bool
@@ -526,7 +526,7 @@ func pruneStaleInventory(inventory []checks.InventoryEntry, findings []checks.Fi
 		case f.Category == checks.Stale && f.Dependency != nil:
 			d := f.Dependency
 			stale[strings.ToLower(d.NWO+"@"+d.Ref+":"+d.SHA)] = true
-		case acceptMoved && (f.Category == checks.LockfileForgery || f.Category == checks.RefMoved) && f.Dependency != nil:
+		case acceptMoved && (f.Category == checks.LockfileIntegrity || f.Category == checks.RefMoved) && f.Dependency != nil:
 			d := f.Dependency
 			stale[strings.ToLower(d.NWO+"@"+d.Ref+":"+d.SHA)] = true
 		}

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -30,7 +30,7 @@ type PlanOptions struct {
 	// patch tags (v4.2.1). Bare-SHA reverse lookup still applies.
 	NoNarrow bool
 
-	// AcceptMoved treats ref-moved and lockfile-integrity findings as
+	// AcceptMoved treats ref-moved and unreachable-pin findings as
 	// resolvable: affected deps are pruned from the inventory and
 	// re-resolved to their current live SHA.
 	AcceptMoved bool
@@ -526,7 +526,7 @@ func pruneStaleInventory(inventory []checks.InventoryEntry, findings []checks.Fi
 		case f.Category == checks.Stale && f.Dependency != nil:
 			d := f.Dependency
 			stale[strings.ToLower(d.NWO+"@"+d.Ref+":"+d.SHA)] = true
-		case acceptMoved && (f.Category == checks.LockfileIntegrity || f.Category == checks.RefMoved) && f.Dependency != nil:
+		case acceptMoved && (f.Category == checks.UnreachablePin || f.Category == checks.RefMoved) && f.Dependency != nil:
 			d := f.Dependency
 			stale[strings.ToLower(d.NWO+"@"+d.Ref+":"+d.SHA)] = true
 		}

--- a/internal/pipeline/checks/category.go
+++ b/internal/pipeline/checks/category.go
@@ -3,9 +3,8 @@
 package checks
 
 // Category classifies the state of a workflow or action dependency. The string
-// values are part of the schema surfaced to consumers (SARIF rule IDs, JSON
-// output, doc URL slugs); the frozen-strings test guards against accidental
-// renames.
+// values are part of the schema surfaced to consumers (JSON output, doc URL
+// slugs); the frozen-strings test guards against accidental renames.
 type Category string
 
 const (
@@ -27,10 +26,10 @@ const (
 	// MisleadingSHA means a ref looks like a SHA but resolves to a
 	// different commit.
 	MisleadingSHA Category = "misleading-sha"
-	// LockfileForgery means the pinned SHA is not an ancestor of the
+	// LockfileIntegrity means the pinned SHA is not an ancestor of the
 	// current ref — the lockfile entry was likely injected or
 	// tampered with.
-	LockfileForgery Category = "lockfile-forgery"
+	LockfileIntegrity Category = "lockfile-integrity"
 	// Valid means the dependency is pinned and verified.
 	Valid Category = "valid"
 	// RunOnly means the workflow has no action refs (only run:
@@ -40,7 +39,7 @@ const (
 	// the pinned SHA is in the ref's history (typically rate-limited
 	// or transient error). Non-blocking diagnostic: we know the SHAs
 	// differ but can't classify the move as benign-but-known
-	// (ref-moved) vs. tampered (lockfile-forgery).
+	// (ref-moved) vs. tampered (lockfile-integrity).
 	AncestryUnknown Category = "ancestry-unknown"
 	// ReachabilityUnknown means branch_commits couldn't decide
 	// whether the pinned SHA is still reachable from any branch in

--- a/internal/pipeline/checks/category.go
+++ b/internal/pipeline/checks/category.go
@@ -26,10 +26,13 @@ const (
 	// MisleadingSHA means a ref looks like a SHA but resolves to a
 	// different commit.
 	MisleadingSHA Category = "misleading-sha"
-	// LockfileIntegrity means the pinned SHA is not an ancestor of the
-	// current ref — the lockfile entry was likely injected or
-	// tampered with.
-	LockfileIntegrity Category = "lockfile-integrity"
+	// UnreachablePin means the pinned SHA is not an ancestor of, and
+	// not reachable from, the ref's current head. The pin points at a
+	// commit that was never in the ref's history or was dropped by an
+	// upstream history rewrite (squash/force-push) — or the lockfile
+	// entry was tampered with. The check can't distinguish those, so it
+	// fails closed without asserting an attack.
+	UnreachablePin Category = "unreachable-pin"
 	// Valid means the dependency is pinned and verified.
 	Valid Category = "valid"
 	// RunOnly means the workflow has no action refs (only run:
@@ -39,7 +42,7 @@ const (
 	// the pinned SHA is in the ref's history (typically rate-limited
 	// or transient error). Non-blocking diagnostic: we know the SHAs
 	// differ but can't classify the move as benign-but-known
-	// (ref-moved) vs. tampered (lockfile-integrity).
+	// (ref-moved) vs. tampered (unreachable-pin).
 	AncestryUnknown Category = "ancestry-unknown"
 	// ReachabilityUnknown means branch_commits couldn't decide
 	// whether the pinned SHA is still reachable from any branch in

--- a/internal/pipeline/checks/category_test.go
+++ b/internal/pipeline/checks/category_test.go
@@ -17,7 +17,7 @@ func TestCategoryStringsAreFrozen(t *testing.T) {
 		{RefMoved, "ref-moved"},
 		{Stale, "stale"},
 		{MisleadingSHA, "misleading-sha"},
-		{LockfileIntegrity, "lockfile-integrity"},
+		{UnreachablePin, "unreachable-pin"},
 		{Valid, "valid"},
 		{RunOnly, "run-only"},
 		{AncestryUnknown, "ancestry-unknown"},
@@ -45,7 +45,7 @@ func TestCategoryIsInconclusive(t *testing.T) {
 	}
 	blocking := []Category{
 		NotPinned, ShaAsRef, RefChanged, RefMoved, Stale,
-		MisleadingSHA, LockfileIntegrity,
+		MisleadingSHA, UnreachablePin,
 		Valid, RunOnly, OnboardingRequired, VersionRef, LocalAction,
 	}
 	for _, c := range blocking {

--- a/internal/pipeline/checks/category_test.go
+++ b/internal/pipeline/checks/category_test.go
@@ -17,7 +17,7 @@ func TestCategoryStringsAreFrozen(t *testing.T) {
 		{RefMoved, "ref-moved"},
 		{Stale, "stale"},
 		{MisleadingSHA, "misleading-sha"},
-		{LockfileForgery, "lockfile-forgery"},
+		{LockfileIntegrity, "lockfile-integrity"},
 		{Valid, "valid"},
 		{RunOnly, "run-only"},
 		{AncestryUnknown, "ancestry-unknown"},
@@ -45,7 +45,7 @@ func TestCategoryIsInconclusive(t *testing.T) {
 	}
 	blocking := []Category{
 		NotPinned, ShaAsRef, RefChanged, RefMoved, Stale,
-		MisleadingSHA, LockfileForgery,
+		MisleadingSHA, LockfileIntegrity,
 		Valid, RunOnly, OnboardingRequired, VersionRef, LocalAction,
 	}
 	for _, c := range blocking {

--- a/internal/pipeline/checks/finding.go
+++ b/internal/pipeline/checks/finding.go
@@ -29,7 +29,7 @@ type Finding struct {
 	Remediation string
 	// ObservedSHA is the SHA the resolver got at scan time, recorded when
 	// it differs from the pinned SHA (e.g. ref-moved, misleading-sha,
-	// lockfile-forgery).
+	// lockfile-integrity).
 	ObservedSHA string
 	// DocURL points to docs explaining the finding. Populated by the
 	// engine adapter so it's parity-aligned with the editor's

--- a/internal/pipeline/checks/finding.go
+++ b/internal/pipeline/checks/finding.go
@@ -29,7 +29,7 @@ type Finding struct {
 	Remediation string
 	// ObservedSHA is the SHA the resolver got at scan time, recorded when
 	// it differs from the pinned SHA (e.g. ref-moved, misleading-sha,
-	// lockfile-integrity).
+	// unreachable-pin).
 	ObservedSHA string
 	// DocURL points to docs explaining the finding. Populated by the
 	// engine adapter so it's parity-aligned with the editor's

--- a/internal/pipeline/checks/misleading.go
+++ b/internal/pipeline/checks/misleading.go
@@ -46,7 +46,7 @@ func checkMisleadingSha(ctx context.Context, pw ParsedWorkflow, r CheckResolver)
 // checkRefMovedAndForgery emits RefMoved when the upstream ref
 // resolves to a different SHA than the lockfile. If CheckAncestry confirms
 // the locked SHA is NOT an ancestor of the observed SHA, the finding is
-// upgraded to LockfileForgery (mutually exclusive with ref-moved).
+// upgraded to LockfileIntegrity (mutually exclusive with ref-moved).
 // When the observed SHA is itself unreachable from any branch of the
 // upstream repo (tag-moved-to-fork-network), an additional
 // lockfile-tampering claim is stronger.
@@ -116,7 +116,7 @@ func checkOneRefMoved(ctx context.Context, pw ParsedWorkflow, ref parserlock.Act
 	f.Dependency = synthDep(ref, pin.SHA())
 	switch ancestry {
 	case resolve.AncestryNotAncestor:
-		f.Category = LockfileForgery
+		f.Category = LockfileIntegrity
 		f.Severity = SeverityError
 		f.Confidence = ConfidenceHigh
 		f.Detail = fmt.Sprintf("pinned %s is not an ancestor of %s — lockfile may have been tampered with", parserlock.ShortSHA(pin.SHA()), parserlock.ShortSHA(sha))
@@ -126,7 +126,7 @@ func checkOneRefMoved(ctx context.Context, pw ParsedWorkflow, ref parserlock.Act
 		f.Severity = SeverityWarning
 		f.Confidence = ConfidenceMedium
 		f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s (ancestry check inconclusive%s)", ref.Ref, parserlock.ShortSHA(sha), parserlock.ShortSHA(pin.SHA()), suffixWith(ancestryDetail))
-		f.Remediation = "retry when the Compare API is available to classify this as ref-moved or lockfile-forgery"
+		f.Remediation = "retry when the Compare API is available to classify this as ref-moved or lockfile-integrity"
 	default:
 		f.Category = RefMoved
 		f.Severity = SeverityWarning

--- a/internal/pipeline/checks/misleading.go
+++ b/internal/pipeline/checks/misleading.go
@@ -46,7 +46,7 @@ func checkMisleadingSha(ctx context.Context, pw ParsedWorkflow, r CheckResolver)
 // checkRefMovedAndForgery emits RefMoved when the upstream ref
 // resolves to a different SHA than the lockfile. If CheckAncestry confirms
 // the locked SHA is NOT an ancestor of the observed SHA, the finding is
-// upgraded to LockfileIntegrity (mutually exclusive with ref-moved).
+// upgraded to UnreachablePin (mutually exclusive with ref-moved).
 // When the observed SHA is itself unreachable from any branch of the
 // upstream repo (tag-moved-to-fork-network), an additional
 // lockfile-tampering claim is stronger.
@@ -116,7 +116,7 @@ func checkOneRefMoved(ctx context.Context, pw ParsedWorkflow, ref parserlock.Act
 	f.Dependency = synthDep(ref, pin.SHA())
 	switch ancestry {
 	case resolve.AncestryNotAncestor:
-		f.Category = LockfileIntegrity
+		f.Category = UnreachablePin
 		f.Severity = SeverityError
 		f.Confidence = ConfidenceHigh
 		f.Detail = fmt.Sprintf("pinned %s is not an ancestor of %s — lockfile may have been tampered with", parserlock.ShortSHA(pin.SHA()), parserlock.ShortSHA(sha))
@@ -126,7 +126,7 @@ func checkOneRefMoved(ctx context.Context, pw ParsedWorkflow, ref parserlock.Act
 		f.Severity = SeverityWarning
 		f.Confidence = ConfidenceMedium
 		f.Detail = fmt.Sprintf("ref %s now resolves to %s, lockfile pins %s (ancestry check inconclusive%s)", ref.Ref, parserlock.ShortSHA(sha), parserlock.ShortSHA(pin.SHA()), suffixWith(ancestryDetail))
-		f.Remediation = "retry when the Compare API is available to classify this as ref-moved or lockfile-integrity"
+		f.Remediation = "retry when the Compare API is available to classify this as ref-moved or unreachable-pin"
 	default:
 		f.Category = RefMoved
 		f.Severity = SeverityWarning

--- a/internal/pipeline/checks/parsed.go
+++ b/internal/pipeline/checks/parsed.go
@@ -63,6 +63,16 @@ func (pw ParsedWorkflow) IsFullyRecorded() bool {
 	return len(pw.Refs) == 0 || len(unrecorded) == 0
 }
 
+// IsImmutableRef reports whether ref is a full semver tag (e.g. v4.2.1),
+// which resolves to exactly one commit for its entire lifetime. Full semver
+// pins are re-verified against upstream on the default path; mutable refs
+// (v4, v4.2, branches) are trusted until --rescan because they legitimately
+// move.
+func IsImmutableRef(ref string) bool {
+	sv, ok := parserlock.ParseSemVer(ref)
+	return ok && sv.IsFull()
+}
+
 // RecordedDeps returns the subset of ExistingDeps whose NWO@Ref or
 // NWO@SHA matches one of the given recorded refs.
 func (pw ParsedWorkflow) RecordedDeps(recorded []parserlock.ActionRef) []dep.Dependency {

--- a/internal/pipeline/checks/parsed_test.go
+++ b/internal/pipeline/checks/parsed_test.go
@@ -1,0 +1,29 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsImmutableRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"v4.2.1", true},      // full semver: one commit for life
+		{"4.2.1", true},       // full semver without leading v
+		{"v4", false},         // major-only: moves as patches land
+		{"v4.2", false},       // major.minor: moves
+		{"v4.2.1-rc1", false}, // prerelease: not a full stable tag
+		{"main", false},       // branch
+		{"master", false},     // branch
+		{"de0fac2e4500dabe0009e67214ff5f5447ce83dd", false}, // bare SHA
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsImmutableRef(tt.ref))
+		})
+	}
+}

--- a/internal/pipeline/checks/run_test.go
+++ b/internal/pipeline/checks/run_test.go
@@ -227,7 +227,7 @@ func TestRunChecks(t *testing.T) {
 			},
 		},
 		{
-			name: "lockfile-forgery: pinned sha is not an ancestor of upstream",
+			name: "lockfile-integrity: pinned sha is not an ancestor of upstream",
 			lockfile: map[string][]string{
 				wfPath: {checkPinKey("actions", "checkout", "v4", shaImpostor)},
 			},
@@ -243,7 +243,7 @@ func TestRunChecks(t *testing.T) {
 			extra: func(t *testing.T, got []Finding) {
 				hasForgery := false
 				for _, f := range got {
-					if f.Category == LockfileForgery {
+					if f.Category == LockfileIntegrity {
 						hasForgery = true
 						if f.Severity != SeverityError {
 							t.Fatalf("expected error severity, got %s", f.Severity)
@@ -257,7 +257,7 @@ func TestRunChecks(t *testing.T) {
 					}
 				}
 				if !hasForgery {
-					t.Fatalf("expected a lockfile-forgery finding, got %v", findingCategories(got))
+					t.Fatalf("expected a lockfile-integrity finding, got %v", findingCategories(got))
 				}
 			},
 		},
@@ -325,7 +325,7 @@ func TestRunChecks(t *testing.T) {
 		{
 			// Compare API rate-limit fallback: ancestry is unknown so
 			// the SHA mismatch can't be classified as ref-moved or
-			// lockfile-forgery. Emit AncestryUnknown so
+			// lockfile-integrity. Emit AncestryUnknown so
 			// consumers don't conflate "scan inconclusive" with valid.
 			name: "ancestry unknown emits ancestry-unknown, not ref-moved",
 			lockfile: map[string][]string{
@@ -450,12 +450,12 @@ func TestRunChecks(t *testing.T) {
 			extra: func(t *testing.T, got []Finding) {
 				hasForgery := false
 				for _, c := range findingCategories(got) {
-					if c == string(LockfileForgery) {
+					if c == string(LockfileIntegrity) {
 						hasForgery = true
 					}
 				}
 				if !hasForgery {
-					t.Fatalf("expected lockfile-forgery, got %v", findingCategories(got))
+					t.Fatalf("expected lockfile-integrity, got %v", findingCategories(got))
 				}
 			},
 		},
@@ -527,7 +527,7 @@ func TestRunChecks(t *testing.T) {
 			},
 			extra: func(t *testing.T, got []Finding) {
 				for _, f := range got {
-					if f.Category == RefMoved || f.Category == LockfileForgery || f.Category == AncestryUnknown {
+					if f.Category == RefMoved || f.Category == LockfileIntegrity || f.Category == AncestryUnknown {
 						t.Fatalf("unexpected ref-moved/forgery finding for current transitive dep: %#v", f)
 					}
 				}

--- a/internal/pipeline/checks/run_test.go
+++ b/internal/pipeline/checks/run_test.go
@@ -227,7 +227,7 @@ func TestRunChecks(t *testing.T) {
 			},
 		},
 		{
-			name: "lockfile-integrity: pinned sha is not an ancestor of upstream",
+			name: "unreachable-pin: pinned sha is not an ancestor of upstream",
 			lockfile: map[string][]string{
 				wfPath: {checkPinKey("actions", "checkout", "v4", shaImpostor)},
 			},
@@ -243,7 +243,7 @@ func TestRunChecks(t *testing.T) {
 			extra: func(t *testing.T, got []Finding) {
 				hasForgery := false
 				for _, f := range got {
-					if f.Category == LockfileIntegrity {
+					if f.Category == UnreachablePin {
 						hasForgery = true
 						if f.Severity != SeverityError {
 							t.Fatalf("expected error severity, got %s", f.Severity)
@@ -257,7 +257,7 @@ func TestRunChecks(t *testing.T) {
 					}
 				}
 				if !hasForgery {
-					t.Fatalf("expected a lockfile-integrity finding, got %v", findingCategories(got))
+					t.Fatalf("expected a unreachable-pin finding, got %v", findingCategories(got))
 				}
 			},
 		},
@@ -325,7 +325,7 @@ func TestRunChecks(t *testing.T) {
 		{
 			// Compare API rate-limit fallback: ancestry is unknown so
 			// the SHA mismatch can't be classified as ref-moved or
-			// lockfile-integrity. Emit AncestryUnknown so
+			// unreachable-pin. Emit AncestryUnknown so
 			// consumers don't conflate "scan inconclusive" with valid.
 			name: "ancestry unknown emits ancestry-unknown, not ref-moved",
 			lockfile: map[string][]string{
@@ -450,12 +450,12 @@ func TestRunChecks(t *testing.T) {
 			extra: func(t *testing.T, got []Finding) {
 				hasForgery := false
 				for _, c := range findingCategories(got) {
-					if c == string(LockfileIntegrity) {
+					if c == string(UnreachablePin) {
 						hasForgery = true
 					}
 				}
 				if !hasForgery {
-					t.Fatalf("expected lockfile-integrity, got %v", findingCategories(got))
+					t.Fatalf("expected unreachable-pin, got %v", findingCategories(got))
 				}
 			},
 		},
@@ -527,7 +527,7 @@ func TestRunChecks(t *testing.T) {
 			},
 			extra: func(t *testing.T, got []Finding) {
 				for _, f := range got {
-					if f.Category == RefMoved || f.Category == LockfileIntegrity || f.Category == AncestryUnknown {
+					if f.Category == RefMoved || f.Category == UnreachablePin || f.Category == AncestryUnknown {
 						t.Fatalf("unexpected ref-moved/forgery finding for current transitive dep: %#v", f)
 					}
 				}

--- a/internal/pipeline/diagnose_helpers_test.go
+++ b/internal/pipeline/diagnose_helpers_test.go
@@ -46,7 +46,7 @@ func TestHasIssues(t *testing.T) {
 		{
 			name: "error severity is always an issue",
 			findings: []checks.Finding{
-				{Category: checks.LockfileIntegrity, Severity: checks.SeverityError},
+				{Category: checks.UnreachablePin, Severity: checks.SeverityError},
 			},
 			want: true,
 		},

--- a/internal/pipeline/diagnose_helpers_test.go
+++ b/internal/pipeline/diagnose_helpers_test.go
@@ -46,7 +46,7 @@ func TestHasIssues(t *testing.T) {
 		{
 			name: "error severity is always an issue",
 			findings: []checks.Finding{
-				{Category: checks.LockfileForgery, Severity: checks.SeverityError},
+				{Category: checks.LockfileIntegrity, Severity: checks.SeverityError},
 			},
 			want: true,
 		},

--- a/internal/pipeline/doc_urls.go
+++ b/internal/pipeline/doc_urls.go
@@ -16,7 +16,7 @@ import "github.com/github/gh-actions-lock/internal/pipeline/checks"
 const securityHardeningBase = "https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions"
 
 // PublisherTagReleasesDocURL points to GitHub's guidance for action publishers
-// on tagging releases from a branch. It's surfaced alongside lockfile-integrity
+// on tagging releases from a branch. It's surfaced alongside unreachable-pin
 // findings to help users escalate to the action's maintainer when the pinned
 // SHA is orphaned (off any branch) — a publisher behavior the consumer can't
 // fix locally beyond re-pinning to a sane release.
@@ -35,7 +35,7 @@ var docURLs = map[checks.Category]string{
 	checks.Stale:               securityHardeningBase + "#using-third-party-actions",
 	checks.MisleadingSHA:       securityHardeningBase + "#using-third-party-actions",
 	checks.RefMoved:            securityHardeningBase + "#using-third-party-actions",
-	checks.LockfileIntegrity:   securityHardeningBase + "#using-third-party-actions",
+	checks.UnreachablePin:      securityHardeningBase + "#using-third-party-actions",
 	checks.OnboardingRequired:  securityHardeningBase + "#using-third-party-actions",
 	checks.AncestryUnknown:     securityHardeningBase + "#using-third-party-actions",
 	checks.ReachabilityUnknown: securityHardeningBase + "#using-third-party-actions",

--- a/internal/pipeline/doc_urls.go
+++ b/internal/pipeline/doc_urls.go
@@ -16,7 +16,7 @@ import "github.com/github/gh-actions-lock/internal/pipeline/checks"
 const securityHardeningBase = "https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions"
 
 // PublisherTagReleasesDocURL points to GitHub's guidance for action publishers
-// on tagging releases from a branch. It's surfaced alongside lockfile-forgery
+// on tagging releases from a branch. It's surfaced alongside lockfile-integrity
 // findings to help users escalate to the action's maintainer when the pinned
 // SHA is orphaned (off any branch) — a publisher behavior the consumer can't
 // fix locally beyond re-pinning to a sane release.
@@ -35,7 +35,7 @@ var docURLs = map[checks.Category]string{
 	checks.Stale:               securityHardeningBase + "#using-third-party-actions",
 	checks.MisleadingSHA:       securityHardeningBase + "#using-third-party-actions",
 	checks.RefMoved:            securityHardeningBase + "#using-third-party-actions",
-	checks.LockfileForgery:     securityHardeningBase + "#using-third-party-actions",
+	checks.LockfileIntegrity:   securityHardeningBase + "#using-third-party-actions",
 	checks.OnboardingRequired:  securityHardeningBase + "#using-third-party-actions",
 	checks.AncestryUnknown:     securityHardeningBase + "#using-third-party-actions",
 	checks.ReachabilityUnknown: securityHardeningBase + "#using-third-party-actions",

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
 	"github.com/github/gh-actions-lock/internal/dep"
 	"github.com/github/gh-actions-lock/internal/lockfile"
 	"github.com/github/gh-actions-lock/internal/pinpool"
@@ -30,7 +31,7 @@ type RunOptions struct {
 type RunResult struct {
 	Report        *checks.Report
 	Valid         bool
-	SkippedRescan int // already-pinned workflows trusted without network calls
+	SkippedRescan int // mutable recorded refs (v4, branches) trusted without a live re-check
 }
 
 // Run executes the full diagnostic pipeline: parse → trust-check →
@@ -51,31 +52,32 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	// Fast path: trust fully-recorded workflows. For partially-recorded
 	// workflows, seed the resolver cache with recorded deps so only
 	// unrecorded refs hit the network.
+	//
+	// Immutable full-semver pins (e.g. v4.2.1) are NOT trusted blindly:
+	// they're routed through live resolution + ancestry so a stale or
+	// unreachable pin is caught on the default path, not just under
+	// --rescan. Mutable recorded refs (v4, v4.2, branches) legitimately
+	// move, so they stay trusted (seeded from the lockfile) until --rescan.
 	skippedRescan := 0
 	var seedDeps []dep.Dependency
 	recordedKeys := make(map[string]bool)
 	if !opts.Rescan {
 		for i := range parsed {
-			// Local-path workflows are skipped at diagnose time; don't
-			// waste network calls resolving their refs.
-			if len(parsed[i].LocalPaths) > 0 {
+			plan := planFastPath(parsed[i])
+			// Mutable recorded refs are trusted without a live re-check
+			// (surfaced in the summary so the operator can --rescan them).
+			skippedRescan += len(plan.mutableRefs)
+			if plan.resolved {
 				parsed[i].Resolved = true
 				continue
 			}
-			recorded, unrecorded := parsed[i].PartitionRefs()
-			if len(parsed[i].Refs) == 0 || len(unrecorded) == 0 {
-				parsed[i].Resolved = true
-				skippedRescan++
-			} else {
-				// Collect deps covered by recorded refs for cache
-				// seeding. These refs have matching lockfile entries,
-				// so their resolve results can be served from the
-				// lockfile rather than the network.
-				rd := parsed[i].RecordedDeps(recorded)
-				seedDeps = append(seedDeps, rd...)
-				for _, r := range recorded {
-					recordedKeys[strings.ToLower(r.Owner+"/"+r.Repo)+"@"+r.Ref] = true
-				}
+			// Seed only the mutable recorded deps so they resolve from
+			// the lockfile (trusted); immutable and unrecorded refs are
+			// left to resolve live from the network.
+			rd := parsed[i].RecordedDeps(plan.mutableRefs)
+			seedDeps = append(seedDeps, rd...)
+			for _, rr := range plan.mutableRefs {
+				recordedKeys[strings.ToLower(rr.Owner+"/"+rr.Repo)+"@"+rr.Ref] = true
 			}
 		}
 	}
@@ -142,4 +144,43 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 		Valid:         valid,
 		SkippedRescan: skippedRescan,
 	}, nil
+}
+
+// fastPathPlan describes how the pre-resolution fast path treats one
+// recorded workflow.
+type fastPathPlan struct {
+	// resolved is true when the workflow needs no live resolution: it has
+	// no refs, is a local-path action, or every recorded ref is a trusted
+	// mutable pin.
+	resolved bool
+	// mutableRefs are recorded refs (v4, v4.2, branches) trusted from the
+	// lockfile without a live re-check.
+	mutableRefs []parserlock.ActionRef
+}
+
+// planFastPath decides, without touching the network, whether a parsed
+// workflow can skip live resolution and which of its recorded refs are
+// trusted mutable pins. Immutable full-semver pins (v4.2.1) are never
+// trusted blindly: their presence forces live resolution so a stale or
+// unreachable pin is caught on the default path, not just under --rescan.
+func planFastPath(pw checks.ParsedWorkflow) fastPathPlan {
+	// Local-path workflows are handled at diagnose time; don't waste
+	// network calls resolving their refs.
+	if len(pw.LocalPaths) > 0 {
+		return fastPathPlan{resolved: true}
+	}
+	recorded, unrecorded := pw.PartitionRefs()
+
+	var mutable []parserlock.ActionRef
+	immutableCount := 0
+	for _, rr := range recorded {
+		if checks.IsImmutableRef(rr.Ref) {
+			immutableCount++
+		} else {
+			mutable = append(mutable, rr)
+		}
+	}
+
+	resolved := len(pw.Refs) == 0 || (len(unrecorded) == 0 && immutableCount == 0)
+	return fastPathPlan{resolved: resolved, mutableRefs: mutable}
 }

--- a/internal/pipeline/run_test.go
+++ b/internal/pipeline/run_test.go
@@ -17,6 +17,80 @@ func mkDep(nwo, ref, sha string) dep.Dependency {
 	return dep.Dependency{NWO: nwo, Ref: ref, SHA: sha}
 }
 
+func TestPlanFastPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		pw           checks.ParsedWorkflow
+		wantResolved bool
+		wantMutable  int
+	}{
+		{
+			name: "all mutable recorded → trusted, no live resolution",
+			pw: checks.ParsedWorkflow{
+				Refs:         []parserlock.ActionRef{ref("actions", "checkout", "", "v4")},
+				ExistingDeps: []dep.Dependency{mkDep("actions/checkout", "v4", "aaa")},
+			},
+			wantResolved: true,
+			wantMutable:  1,
+		},
+		{
+			name: "immutable recorded pin → forces live resolution (the #819 fix)",
+			pw: checks.ParsedWorkflow{
+				Refs:         []parserlock.ActionRef{ref("actions", "checkout", "", "v4.2.1")},
+				ExistingDeps: []dep.Dependency{mkDep("actions/checkout", "v4.2.1", "aaa")},
+			},
+			wantResolved: false,
+			wantMutable:  0,
+		},
+		{
+			name: "mixed immutable + mutable → resolve live, trust the mutable one",
+			pw: checks.ParsedWorkflow{
+				Refs: []parserlock.ActionRef{
+					ref("actions", "checkout", "", "v4.2.1"),
+					ref("actions", "setup-go", "", "v5"),
+				},
+				ExistingDeps: []dep.Dependency{
+					mkDep("actions/checkout", "v4.2.1", "aaa"),
+					mkDep("actions/setup-go", "v5", "bbb"),
+				},
+			},
+			wantResolved: false,
+			wantMutable:  1,
+		},
+		{
+			name: "unrecorded ref → resolve live, nothing trusted",
+			pw: checks.ParsedWorkflow{
+				Refs:         []parserlock.ActionRef{ref("actions", "checkout", "", "v4")},
+				ExistingDeps: nil,
+			},
+			wantResolved: false,
+			wantMutable:  0,
+		},
+		{
+			name:         "no refs → resolved, nothing to do",
+			pw:           checks.ParsedWorkflow{},
+			wantResolved: true,
+			wantMutable:  0,
+		},
+		{
+			name: "local-path workflow → resolved, refs untouched",
+			pw: checks.ParsedWorkflow{
+				LocalPaths: []string{"./my-local-action"},
+				Refs:       []parserlock.ActionRef{ref("actions", "checkout", "", "v4.2.1")},
+			},
+			wantResolved: true,
+			wantMutable:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := planFastPath(tt.pw)
+			assert.Equal(t, tt.wantResolved, plan.resolved, "resolved")
+			assert.Len(t, plan.mutableRefs, tt.wantMutable, "mutableRefs")
+		})
+	}
+}
+
 func TestPartitionRefs(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/script/lockfile-lint.sh
+++ b/script/lockfile-lint.sh
@@ -16,14 +16,17 @@ else
   jq_ignore_filter='[]'
 fi
 
-# Run the check, capture JSON stdout separately from stderr
+# Run the check, capture JSON stdout separately from stderr.
+# --rescan re-verifies every recorded pin against upstream (bypasses the
+# lockfile fast path) so CI catches stale/unreachable pins, not just
+# structural drift. GH_TOKEN (wired by the action) covers resolution.
 exit_code=0
-json_output=$($binary --no-fix --no-interactive --json=valid,findings,workflows "$@" 2>/dev/null) || exit_code=$?
+json_output=$($binary --no-fix --rescan --no-interactive --json=valid,findings,workflows "$@" 2>/dev/null) || exit_code=$?
 
 # If exit code 2, the tool itself failed — re-run to show stderr
 if [ "$exit_code" -eq 2 ]; then
   echo "::error::gh-actions-lock failed:"
-  $binary --no-fix --no-interactive "$@" 2>&1 || true
+  $binary --no-fix --rescan --no-interactive "$@" 2>&1 || true
   exit 2
 fi
 

--- a/test/integration/harness.rb
+++ b/test/integration/harness.rb
@@ -549,7 +549,7 @@ module ActionsPin
       # corresponding response is written to the PTY's stdin.
       def run_pty(input_prompts: nil, extra_args: [])
         cmd = @cmd + extra_args
-        flat_env = @env.map { |k, v| "#{k}=#{Shellwords.shellescape(v)}" }
+        flat_env = @env.reject { |_, v| v.nil? }.map { |k, v| "#{k}=#{Shellwords.shellescape(v)}" }
         # Unset CI so the binary's interactive prompt isn't suppressed
         # (GitHub Actions always exports CI=true).
         flat_env.unshift("CI=")
@@ -617,7 +617,9 @@ module ActionsPin
       end
 
       def env_exports
-        @env.map { |k, v| "export #{k}=#{Shellwords.shellescape(v)}" }.join("\n")
+        @env.map do |k, v|
+          v.nil? ? "unset #{k}" : "export #{k}=#{Shellwords.shellescape(v)}"
+        end.join("\n")
       end
 
       def cmd_string(extra_args: [])

--- a/test/integration/run.rb
+++ b/test/integration/run.rb
@@ -755,6 +755,12 @@ catalog["scenarios"].each do |spec|
     # CLI flags
     s.args(*flags) unless flags.empty?
 
+    # Declarative env overrides (nil value unsets the var). Used by
+    # offline/unauthed scenarios to strip ambient auth and redirect GH_HOST.
+    if spec["env"].is_a?(Hash)
+      spec["env"].each { |k, v| s.env(k => v) }
+    end
+
     # Token-required scenarios: use explicit GH_TOKEN if set, otherwise
     # fall back to gh CLI auth (go-gh resolves this automatically).
     # Only skip if neither is available.

--- a/test/scenarios/catalog.go
+++ b/test/scenarios/catalog.go
@@ -35,6 +35,11 @@ type Scenario struct {
 	Flags       []string `yaml:"flags"`
 	LiveRepo    string   `yaml:"live_repo"`
 
+	// Env sets or unsets process environment variables for the run. A nil
+	// value unsets the variable (YAML null), letting scenarios strip ambient
+	// auth or redirect GH_HOST to prove offline behavior.
+	Env map[string]*string `yaml:"env,omitempty"`
+
 	Fixtures Fixtures `yaml:"fixtures"`
 	Expect   Expect   `yaml:"expect"`
 }

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -81,11 +81,13 @@ scenarios:
       lockfile_deps_cover_direct: true
       lockfile_contains: ["'actions/checkout@v4':"]
       lockfile_comment_excludes: 'actions/checkout@v4\.\d'
-      # v4 is a mutable pin: trusted without a live check, and the summary
-      # says so honestly instead of asserting "valid" then telling you to
-      # --rescan to actually verify it.
-      output_contains: ["trusted without a live check"]
-      output_excludes: ["re-verify reachability"]
+      # v4 is a partial-semver pin: with narrowing on (default), the
+      # version-ref nudge is the single actionable message (pin precisely,
+      # which also earns live re-verification). The summary must NOT add a
+      # competing --rescan line, and must not resurrect the old "re-verify
+      # reachability" contradiction.
+      output_contains: ["pinned without a full semver tag", "lock precisely"]
+      output_excludes: ["trusted without a live check", "re-verify reachability"]
 
   - name: multi_action_happy
     category: happy_path

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -38,7 +38,7 @@ categories:
   - name: multi_workflow
     description: "Cross-workflow scenarios and dependency tracking"
   - name: security
-    description: "Impostor commit, lockfile forgery, reachability"
+    description: "Impostor commit, unreachable pin, reachability"
   - name: narrowing
     description: "Tag narrowing, --no-narrow, sticky precision, and version-ref nudges"
   - name: onboarding
@@ -1682,7 +1682,7 @@ scenarios:
 
   - name: dbot_forgery_blocks
     category: dependabot
-    description: "Lockfile forgery (pin doesn't match resolved commit) produces lockfile-forgery/error finding"
+    description: "Stale pin (lockfile SHA not reachable from the ref head) produces unreachable-pin/error finding"
     needs_stub: true
     tags: [stub]
     flags: ["--no-onboard", "--no-narrow", "--no-interactive", "--rescan", "--json=valid,findings"]
@@ -1700,9 +1700,9 @@ scenarios:
           equals: "false"
         - expr: '.findings | length'
           greater_than: 0
-        - expr: '.findings[] | select(.category == "lockfile-forgery") | .category'
-          equals: "lockfile-forgery"
-        - expr: '.findings[] | select(.category == "lockfile-forgery") | .severity'
+        - expr: '.findings[] | select(.category == "unreachable-pin") | .category'
+          equals: "unreachable-pin"
+        - expr: '.findings[] | select(.category == "unreachable-pin") | .severity'
           equals: "error"
 
       golden_json:
@@ -1710,7 +1710,7 @@ scenarios:
         lockfile_version: v0.0.2
         valid: false
         findings:
-          - category: lockfile-forgery
+          - category: unreachable-pin
             confidence: high
             dependency: actions/checkout@v4
             detail: "pinned de0fac2e4500 is not an ancestor of bbbbbbbbbbbb \u2014 lockfile may have been tampered with"
@@ -1726,7 +1726,7 @@ scenarios:
 
   - name: accept_moved_resolves_forgery
     category: security
-    description: "--accept-moved re-resolves a lockfile-forgery dep to the current live SHA"
+    description: "--accept-moved re-resolves an unreachable-pin dep to the current live SHA"
     needs_token: true
     tags: [smoke]
     flags: ["--accept-moved", "--no-narrow"]

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -81,6 +81,11 @@ scenarios:
       lockfile_deps_cover_direct: true
       lockfile_contains: ["'actions/checkout@v4':"]
       lockfile_comment_excludes: 'actions/checkout@v4\.\d'
+      # v4 is a mutable pin: trusted without a live check, and the summary
+      # says so honestly instead of asserting "valid" then telling you to
+      # --rescan to actually verify it.
+      output_contains: ["trusted without a live check"]
+      output_excludes: ["re-verify reachability"]
 
   - name: multi_action_happy
     category: happy_path

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -685,6 +685,29 @@ scenarios:
       exit: 0
       stdout_is_json: true
 
+  - name: verify_local_offline_unauthed
+    category: output_modes
+    description: "--verify-local succeeds with no token and GH_HOST pointed at a refused address — proves the offline path never touches the network or auth"
+    needs_stub: false
+    flags: ["--verify-local"]
+    env:
+      # Any network call is a connection refused; stored github.com auth does
+      # not apply to this host either, so the run is effectively unauthed.
+      GH_HOST: "127.0.0.1:1"
+      # Strip ambient tokens so nothing is authed.
+      GH_TOKEN:
+      GITHUB_TOKEN:
+      GH_ENTERPRISE_TOKEN:
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions: ["actions/checkout@v4"]
+      lockfile_template: pinned_checkout
+    expect:
+      exit: 0
+      output_contains: ["complete lockfile coverage"]
+
   - name: verify_conflict_verify_local
     category: output_modes
     description: "--verify and --verify-local are mutually exclusive — errors before any work"


### PR DESCRIPTION
## Summary

This PR started as a terminal-output fix and grew to close the trust-model gap behind it: a stale or unreachable pin could sit in the lockfile and never be re-verified. It now does three things:

1. **Surface verify failures in the terminal** (the original fix).
2. **Re-verify immutable pins on the default run** — not just under `--rescan`.
3. **Re-verify pins in CI** and make the "all valid" summary honest about what it did and didn't check.

## 1. Surface verify failures in the terminal

`gh actions-lock --verify` (and `--no-fix` without `--json`) exited non-zero on a failing lockfile but printed **nothing** about which workflow failed or why — the finding only existed in `--json` output. Root cause: for human-terminal runs, `runCheck` attaches an `io.Discard` log sink, so narration helpers (`out.Error`/`out.Detail`) are thrown away; only the `Term*` family reaches the terminal. Fix mode re-surfaces errors through the summary, but `--no-fix`/`--verify` returns before that runs.

Added `format.PresentReadOnlyFailures`, a `Term*` renderer that groups error findings by dependency and prints category, detail, remediation, and affected workflow path(s). The *"Re-run without --no-fix"* hint now only prints when a finding is actually auto-fixable.

```
$ gh actions-lock --verify .github/workflows/ci.yml
Scanning 1 workflow
1 of 1 workflow failed verification
✗ Unreachable pin nodeselector/sq-action@main
  pinned 1e7de743d95c is not reachable from the ref's current head
  ! investigate immediately — verify the lockfile entry against upstream history
```

Copy was also run through the actions-copy voice/tone pass: humanized the shouty `LOCKFILE-FORGERY`-style label into "Unreachable pin", reworded the suggested-pin line, and gave the doc link an honest label.

## 2. Re-verify immutable pins on the default run

The lockfile fast path trusted any ref that already had a lockfile row: `IsFullyRecorded` marked the workflow `Resolved`, skipping all live resolution, reachability, and ancestry. A stale/unreachable pin whose row existed was never re-checked — only `--rescan` bypassed the fast path. So a plain `gh actions-lock` run could not catch a pin that no longer resolves to the tag it claims.

Now recorded refs are split by mutability:

- **Full-semver tags** (`v4.2.1`) are immutable — one commit for life — so a drifted SHA is always a defect. They're routed through live resolution so `unreachable-pin` / `ref-changed` / `misleading-sha` fire on the default path.
- **Mutable refs** (`v4`, `v4.2`, branches) legitimately move, so they stay trusted (seeded from the lockfile) until `--rescan`.

The classification is extracted into `planFastPath` and unit-tested without a network resolver.

**Behavior shift:** the default run now needs network + auth whenever a pin is full-semver (nearly always). `--verify-local` remains the explicit zero-network path — it short-circuits before the resolver, so it still only catches structural issues (`not-pinned`), not stale SHAs.

## 3. Re-verify in CI + honest summary

- `script/lockfile-lint.sh` now passes `--rescan` to its `--no-fix` invocations, so CI actually re-verifies pins instead of only checking structural drift (`GH_TOKEN` is already wired in `actions/lint/action.yml`).
- The already-pinned summary used to assert `All N valid` and then tell you to `--rescan` "to re-verify reachability" — admitting it hadn't verified what it just called valid (flagged as confusing in QA). Now that the default run re-verifies immutable pins, the nudge is rescoped to name only the mutable refs that were trusted without a live check, so "valid" isn't contradicted. It disappears entirely when every pin is immutable.

## Also in here: category rename

`lockfile-forgery` → `unreachable-pin`. "Forgery" over-asserted attack; a non-ancestor pin can just as easily be a legitimate upstream squash/force-push. This aligns with how github/launch's resolver frames the same check and reads honestly ("the pinned commit is not reachable from the ref's current head"). Docs are unpublished, so the slug moved with it; no org consumer keys on the old string. Deep-linked `DocURL`s land in a fast-follow once the docs page ships.

## Testing

- `terminal_test.go`: forgery/unreachable finding reaches the terminal and reports not-fixable; a directly-unpinned action reports fixable; a valid report stays silent. Pins the discard-log regression.
- `planFastPath` / `IsImmutableRef` table tests cover the immutable-vs-mutable split.
- `already_pinned_all_valid` scenario asserts the new summary copy and excludes the old "re-verify reachability" phrasing.
- Verified end-to-end against a repo whose branch history was rewritten so the pinned SHA was orphaned.
- `go test ./...` green; `go vet ./...` and `gofmt` clean.

Addresses the verify-UX feedback in github/actions-dispatch#776 and the QA note about the confusing "all valid" summary.
