### PR TITLE
Don't count about-to-be-pinned workflows as failed

### DIFF
--- a/cmd/gh-actions-lock/command_test.go
+++ b/cmd/gh-actions-lock/command_test.go
@@ -1068,6 +1068,28 @@ func TestCheckCommand_JSONLoadErrorIsInvalid(t *testing.T) {
 	assert.Equal(t, "error", payload.Findings[0].Severity)
 }
 
+func TestCheckCommand_LoadErrorFailsFixMode(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+	}{
+		{name: "migration enabled"},
+		{name: "migration disabled", args: []string{"--no-migrate-local-actions"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			workflowPath := writeTempWorkflow(t, "name: [")
+			args := append(tt.args, workflowPath)
+			_, stderr, err := runCommandWithHTTP(t, reg, args...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "parsing workflow YAML")
+			assert.NotContains(t, stderr, "All 1 workflow valid")
+		})
+	}
+}
+
 // TestCheck_Relock_BumpsMovedBranchRef covers github/actions-dispatch#751:
 // a branch ref (main) whose upstream head advanced is trusted as-is on a
 // normal run and merely flagged ref-moved under --rescan. --relock must

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -30,21 +30,51 @@ func PresentResults(out *ui.UI, report *checks.Report, valid bool, willRemediate
 		}
 	}
 
-	var validCount, failedCount int
-	for _, wr := range report.Workflows {
-		if wr.IsValid() {
-			validCount++
-		} else {
-			failedCount++
+	// A workflow whose only non-valid findings are NotPinned is not
+	// failing when this run is about to pin it — it's remediable, not
+	// broken. Don't count it as failed (and drop not-pinned from the
+	// error block below), otherwise a plain onboarding run reports
+	// "N of N workflows failed" for work it's actively doing.
+	var failedCount int
+	for i := range report.Workflows {
+		wr := &report.Workflows[i]
+		if wr.IsValid() || isRemediableOnly(wr, willRemediate) {
+			continue
 		}
+		failedCount++
 	}
-	checked := validCount + failedCount
+	checked := len(report.Workflows)
 
-	if !valid && checked > 0 {
+	if failedCount > 0 {
+		if willRemediate {
+			exclude[checks.NotPinned] = true
+		}
 		renderErrorFindings(out, report, failedCount, checked, exclude)
 	}
 
 	renderWarnings(out, report, willRemediate)
+}
+
+// isRemediableOnly reports whether a workflow's only integrity problems
+// are unpinned dependencies that this run is about to pin. Such a
+// workflow is being remediated, not failing, so it must not be counted
+// or labeled as failed. Returns false in read-only modes
+// (willRemediate == false), where not-pinned is a genuine coverage gap.
+func isRemediableOnly(wr *checks.WorkflowReport, willRemediate bool) bool {
+	if !willRemediate {
+		return false
+	}
+	sawNotPinned := false
+	for _, f := range wr.Findings {
+		if f.IsValid() {
+			continue
+		}
+		if f.Category != checks.NotPinned {
+			return false
+		}
+		sawNotPinned = true
+	}
+	return sawNotPinned
 }
 
 // PresentReadOnlyFailures renders error-level findings directly to the

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -30,23 +30,34 @@ func PresentResults(out *ui.UI, report *checks.Report, valid bool, willRemediate
 		}
 	}
 
-	// A workflow whose only non-valid findings are NotPinned is not
-	// failing when this run is about to pin it — it's remediable, not
+	// A workflow whose only non-valid findings are dep-level NotPinned is
+	// not failing when this run is about to pin it — it's remediable, not
 	// broken. Don't count it as failed (and drop not-pinned from the
 	// error block below), otherwise a plain onboarding run reports
 	// "N of N workflows failed" for work it's actively doing.
 	var failedCount int
+	sawOtherFailure := false
 	for i := range report.Workflows {
 		wr := &report.Workflows[i]
 		if wr.IsValid() || isRemediableOnly(wr, willRemediate) {
 			continue
 		}
 		failedCount++
+		for _, f := range wr.Findings {
+			if !f.IsValid() && f.Category != checks.NotPinned {
+				sawOtherFailure = true
+			}
+		}
 	}
 	checked := len(report.Workflows)
 
 	if failedCount > 0 {
-		if willRemediate {
+		// Suppress not-pinned from the failure summary only when another
+		// category already explains the failure. If not-pinned is the sole
+		// reason a workflow failed — e.g. a fatal load/deps error that
+		// diagnose.go reports as workflow-level NotPinned with no
+		// ActionRef — keep it so the summary isn't left blank.
+		if willRemediate && sawOtherFailure {
 			exclude[checks.NotPinned] = true
 		}
 		renderErrorFindings(out, report, failedCount, checked, exclude)
@@ -64,17 +75,21 @@ func isRemediableOnly(wr *checks.WorkflowReport, willRemediate bool) bool {
 	if !willRemediate {
 		return false
 	}
-	sawNotPinned := false
+	sawRemediable := false
 	for _, f := range wr.Findings {
 		if f.IsValid() {
 			continue
 		}
-		if f.Category != checks.NotPinned {
+		// Only a dep-level NotPinned (an actual uses: ref this run will
+		// pin) is remediable. A NotPinned with no ActionRef is a
+		// workflow-level fatal error (failed to load / read deps), which
+		// remediation cannot fix, so the workflow is genuinely failing.
+		if f.Category != checks.NotPinned || f.ActionRef == nil {
 			return false
 		}
-		sawNotPinned = true
+		sawRemediable = true
 	}
-	return sawNotPinned
+	return sawRemediable
 }
 
 // PresentReadOnlyFailures renders error-level findings directly to the

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -49,7 +49,7 @@ func PresentResults(out *ui.UI, report *checks.Report, valid bool, willRemediate
 }
 
 func findingExcluded(f checks.Finding, exclude map[checks.Category]bool, willRemediate bool) bool {
-	if f.Category == checks.NotPinned && f.ActionRef == nil {
+	if f.Category == checks.NotPinned && !f.IsRemediableNotPinned() {
 		// Workflow-level NotPinned is a load failure, not a pin finding.
 		return false
 	}
@@ -201,6 +201,9 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 				continue
 			}
 			depKey := f.DepKey()
+			if depKey == "" {
+				depKey = wr.Path
+			}
 			if dg, ok := depMap[depKey]; ok {
 				dg.findings = append(dg.findings, f)
 			} else {
@@ -220,7 +223,7 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 				continue
 			}
 			catCounts[f.Category]++
-			if f.Category != checks.NotPinned {
+			if f.Category != checks.NotPinned || !f.IsRemediableNotPinned() {
 				allSkip = false
 			}
 		}
@@ -231,7 +234,8 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 		// Self-hosted-runner findings are no longer generated; render
 		// remaining non-excluded, non-not-pinned findings directly.
 		for _, f := range dg.findings {
-			if f.Category == checks.NotPinned || findingExcluded(f, exclude, willRemediate) {
+			if findingExcluded(f, exclude, willRemediate) ||
+				f.IsRemediableNotPinned() {
 				continue
 			}
 			renderFindingDetail(out, f, dep)

--- a/cmd/gh-actions-lock/format/terminal.go
+++ b/cmd/gh-actions-lock/format/terminal.go
@@ -30,66 +30,30 @@ func PresentResults(out *ui.UI, report *checks.Report, valid bool, willRemediate
 		}
 	}
 
-	// A workflow whose only non-valid findings are dep-level NotPinned is
-	// not failing when this run is about to pin it — it's remediable, not
-	// broken. Don't count it as failed (and drop not-pinned from the
-	// error block below), otherwise a plain onboarding run reports
-	// "N of N workflows failed" for work it's actively doing.
 	var failedCount int
-	sawOtherFailure := false
-	for i := range report.Workflows {
-		wr := &report.Workflows[i]
-		if wr.IsValid() || isRemediableOnly(wr, willRemediate) {
-			continue
-		}
-		failedCount++
+	for _, wr := range report.Workflows {
 		for _, f := range wr.Findings {
-			if !f.IsValid() && f.Category != checks.NotPinned {
-				sawOtherFailure = true
+			if !f.IsValid() && !findingExcluded(f, exclude, willRemediate) {
+				failedCount++
+				break
 			}
 		}
 	}
 	checked := len(report.Workflows)
 
-	if failedCount > 0 {
-		// Suppress not-pinned from the failure summary only when another
-		// category already explains the failure. If not-pinned is the sole
-		// reason a workflow failed — e.g. a fatal load/deps error that
-		// diagnose.go reports as workflow-level NotPinned with no
-		// ActionRef — keep it so the summary isn't left blank.
-		if willRemediate && sawOtherFailure {
-			exclude[checks.NotPinned] = true
-		}
-		renderErrorFindings(out, report, failedCount, checked, exclude)
+	if !valid && failedCount > 0 {
+		renderErrorFindings(out, report, failedCount, checked, exclude, willRemediate)
 	}
 
 	renderWarnings(out, report, willRemediate)
 }
 
-// isRemediableOnly reports whether a workflow's only integrity problems
-// are unpinned dependencies that this run is about to pin. Such a
-// workflow is being remediated, not failing, so it must not be counted
-// or labeled as failed. Returns false in read-only modes
-// (willRemediate == false), where not-pinned is a genuine coverage gap.
-func isRemediableOnly(wr *checks.WorkflowReport, willRemediate bool) bool {
-	if !willRemediate {
+func findingExcluded(f checks.Finding, exclude map[checks.Category]bool, willRemediate bool) bool {
+	if f.Category == checks.NotPinned && f.ActionRef == nil {
+		// Workflow-level NotPinned is a load failure, not a pin finding.
 		return false
 	}
-	sawRemediable := false
-	for _, f := range wr.Findings {
-		if f.IsValid() {
-			continue
-		}
-		// Only a dep-level NotPinned (an actual uses: ref this run will
-		// pin) is remediable. A NotPinned with no ActionRef is a
-		// workflow-level fatal error (failed to load / read deps), which
-		// remediation cannot fix, so the workflow is genuinely failing.
-		if f.Category != checks.NotPinned || f.ActionRef == nil {
-			return false
-		}
-		sawRemediable = true
-	}
-	return sawRemediable
+	return exclude[f.Category] || willRemediate && f.Category == checks.NotPinned
 }
 
 // PresentReadOnlyFailures renders error-level findings directly to the
@@ -223,7 +187,7 @@ func categoryLabel(c checks.Category) string {
 
 // renderErrorFindings groups error-level findings by dependency and prints
 // per-dep detail lines followed by a category-count summary.
-func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked int, exclude map[checks.Category]bool) {
+func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked int, exclude map[checks.Category]bool, willRemediate bool) {
 	type depGroup struct {
 		dep      string
 		findings []checks.Finding
@@ -252,7 +216,7 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 
 		allSkip := true
 		for _, f := range dg.findings {
-			if exclude[f.Category] {
+			if findingExcluded(f, exclude, willRemediate) {
 				continue
 			}
 			catCounts[f.Category]++
@@ -267,7 +231,7 @@ func renderErrorFindings(out *ui.UI, report *checks.Report, failedCount, checked
 		// Self-hosted-runner findings are no longer generated; render
 		// remaining non-excluded, non-not-pinned findings directly.
 		for _, f := range dg.findings {
-			if f.Category == checks.NotPinned || exclude[f.Category] {
+			if f.Category == checks.NotPinned || findingExcluded(f, exclude, willRemediate) {
 				continue
 			}
 			renderFindingDetail(out, f, dep)

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -608,10 +608,22 @@ func TestPresentResults_RemediableNotCountedFailed(t *testing.T) {
 		return checks.Finding{
 			WorkflowPath: wf,
 			Category:     checks.NotPinned,
-			Severity:     checks.SeverityWarning,
+			Severity:     checks.SeverityError,
 			Confidence:   checks.ConfidenceHigh,
 			ActionRef:    &parserlock.ActionRef{Owner: "octo", Repo: "action", Ref: "v1"},
 			Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "v1"},
+		}
+	}
+	// loadError models diagnose.go's workflow-level NotPinned for a
+	// failed load/deps read: SeverityError, no ActionRef. It is fatal, not
+	// remediable, so a run that pins everything else must still fail it.
+	loadError := func(wf string) checks.Finding {
+		return checks.Finding{
+			WorkflowPath: wf,
+			Category:     checks.NotPinned,
+			Severity:     checks.SeverityError,
+			Confidence:   checks.ConfidenceHigh,
+			Detail:       "failed to load workflow: yaml: line 3: bad indent",
 		}
 	}
 	unreachable := func(wf string) checks.Finding {
@@ -658,6 +670,24 @@ func TestPresentResults_RemediableNotCountedFailed(t *testing.T) {
 				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
 			},
 			wantOutput: []string{"1 of 1 workflow failed", "1 not-pinned"},
+		},
+		{
+			name:          "fatal load error is not remediable and keeps its reason",
+			willRemediate: true,
+			workflows: []checks.WorkflowReport{
+				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
+				{Path: ".github/workflows/b.yml", Findings: []checks.Finding{loadError(".github/workflows/b.yml")}},
+			},
+			wantOutput: []string{"1 of 2 workflows failed", "not-pinned"},
+		},
+		{
+			name:          "fatal load error alongside another failure still fails",
+			willRemediate: true,
+			workflows: []checks.WorkflowReport{
+				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{loadError(".github/workflows/a.yml")}},
+				{Path: ".github/workflows/b.yml", Findings: []checks.Finding{unreachable(".github/workflows/b.yml")}},
+			},
+			wantOutput: []string{"2 of 2 workflows failed", "unreachable-pin"},
 		},
 	}
 

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -597,3 +597,91 @@ func TestPresentReadOnlyFailures_UnreachablePinShowsReleases(t *testing.T) {
 		t.Errorf("expected upstream releases link in read-only output:\n%s", got)
 	}
 }
+
+// TestPresentResults_RemediableNotCountedFailed covers github/actions-dispatch#802:
+// a workflow whose only non-valid finding is a dep-level NotPinned is being
+// remediated on this run, not failing. It must not be counted or labeled as
+// "failed" when willRemediate is true, but still counts as a coverage gap in
+// read-only mode (willRemediate false).
+func TestPresentResults_RemediableNotCountedFailed(t *testing.T) {
+	notPinned := func(wf string) checks.Finding {
+		return checks.Finding{
+			WorkflowPath: wf,
+			Category:     checks.NotPinned,
+			Severity:     checks.SeverityWarning,
+			Confidence:   checks.ConfidenceHigh,
+			ActionRef:    &parserlock.ActionRef{Owner: "octo", Repo: "action", Ref: "v1"},
+			Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "v1"},
+		}
+	}
+	unreachable := func(wf string) checks.Finding {
+		return checks.Finding{
+			WorkflowPath: wf,
+			Category:     checks.UnreachablePin,
+			Severity:     checks.SeverityError,
+			Confidence:   checks.ConfidenceHigh,
+			Dependency:   &dep.Dependency{NWO: "octo/broken", Ref: "main", SHA: "aaaa"},
+			Detail:       "pinned aaaa is not an ancestor of bbbb",
+		}
+	}
+
+	tests := []struct {
+		name          string
+		willRemediate bool
+		workflows     []checks.WorkflowReport
+		wantOutput    []string
+		notWanted     []string
+	}{
+		{
+			name:          "pure onboarding emits no failed line when remediating",
+			willRemediate: true,
+			workflows: []checks.WorkflowReport{
+				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
+				{Path: ".github/workflows/b.yml", Findings: []checks.Finding{notPinned(".github/workflows/b.yml")}},
+			},
+			notWanted: []string{"failed", "not-pinned"},
+		},
+		{
+			name:          "genuine failure counted, remediable excluded from count and parts",
+			willRemediate: true,
+			workflows: []checks.WorkflowReport{
+				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
+				{Path: ".github/workflows/b.yml", Findings: []checks.Finding{unreachable(".github/workflows/b.yml")}},
+			},
+			wantOutput: []string{"1 of 2 workflows failed", "unreachable-pin"},
+			notWanted:  []string{"not-pinned"},
+		},
+		{
+			name:          "read-only still counts not-pinned as a gap",
+			willRemediate: false,
+			workflows: []checks.WorkflowReport{
+				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
+			},
+			wantOutput: []string{"1 of 1 workflow failed", "1 not-pinned"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The "N of N failed" block renders via the narration log
+			// (out.Error), so point the log at the buffer to capture it.
+			var buf bytes.Buffer
+			u := ui.NewPlain(&buf)
+			u.SetLog(&buf)
+			report := &checks.Report{Workflows: tt.workflows}
+			PresentResults(u, report, report.IsValid(), tt.willRemediate)
+
+			got := buf.String()
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q\nfull output:\n%s", want, got)
+				}
+			}
+			for _, unwanted := range tt.notWanted {
+				if strings.Contains(got, unwanted) {
+					t.Errorf("output unexpectedly contains %q\nfull output:\n%s", unwanted, got)
+				}
+			}
+		})
+	}
+}

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -402,10 +402,21 @@ func TestPresentResults_ExcludeKeepsOtherFindings(t *testing.T) {
 					},
 				},
 			},
+			{
+				Path: ".github/workflows/release.yml",
+				Findings: []checks.Finding{{
+					WorkflowPath: ".github/workflows/release.yml",
+					Category:     checks.NotPinned,
+					Severity:     checks.SeverityError,
+					Confidence:   checks.ConfidenceHigh,
+					ActionRef:    &parserlock.ActionRef{Owner: "actions", Repo: "checkout", Ref: "v4"},
+					Dependency:   &dep.Dependency{NWO: "actions/checkout", Ref: "v4"},
+				}},
+			},
 		},
 	}
 
-	PresentResults(u, report, false, false, checks.UnreachablePin)
+	PresentResults(u, report, false, false, checks.UnreachablePin, checks.NotPinned)
 	got := buf.String()
 
 	if strings.Contains(got, "UNREACHABLE-PIN") {
@@ -413,6 +424,41 @@ func TestPresentResults_ExcludeKeepsOtherFindings(t *testing.T) {
 	}
 	if !strings.Contains(got, "LOCAL-ACTION") {
 		t.Errorf("non-excluded local-action should still appear:\n%s", got)
+	}
+	if !strings.Contains(got, "1 of 2 workflows failed: 1 local-action") {
+		t.Errorf("excluded findings should not count as failed:\n%s", got)
+	}
+	if strings.Contains(got, "not-pinned") {
+		t.Errorf("excluded not-pinned should not appear:\n%s", got)
+	}
+}
+
+func TestPresentResults_ExcludedNotPinnedKeepsWorkflowLoadErrors(t *testing.T) {
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{
+			{
+				Path: ".github/workflows/pinned.yml",
+				Findings: []checks.Finding{{
+					Category:  checks.NotPinned,
+					Severity:  checks.SeverityError,
+					ActionRef: &parserlock.ActionRef{Owner: "actions", Repo: "checkout", Ref: "v4"},
+				}},
+			},
+			{
+				Path: ".github/workflows/broken.yml",
+				Findings: []checks.Finding{{
+					Category: checks.NotPinned,
+					Severity: checks.SeverityError,
+					Detail:   "failed to load workflow",
+				}},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	PresentResults(ui.NewPlain(&buf), report, false, false, checks.NotPinned)
+
+	if got := buf.String(); !strings.Contains(got, "1 of 2 workflows failed: 1 not-pinned") {
+		t.Errorf("workflow load error should remain after remediation:\n%s", got)
 	}
 }
 
@@ -595,123 +641,5 @@ func TestPresentReadOnlyFailures_UnreachablePinShowsReleases(t *testing.T) {
 	PresentReadOnlyFailures(u, report)
 	if got := buf.String(); !strings.Contains(got, "https://github.com/octo/action/releases") {
 		t.Errorf("expected upstream releases link in read-only output:\n%s", got)
-	}
-}
-
-// TestPresentResults_RemediableNotCountedFailed covers github/actions-dispatch#802:
-// a workflow whose only non-valid finding is a dep-level NotPinned is being
-// remediated on this run, not failing. It must not be counted or labeled as
-// "failed" when willRemediate is true, but still counts as a coverage gap in
-// read-only mode (willRemediate false).
-func TestPresentResults_RemediableNotCountedFailed(t *testing.T) {
-	notPinned := func(wf string) checks.Finding {
-		return checks.Finding{
-			WorkflowPath: wf,
-			Category:     checks.NotPinned,
-			Severity:     checks.SeverityError,
-			Confidence:   checks.ConfidenceHigh,
-			ActionRef:    &parserlock.ActionRef{Owner: "octo", Repo: "action", Ref: "v1"},
-			Dependency:   &dep.Dependency{NWO: "octo/action", Ref: "v1"},
-		}
-	}
-	// loadError models diagnose.go's workflow-level NotPinned for a
-	// failed load/deps read: SeverityError, no ActionRef. It is fatal, not
-	// remediable, so a run that pins everything else must still fail it.
-	loadError := func(wf string) checks.Finding {
-		return checks.Finding{
-			WorkflowPath: wf,
-			Category:     checks.NotPinned,
-			Severity:     checks.SeverityError,
-			Confidence:   checks.ConfidenceHigh,
-			Detail:       "failed to load workflow: yaml: line 3: bad indent",
-		}
-	}
-	unreachable := func(wf string) checks.Finding {
-		return checks.Finding{
-			WorkflowPath: wf,
-			Category:     checks.UnreachablePin,
-			Severity:     checks.SeverityError,
-			Confidence:   checks.ConfidenceHigh,
-			Dependency:   &dep.Dependency{NWO: "octo/broken", Ref: "main", SHA: "aaaa"},
-			Detail:       "pinned aaaa is not an ancestor of bbbb",
-		}
-	}
-
-	tests := []struct {
-		name          string
-		willRemediate bool
-		workflows     []checks.WorkflowReport
-		wantOutput    []string
-		notWanted     []string
-	}{
-		{
-			name:          "pure onboarding emits no failed line when remediating",
-			willRemediate: true,
-			workflows: []checks.WorkflowReport{
-				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
-				{Path: ".github/workflows/b.yml", Findings: []checks.Finding{notPinned(".github/workflows/b.yml")}},
-			},
-			notWanted: []string{"failed", "not-pinned"},
-		},
-		{
-			name:          "genuine failure counted, remediable excluded from count and parts",
-			willRemediate: true,
-			workflows: []checks.WorkflowReport{
-				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
-				{Path: ".github/workflows/b.yml", Findings: []checks.Finding{unreachable(".github/workflows/b.yml")}},
-			},
-			wantOutput: []string{"1 of 2 workflows failed", "unreachable-pin"},
-			notWanted:  []string{"not-pinned"},
-		},
-		{
-			name:          "read-only still counts not-pinned as a gap",
-			willRemediate: false,
-			workflows: []checks.WorkflowReport{
-				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
-			},
-			wantOutput: []string{"1 of 1 workflow failed", "1 not-pinned"},
-		},
-		{
-			name:          "fatal load error is not remediable and keeps its reason",
-			willRemediate: true,
-			workflows: []checks.WorkflowReport{
-				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{notPinned(".github/workflows/a.yml")}},
-				{Path: ".github/workflows/b.yml", Findings: []checks.Finding{loadError(".github/workflows/b.yml")}},
-			},
-			wantOutput: []string{"1 of 2 workflows failed", "not-pinned"},
-		},
-		{
-			name:          "fatal load error alongside another failure still fails",
-			willRemediate: true,
-			workflows: []checks.WorkflowReport{
-				{Path: ".github/workflows/a.yml", Findings: []checks.Finding{loadError(".github/workflows/a.yml")}},
-				{Path: ".github/workflows/b.yml", Findings: []checks.Finding{unreachable(".github/workflows/b.yml")}},
-			},
-			wantOutput: []string{"2 of 2 workflows failed", "unreachable-pin"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// The "N of N failed" block renders via the narration log
-			// (out.Error), so point the log at the buffer to capture it.
-			var buf bytes.Buffer
-			u := ui.NewPlain(&buf)
-			u.SetLog(&buf)
-			report := &checks.Report{Workflows: tt.workflows}
-			PresentResults(u, report, report.IsValid(), tt.willRemediate)
-
-			got := buf.String()
-			for _, want := range tt.wantOutput {
-				if !strings.Contains(got, want) {
-					t.Errorf("output missing %q\nfull output:\n%s", want, got)
-				}
-			}
-			for _, unwanted := range tt.notWanted {
-				if strings.Contains(got, unwanted) {
-					t.Errorf("output unexpectedly contains %q\nfull output:\n%s", unwanted, got)
-				}
-			}
-		})
 	}
 }

--- a/cmd/gh-actions-lock/format/terminal_test.go
+++ b/cmd/gh-actions-lock/format/terminal_test.go
@@ -457,8 +457,50 @@ func TestPresentResults_ExcludedNotPinnedKeepsWorkflowLoadErrors(t *testing.T) {
 	var buf bytes.Buffer
 	PresentResults(ui.NewPlain(&buf), report, false, false, checks.NotPinned)
 
-	if got := buf.String(); !strings.Contains(got, "1 of 2 workflows failed: 1 not-pinned") {
+	got := buf.String()
+	if !strings.Contains(got, "1 of 2 workflows failed: 1 not-pinned") {
 		t.Errorf("workflow load error should remain after remediation:\n%s", got)
+	}
+	if !strings.Contains(got, ".github/workflows/broken.yml") ||
+		!strings.Contains(got, "failed to load workflow") {
+		t.Errorf("workflow load error detail should be rendered:\n%s", got)
+	}
+	if strings.Contains(got, "not yet pinned") {
+		t.Errorf("workflow load error should not render as a fixable warning:\n%s", got)
+	}
+}
+
+func TestPresentResults_ExcludedNotPinnedDropsRemediableWorkflowErrors(t *testing.T) {
+	report := &checks.Report{
+		Workflows: []checks.WorkflowReport{
+			{
+				Path: ".github/workflows/repaired.yml",
+				Findings: []checks.Finding{{
+					Category:   checks.NotPinned,
+					Severity:   checks.SeverityError,
+					Remediable: true,
+					Detail:     "failed to read dependencies",
+				}},
+			},
+			{
+				Path: ".github/workflows/blocked.yml",
+				Findings: []checks.Finding{{
+					Category: checks.LocalAction,
+					Severity: checks.SeverityError,
+					Detail:   "local action ./my-action",
+				}},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	PresentResults(ui.NewPlain(&buf), report, false, false, checks.NotPinned)
+
+	got := buf.String()
+	if !strings.Contains(got, "1 of 2 workflows failed: 1 local-action") {
+		t.Errorf("repaired dependency error should not remain after remediation:\n%s", got)
+	}
+	if strings.Contains(got, "not-pinned") || strings.Contains(got, "failed to read dependencies") {
+		t.Errorf("repaired dependency error should be excluded:\n%s", got)
 	}
 }
 

--- a/cmd/gh-actions-lock/pin_summary.go
+++ b/cmd/gh-actions-lock/pin_summary.go
@@ -143,14 +143,12 @@ func renderPinSummary(ctx context.Context, console *ui.UI, record *pin.Record, r
 	// so they didn't reach stderr. Temporarily detach the log so the
 	// findings surface on the terminal.
 	//
-	// Only trigger for categories NOT already rendered by
-	// renderInvestigationAlerts (which handles unreachable-pin).
-	// Without this gate PresentResults would also emit a stale summary
-	// line counting pre-fix not-pinned findings.
+	// Exclude findings already handled elsewhere and pre-fix not-pinned
+	// findings that may have been committed for other workflows.
 	if reportHasNonInvestigatedUnfixableErrors(report) {
 		console.SetLog(nil)
 		format.PresentResults(console, report, false, false,
-			checks.UnreachablePin)
+			checks.UnreachablePin, checks.NotPinned)
 	}
 
 	if len(investigated) > 0 || len(unresolvedEntries) > 0 || hasUnfixable {

--- a/cmd/gh-actions-lock/pin_summary.go
+++ b/cmd/gh-actions-lock/pin_summary.go
@@ -27,6 +27,10 @@ func reportHasUnfixableErrors(report *checks.Report, acceptMoved bool) bool {
 			switch f.Category {
 			case checks.LocalAction, checks.InvalidSelfRepositoryRef:
 				return true
+			case checks.NotPinned:
+				if !f.IsRemediableNotPinned() {
+					return true
+				}
 			case checks.UnreachablePin:
 				if !acceptMoved {
 					return true
@@ -48,7 +52,9 @@ func reportHasNonInvestigatedUnfixableErrors(report *checks.Report) bool {
 			if f.Severity != checks.SeverityError {
 				continue
 			}
-			if f.Category == checks.LocalAction || f.Category == checks.InvalidSelfRepositoryRef {
+			if f.Category == checks.LocalAction ||
+				f.Category == checks.InvalidSelfRepositoryRef ||
+				f.Category == checks.NotPinned && !f.IsRemediableNotPinned() {
 				return true
 			}
 		}

--- a/cmd/gh-actions-lock/pin_summary_test.go
+++ b/cmd/gh-actions-lock/pin_summary_test.go
@@ -39,6 +39,36 @@ func TestRenderPinnedEntries_WorkflowSharedAcrossActions(t *testing.T) {
 	}
 }
 
+func TestReportHasUnfixableErrors_ClassifiesWorkflowNotPinned(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		remediable  bool
+		wantBlocked bool
+	}{
+		{name: "workflow load error", wantBlocked: true},
+		{name: "dependency inventory error", remediable: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &checks.Report{
+				Workflows: []checks.WorkflowReport{{
+					Findings: []checks.Finding{{
+						Category:   checks.NotPinned,
+						Severity:   checks.SeverityError,
+						Remediable: tt.remediable,
+					}},
+				}},
+			}
+
+			if got := reportHasUnfixableErrors(report, false); got != tt.wantBlocked {
+				t.Errorf("reportHasUnfixableErrors() = %v, want %v", got, tt.wantBlocked)
+			}
+			if got := reportHasNonInvestigatedUnfixableErrors(report); got != tt.wantBlocked {
+				t.Errorf("reportHasNonInvestigatedUnfixableErrors() = %v, want %v", got, tt.wantBlocked)
+			}
+		})
+	}
+}
+
 func TestRenderInvestigationAlerts_DeduplicatesByNWORef(t *testing.T) {
 	entries := []pin.Entry{
 		{

--- a/internal/pipeline/checks/finding.go
+++ b/internal/pipeline/checks/finding.go
@@ -19,6 +19,8 @@ type Finding struct {
 	Confidence Confidence
 	// ActionRef is the action reference this finding relates to (nil for workflow-level findings).
 	ActionRef *parserlock.ActionRef
+	// Remediable is true for workflow-level findings that pinning can repair.
+	Remediable bool
 	// Dependency is the existing pinned dep if any.
 	Dependency *dep.Dependency
 	// ParentNWO is the dep key of the direct action that pulls in this transitive dep (empty if direct).
@@ -131,10 +133,15 @@ func (f *Finding) IsWarning() bool {
 	case f.Category.IsInconclusive():
 		return true
 	case f.Category == NotPinned && f.ActionRef == nil:
-		return true
+		return f.Severity != SeverityError
 	default:
 		return false
 	}
+}
+
+// IsRemediableNotPinned reports whether pinning can resolve this finding.
+func (f *Finding) IsRemediableNotPinned() bool {
+	return f.Category == NotPinned && (f.ActionRef != nil || f.Remediable)
 }
 
 // DepKey returns a dependency identifier for display grouping.

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -271,6 +271,7 @@ func precheckWorkflow(pw checks.ParsedWorkflow, store *lockfile.State) (checks.W
 			Category:     checks.NotPinned,
 			Severity:     checks.SeverityError,
 			Confidence:   checks.ConfidenceHigh,
+			Remediable:   true,
 			Detail:       fmt.Sprintf("failed to read dependencies: %s", pw.DepsErr),
 			Remediation:  "fix or regenerate the dependencies: section with `gh actions-lock`",
 			DocURL:       DocURLFor(checks.NotPinned),

--- a/internal/pipeline/diagnose_helpers_test.go
+++ b/internal/pipeline/diagnose_helpers_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"testing"
 
+	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
 	"github.com/github/gh-actions-lock/internal/dep"
 	"github.com/github/gh-actions-lock/internal/pipeline/checks"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,35 @@ func TestIndexDeps_LastWins(t *testing.T) {
 
 	assert.Len(t, got, 1)
 	assert.Equal(t, "bbb", got["actions/checkout@v4"].SHA)
+}
+
+func TestPrecheckWorkflow_NotPinnedRemediability(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		workflow       checks.ParsedWorkflow
+		wantRemediable bool
+	}{
+		{
+			name:     "load error",
+			workflow: checks.ParsedWorkflow{Path: "broken.yml", LoadErr: assert.AnError},
+		},
+		{
+			name: "dependency inventory error",
+			workflow: checks.ParsedWorkflow{
+				Path:    "repairable.yml",
+				Refs:    []parserlock.ActionRef{{Owner: "actions", Repo: "checkout", Ref: "v4"}},
+				DepsErr: assert.AnError,
+			},
+			wantRemediable: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			report, terminal := precheckWorkflow(tt.workflow, nil)
+			assert.True(t, terminal)
+			assert.Len(t, report.Findings, 1)
+			assert.Equal(t, tt.wantRemediable, report.Findings[0].IsRemediableNotPinned())
+		})
+	}
 }
 
 func TestHasIssues(t *testing.T) {

--- a/internal/pipeline/verify_local.go
+++ b/internal/pipeline/verify_local.go
@@ -49,6 +49,7 @@ func VerifyLocalCoverage(parsed []checks.ParsedWorkflow, store *lockfile.State) 
 				Category:     checks.NotPinned,
 				Severity:     checks.SeverityError,
 				Confidence:   checks.ConfidenceHigh,
+				Remediable:   true,
 				Detail:       fmt.Sprintf("failed to read dependencies: %s", pw.DepsErr),
 				Remediation:  "fix or regenerate the dependencies: section with `gh actions-lock`",
 			})

--- a/internal/pipeline/verify_local_test.go
+++ b/internal/pipeline/verify_local_test.go
@@ -190,6 +190,7 @@ func TestVerifyLocalCoverage_LoadError(t *testing.T) {
 	report := VerifyLocalCoverage(parsed, store)
 	assert.False(t, report.IsValid())
 	assert.Equal(t, checks.NotPinned, report.Workflows[0].Findings[0].Category)
+	assert.False(t, report.Workflows[0].Findings[0].IsRemediableNotPinned())
 }
 
 func TestVerifyLocalCoverage_DepsError(t *testing.T) {
@@ -206,5 +207,6 @@ func TestVerifyLocalCoverage_DepsError(t *testing.T) {
 	report := VerifyLocalCoverage(parsed, store)
 	assert.False(t, report.IsValid())
 	assert.Equal(t, checks.NotPinned, report.Workflows[0].Findings[0].Category)
+	assert.True(t, report.Workflows[0].Findings[0].IsRemediableNotPinned())
 	assert.Contains(t, report.Workflows[0].Findings[0].Detail, "failed to read dependencies")
 }

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -1596,6 +1596,25 @@ scenarios:
     expect:
       exit: 0
 
+  - name: onboarding_pin_run_not_reported_failed
+    category: onboarding
+    description: "github/actions-dispatch#802 — a fresh run that pins every workflow must not report 'N of N workflows failed'; about-to-be-pinned deps are remediable, not failures"
+    needs_token: true
+    fixtures:
+      workflows:
+        a.yml:
+          name: A
+          actions: ["actions/checkout@v4"]
+        b.yml:
+          name: B
+          actions: ["actions/setup-go@v5"]
+    expect:
+      exit: 0
+      lockfile_deps_cover_direct: true
+      output_excludes:
+        - "workflows failed"
+        - "not-pinned"
+
   # ═══════════════════════════════════════════════════════════════════════
   # CATEGORY: lockfile (additional scenarios)
   # ═══════════════════════════════════════════════════════════════════════

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -1596,24 +1596,41 @@ scenarios:
     expect:
       exit: 0
 
-  - name: onboarding_pin_run_not_reported_failed
-    category: onboarding
-    description: "github/actions-dispatch#802 — a fresh run that pins every workflow must not report 'N of N workflows failed'; about-to-be-pinned deps are remediable, not failures"
+  - name: partial_onboarding_counts_only_blocked_workflow
+    category: multi_workflow
+    description: "Successful workflows are pinned while a blocked workflow stays untouched and is the only failure counted"
     needs_token: true
     fixtures:
       workflows:
-        a.yml:
-          name: A
-          actions: ["actions/checkout@v4"]
-        b.yml:
-          name: B
-          actions: ["actions/setup-go@v5"]
+        blocked.yml:
+          name: Blocked
+          actions:
+            - "nodeselector/actions-test-fixtures/composite-with-local-path@main"
+            - "nodeselector/actions-test-fixtures/simple-node@tampered"
+        main.yml:
+          name: Main
+          actions: ["nodeselector/actions-test-fixtures/simple-node@main"]
+        updated.yml:
+          name: Updated
+          actions: ["nodeselector/actions-test-fixtures/simple-node@updated"]
+        v1.yml:
+          name: V1
+          actions: ["nodeselector/actions-test-fixtures/simple-node@v1"]
     expect:
-      exit: 0
-      lockfile_deps_cover_direct: true
+      exit: 1
+      output_contains:
+        - "Pinned 3 actions across 3 workflows"
+        - "1 of 4 workflows failed: 1 local-action"
       output_excludes:
-        - "workflows failed"
+        - "4 of 4 workflows failed"
         - "not-pinned"
+      lockfile_contains:
+        - "nodeselector/actions-test-fixtures@main"
+        - "nodeselector/actions-test-fixtures@updated"
+        - "nodeselector/actions-test-fixtures@v1"
+      lockfile_excludes:
+        - "blocked.yml"
+        - "nodeselector/actions-test-fixtures@tampered"
 
   # ═══════════════════════════════════════════════════════════════════════
   # CATEGORY: lockfile (additional scenarios)


### PR DESCRIPTION
## What

Count only workflows that remain blocked after partial lockfile onboarding.

## Why

Onboarding is atomic per workflow, not per repository. A mixed run can persist successful workflows while leaving a blocked workflow untouched, but the post-fix summary counted every pre-fix `not-pinned` finding as a failure.

That produced output such as `4 of 4 workflows failed` after three workflows had been pinned successfully.

Resolves github/actions-dispatch#802.

## How

- Apply the same finding-exclusion predicate to workflow and category counts.
- Exclude dependency-level `not-pinned` findings after remediation.
- Keep fatal workflow load errors visible and in the nonzero-exit gate.
- Mark dependency-inventory read errors as remediable because pinning can regenerate those entries.
- Preserve per-workflow writes: successful workflows commit while blocked workflows remain untouched.

## Alternatives considered

- **Treat every workflow-level `not-pinned` finding as fatal**: rejected because dependency-inventory errors can be repaired during the same run.
- **Suppress every `not-pinned` finding after remediation**: rejected because workflow parse failures must remain visible and fail the command.
- **Make onboarding repository-atomic**: rejected because the intended behavior is atomicity per workflow.

## Risk

| Aspect | Assessment |
| --- | --- |
| Blast radius | Terminal summaries and error gating for fix-mode lockfile onboarding |
| Reversibility | Easy rollback |
| Rollback plan | Revert the four branch commits |
| Dependencies | None |

## Testing

- Full Go test suite with the race detector
- Go vet and formatting checks
- Command tests for malformed workflows with migration enabled and disabled
- Renderer and gate tests for fatal load errors and repairable dependency errors
- Live catalog regression proving three workflows persist while one blocked workflow is the only failure counted