### PR TITLE
Prune deleted workflows from the lockfile on a full scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ After the initial run to onboard workflows, you will need to run `gh actions-loc
 - A new workflow is created that has `uses` dependencies.
 - An existing workflow adds or removes `uses` dependencies.
 
+A full-directory run (`gh actions-lock` with no path arguments) also prunes lockfile entries for workflows that have been deleted from `.github/workflows/`, dropping any dependencies left orphaned by the removal. Scoped runs that name specific workflows never prune out-of-scope entries.
+
 ## How it works
 
 A repo gets a lockfile (located at [`.github/workflows/actions.lock`](https://github.com/github/gh-actions-lock/blob/main/.github/workflows/actions.lock)) and workflows are onboarded to the lockfile on a per-workflow basis. 

--- a/cmd/gh-actions-lock/pin_summary.go
+++ b/cmd/gh-actions-lock/pin_summary.go
@@ -59,7 +59,7 @@ func reportHasNonInvestigatedUnfixableErrors(report *checks.Report) bool {
 // renderPinSummary prints the terminal summary after pin.Plan + pin.Commit.
 // It groups pinned entries by NWO@Ref, shows investigation alerts, unresolved
 // warnings, and the all-valid message when nothing changed.
-func renderPinSummary(ctx context.Context, console *ui.UI, record *pin.Record, report *checks.Report, r *resolve.Resolver, skippedRescan int, hasInconclusive bool, refusedLabels []string, noNarrow bool, acceptMoved bool, originalVersion string) error {
+func renderPinSummary(ctx context.Context, console *ui.UI, record *pin.Record, report *checks.Report, r *resolve.Resolver, skippedRescan int, hasInconclusive bool, refusedLabels []string, noNarrow bool, acceptMoved bool, originalVersion string, prunedWorkflows []string) error {
 	pinned := record.Pinned()
 	investigated := record.Investigated()
 	narrowed := record.Narrowed()
@@ -94,6 +94,10 @@ func renderPinSummary(ctx context.Context, console *ui.UI, record *pin.Record, r
 	if total == 0 {
 		console.TermNeutral("No workflows to check")
 		return nil
+	}
+
+	if n := len(prunedWorkflows); n > 0 {
+		console.TermDetail("Pruned %d deleted %s from the lockfile", n, ui.Pluralize(n, "workflow", "workflows"))
 	}
 
 	// Surface lockfile schema upgrade when the on-disk version differs from

--- a/cmd/gh-actions-lock/prune_workflow_test.go
+++ b/cmd/gh-actions-lock/prune_workflow_test.go
@@ -127,3 +127,96 @@ func TestCheck_NoFix_ReportsStaleWorkflow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(lockBefore), string(lockAfter), "--no-fix must not modify the lockfile")
 }
+
+// writeLastWorkflowDeletedRepo builds a scratch repo whose lockfile records a
+// single workflow that no longer exists on disk (the workflows directory holds
+// only the lockfile). It chdirs into the repo and returns the lockfile path.
+func writeLastWorkflowDeletedRepo(t *testing.T) string {
+	t.Helper()
+	setupGoSHA := "4a3601121dd01d1626a1e23e37211e3254c1c06c"
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755))
+
+	lockYAML := "version: '" + parserlock.Version + "'\ndependencies:\n" +
+		"  'actions/setup-go@v6':\n" +
+		"    ref: 'v6'\n    commit: 'sha1-" + setupGoSHA + "'\n    owner_id: 1\n    repo_id: 1\n" +
+		"workflows:\n" +
+		"  '.github/workflows/deleted.yml':\n    - 'actions/setup-go@v6'\n"
+	lockPath := filepath.Join(dir, ".github", "workflows", "actions.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte(lockYAML), 0o600))
+	t.Chdir(dir)
+	return lockPath
+}
+
+// TestCheck_FullScan_PrunesLastDeletedWorkflow proves that deleting the final
+// workflow doesn't strand its lockfile entry: a full scan that discovers zero
+// workflows still loads the lockfile and prunes the stale entry (and its
+// orphaned dep) instead of aborting with "no workflow files found".
+func TestCheck_FullScan_PrunesLastDeletedWorkflow(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	lockPath := writeLastWorkflowDeletedRepo(t)
+
+	_, _, err := runCommandWithHTTP(t, reg, "--json=valid,workflows")
+	require.NoError(t, err, "an empty scan with a stale lockfile must prune, not error")
+
+	// Pruning the last workflow empties the lockfile; the tool cleans up the
+	// now-empty file. Either way the stale entry must not survive.
+	lockAfter, err := os.ReadFile(lockPath)
+	if err == nil {
+		got := string(lockAfter)
+		assert.NotContains(t, got, "deleted.yml", "stale workflow entry must be pruned")
+		assert.NotContains(t, got, "setup-go", "orphaned dep must be garbage-collected")
+	} else {
+		assert.True(t, os.IsNotExist(err), "unexpected error reading lockfile: %v", err)
+	}
+}
+
+// TestCheck_NoFix_ReportsLastDeletedWorkflow proves read-only mode still
+// surfaces the stale entry when the last workflow is gone, without touching the
+// lockfile.
+func TestCheck_NoFix_ReportsLastDeletedWorkflow(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	lockPath := writeLastWorkflowDeletedRepo(t)
+	lockBefore, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+
+	stdout, _, err := runCommandWithHTTP(t, reg, "--no-fix", "--json=valid,findings")
+	require.NoError(t, err, "stale-workflow is non-blocking, exit stays 0")
+
+	var payload struct {
+		Findings []format.Finding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	var found bool
+	for i := range payload.Findings {
+		if payload.Findings[i].Category == "stale-workflow" {
+			found = true
+			assert.Contains(t, payload.Findings[i].Detail, "deleted.yml")
+		}
+	}
+	assert.True(t, found, "expected a stale-workflow finding: %+v", payload.Findings)
+
+	lockAfter, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(lockBefore), string(lockAfter), "--no-fix must not modify the lockfile")
+}
+
+// TestCheck_EmptyRepo_NoLockfile_Errors proves the helpful "no workflow files"
+// error is preserved when there's nothing on disk and nothing to prune.
+func TestCheck_EmptyRepo_NoLockfile_Errors(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755))
+	t.Chdir(dir)
+
+	_, _, err := runCommandWithHTTP(t, reg, "--json=valid,workflows")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow files found")
+}

--- a/cmd/gh-actions-lock/prune_workflow_test.go
+++ b/cmd/gh-actions-lock/prune_workflow_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
+	"github.com/github/gh-actions-lock/cmd/gh-actions-lock/format"
+	"github.com/github/gh-actions-lock/internal/ghapi/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeStaleLockfileRepo builds a scratch repo whose lockfile records two
+// workflows — workflow.yml (present on disk, uses checkout@v6) and deleted.yml
+// (no file on disk, uses setup-go@v6) — and chdirs into it. Both pins are
+// mutable v6 refs so they're trusted from the lockfile without any network
+// call. Returns the lockfile path.
+func writeStaleLockfileRepo(t *testing.T) string {
+	t.Helper()
+	checkoutSHA := "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+	setupGoSHA := "4a3601121dd01d1626a1e23e37211e3254c1c06c"
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755))
+	wfBody := strings.TrimSpace(`
+name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".github", "workflows", "workflow.yml"), []byte(wfBody), 0o600))
+
+	lockYAML := "version: '" + parserlock.Version + "'\ndependencies:\n" +
+		"  'actions/checkout@v6':\n" +
+		"    ref: 'v6'\n    commit: 'sha1-" + checkoutSHA + "'\n    owner_id: 1\n    repo_id: 1\n" +
+		"  'actions/setup-go@v6':\n" +
+		"    ref: 'v6'\n    commit: 'sha1-" + setupGoSHA + "'\n    owner_id: 1\n    repo_id: 1\n" +
+		"workflows:\n" +
+		"  '.github/workflows/workflow.yml':\n    - 'actions/checkout@v6'\n" +
+		"  '.github/workflows/deleted.yml':\n    - 'actions/setup-go@v6'\n"
+	lockPath := filepath.Join(dir, ".github", "workflows", "actions.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte(lockYAML), 0o600))
+	t.Chdir(dir)
+	return lockPath
+}
+
+// TestCheck_FullScan_PrunesDeletedWorkflow proves a default full-directory fix
+// run drops the lockfile entry for a workflow that no longer exists on disk,
+// and that the now-orphaned dependency is garbage-collected with it.
+func TestCheck_FullScan_PrunesDeletedWorkflow(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	lockPath := writeStaleLockfileRepo(t)
+
+	// No explicit workflow-path arg → full scan → prune authority.
+	_, _, err := runCommandWithHTTP(t, reg, "--json=valid,workflows")
+	require.NoError(t, err)
+
+	lockAfter, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	got := string(lockAfter)
+	assert.Contains(t, got, "workflow.yml", "live workflow must be retained")
+	assert.Contains(t, got, "actions/checkout", "live dep must be retained")
+	assert.NotContains(t, got, "deleted.yml", "stale workflow entry must be pruned")
+	assert.NotContains(t, got, "setup-go", "orphaned dep must be garbage-collected")
+}
+
+// TestCheck_PartialInvocation_DoesNotPrune proves an explicit-path invocation
+// has no authority to declare another workflow deleted: the stale entry and its
+// dep survive untouched.
+func TestCheck_PartialInvocation_DoesNotPrune(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	lockPath := writeStaleLockfileRepo(t)
+
+	_, _, err := runCommandWithHTTP(t, reg, "--json=valid,workflows", ".github/workflows/workflow.yml")
+	require.NoError(t, err)
+
+	lockAfter, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	got := string(lockAfter)
+	assert.Contains(t, got, "deleted.yml", "partial run must not prune out-of-scope workflows")
+	assert.Contains(t, got, "setup-go", "partial run must not GC an out-of-scope workflow's dep")
+}
+
+// TestCheck_NoFix_ReportsStaleWorkflow proves read-only mode surfaces a stale
+// entry as a non-blocking info finding without touching the lockfile.
+func TestCheck_NoFix_ReportsStaleWorkflow(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	lockPath := writeStaleLockfileRepo(t)
+	lockBefore, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+
+	stdout, _, err := runCommandWithHTTP(t, reg, "--no-fix", "--json=valid,findings")
+	require.NoError(t, err, "stale-workflow is non-blocking, exit stays 0")
+
+	var payload struct {
+		Valid    bool             `json:"valid"`
+		Findings []format.Finding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.True(t, payload.Valid)
+
+	var found *format.Finding
+	for i := range payload.Findings {
+		if payload.Findings[i].Category == "stale-workflow" {
+			found = &payload.Findings[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected a stale-workflow finding: %+v", payload.Findings)
+	assert.Equal(t, "info", found.Severity)
+	assert.Contains(t, found.Detail, "deleted.yml")
+
+	lockAfter, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(lockBefore), string(lockAfter), "--no-fix must not modify the lockfile")
+}

--- a/cmd/gh-actions-lock/root.go
+++ b/cmd/gh-actions-lock/root.go
@@ -146,7 +146,12 @@ $ gh actions-lock --json
 // Compare walk. newResolver is the DI seam; pass nil for production wiring.
 func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newResolver resolverFunc, onCorrupt lockRecovery) ([]string, *resolve.Resolver, *lockfile.State, error) {
 	workflowsDir := os.Getenv("GH_ACTIONS_LOCK_WORKFLOWS_DIR")
-	paths, err := discoverWorkflowPaths(workflowPaths, workflowsDir)
+	// A full-directory scan (no explicit paths) may legitimately find zero
+	// workflows when the last one was deleted; it must still load the
+	// lockfile so the now-stale entry can be pruned. Explicit-path runs keep
+	// erroring on a missing file.
+	fullScan := len(workflowPaths) == 0
+	paths, err := discoverWorkflowPaths(workflowPaths, workflowsDir, fullScan)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -195,10 +200,17 @@ func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newReso
 	store.SetMetadataResolver(r)
 	r.SeedBranchHints(store.AllDeps())
 
+	// An empty full scan is only meaningful when the lockfile still records
+	// workflows to prune. With nothing on disk and nothing recorded, there's
+	// genuinely no work — keep the original "no workflow files" error.
+	if len(paths) == 0 && len(store.WorkflowKeys()) == 0 {
+		return nil, nil, nil, noWorkflowsError(workflowsDir)
+	}
+
 	return paths, r, store, nil
 }
 
-func discoverWorkflowPaths(existing []string, workflowsDir string) ([]string, error) {
+func discoverWorkflowPaths(existing []string, workflowsDir string, allowEmpty bool) ([]string, error) {
 	if len(existing) > 0 {
 		return expandWorkflowPaths(existing)
 	}
@@ -208,7 +220,7 @@ func discoverWorkflowPaths(existing []string, workflowsDir string) ([]string, er
 		if err != nil {
 			return nil, err
 		}
-		if len(paths) == 0 {
+		if len(paths) == 0 && !allowEmpty {
 			return nil, fmt.Errorf("no workflow files found in %s", workflowsDir)
 		}
 		return paths, nil
@@ -218,10 +230,19 @@ func discoverWorkflowPaths(existing []string, workflowsDir string) ([]string, er
 	if err != nil {
 		return nil, err
 	}
-	if len(paths) == 0 {
+	if len(paths) == 0 && !allowEmpty {
 		return nil, fmt.Errorf("no workflow files found in .github/workflows/")
 	}
 	return paths, nil
+}
+
+// noWorkflowsError returns the error emitted when a scan finds no workflow
+// files, matching the location it searched.
+func noWorkflowsError(workflowsDir string) error {
+	if workflowsDir != "" {
+		return fmt.Errorf("no workflow files found in %s", workflowsDir)
+	}
+	return fmt.Errorf("no workflow files found in .github/workflows/")
 }
 
 func expandWorkflowPaths(paths []string) ([]string, error) {

--- a/cmd/gh-actions-lock/root.go
+++ b/cmd/gh-actions-lock/root.go
@@ -224,7 +224,7 @@ func discoverWorkflowPaths(existing []string, workflowsDir string, allowEmpty bo
 			return nil, err
 		}
 		if len(paths) == 0 && !allowEmpty {
-			return nil, fmt.Errorf("no workflow files found in %s", workflowsDir)
+			return nil, noWorkflowsError(workflowsDir)
 		}
 		return paths, nil
 	}
@@ -234,7 +234,7 @@ func discoverWorkflowPaths(existing []string, workflowsDir string, allowEmpty bo
 		return nil, err
 	}
 	if len(paths) == 0 && !allowEmpty {
-		return nil, fmt.Errorf("no workflow files found in .github/workflows/")
+		return nil, noWorkflowsError(workflowsDir)
 	}
 	return paths, nil
 }

--- a/cmd/gh-actions-lock/root.go
+++ b/cmd/gh-actions-lock/root.go
@@ -190,6 +190,16 @@ func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newReso
 			return resolve.New(hostname, pool)
 		}
 	}
+
+	// An empty full scan is only meaningful when the lockfile still records
+	// workflows to prune. With nothing on disk and nothing recorded, there's
+	// genuinely no work — keep the original "no workflow files" error, and
+	// emit it before auth so an empty repo doesn't complain about a missing
+	// token.
+	if len(paths) == 0 && len(store.WorkflowKeys()) == 0 {
+		return nil, nil, nil, noWorkflowsError(workflowsDir)
+	}
+
 	r, err := newResolver(resolveHostname(hostname), pool)
 	if err != nil {
 		return nil, nil, nil, err
@@ -199,13 +209,6 @@ func newRun(workflowPaths []string, hostname string, pool *pinpool.Pool, newReso
 	// for the store and re-seed branch hints.
 	store.SetMetadataResolver(r)
 	r.SeedBranchHints(store.AllDeps())
-
-	// An empty full scan is only meaningful when the lockfile still records
-	// workflows to prune. With nothing on disk and nothing recorded, there's
-	// genuinely no work — keep the original "no workflow files" error.
-	if len(paths) == 0 && len(store.WorkflowKeys()) == 0 {
-		return nil, nil, nil, noWorkflowsError(workflowsDir)
-	}
 
 	return paths, r, store, nil
 }

--- a/cmd/gh-actions-lock/run.go
+++ b/cmd/gh-actions-lock/run.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"sync"
 
 	"github.com/cli/go-gh/v2/pkg/repository"
@@ -23,6 +24,7 @@ import (
 	"github.com/github/gh-actions-lock/internal/resolve"
 	"github.com/github/gh-actions-lock/internal/tag"
 	"github.com/github/gh-actions-lock/internal/ui"
+	"github.com/github/gh-actions-lock/internal/workflowfile"
 	"github.com/spf13/cobra"
 )
 
@@ -152,6 +154,11 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	}
 
 	endSetup := prof.Phase("setup (discover + lockfile)")
+	// A full-directory scan (no explicit workflow-path args) is the only
+	// invocation with the authority to declare a workflow deleted. Capture
+	// this before newRun overwrites opts.workflowPaths with the discovered
+	// set.
+	fullScan := len(opts.workflowPaths) == 0
 	// check fix mode can rebuild a deleted lockfile, so interactive sessions
 	// may delete-and-recreate an unreadable one. --no-fix is read-only and
 	// must not delete; it fails instead.
@@ -174,6 +181,25 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	endSetup()
 
 	opts.workflowPaths = paths
+
+	// Reconcile the lockfile's recorded workflow set against what's on disk.
+	// Only a full-directory scan can prove a workflow was deleted; a partial
+	// invocation (explicit paths) has no authority to prune out-of-scope
+	// entries. keep is authoritative only when fullScan is true.
+	var keepWorkflows map[string]bool
+	var staleWorkflows []string
+	if fullScan {
+		keepWorkflows = make(map[string]bool, len(paths))
+		for _, p := range paths {
+			keepWorkflows[workflowfile.KeyFromPath(p)] = true
+		}
+		for _, k := range store.WorkflowKeys() {
+			if !keepWorkflows[k] {
+				staleWorkflows = append(staleWorkflows, k)
+			}
+		}
+		sort.Strings(staleWorkflows)
+	}
 
 	// Detailed narration is suppressed from the terminal during the run so the
 	// output stays limited to phase labels, prompts, and the final summary.
@@ -235,6 +261,13 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	report := result.Report
 	valid := result.Valid
 	skippedRescan := result.SkippedRescan
+
+	// Read-only modes never touch the lockfile, so surface stale entries as
+	// non-blocking info findings instead of pruning them. Fix mode prunes
+	// them below (before the lockfile is saved) and reports that instead.
+	if opts.noFix && len(staleWorkflows) > 0 {
+		appendStaleWorkflowFindings(report, staleWorkflows, false)
+	}
 
 	// --no-onboard: refuse to onboard new workflows or actions. Rewrite the
 	// relevant not-pinned findings to onboarding-required and drop their refs
@@ -323,6 +356,14 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 		return fmt.Errorf("planning pins: %w", planErr)
 	}
 
+	// Prune stale workflow entries before the commit persists the lockfile.
+	// Removing the keys orphans their pins, which Save's existing GC then
+	// drops. Only reached in fix mode (--no-fix returns earlier) and only on
+	// a full scan (staleWorkflows is empty otherwise).
+	if len(staleWorkflows) > 0 {
+		store.PruneWorkflows(keepWorkflows)
+	}
+
 	// Commit: write all changes to disk atomically (fast local I/O, no
 	// spinner label — it finishes before the user could read one).
 	endCommit := prof.Phase("pin.Commit (disk writes)")
@@ -333,6 +374,12 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 	endCommit()
 
 	console.StopProgress()
+
+	// Record the prune in the report so --json consumers see what was
+	// dropped. The terminal surface reports it via the pin summary instead.
+	if len(staleWorkflows) > 0 {
+		appendStaleWorkflowFindings(report, staleWorkflows, true)
+	}
 
 	// Inject info-severity findings for non-semver refs so they appear
 	// in --json output. Suppressed when --no-narrow is set (user chose
@@ -367,7 +414,7 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 
 	// Terminal summary.
 	hasInconclusive := opts.rescan && report.HasInconclusive()
-	summaryErr := renderPinSummary(ctx, console, record, report, r, skippedRescan, hasInconclusive, refusedLabels, opts.noNarrow, opts.acceptMoved, store.OriginalVersion())
+	summaryErr := renderPinSummary(ctx, console, record, report, r, skippedRescan, hasInconclusive, refusedLabels, opts.noNarrow, opts.acceptMoved, store.OriginalVersion(), staleWorkflows)
 
 	if summaryErr != nil {
 		return summaryErr
@@ -444,6 +491,26 @@ func injectVersionRefFindings(report *checks.Report, record *pin.Record) {
 				),
 			})
 		}
+	}
+}
+
+// appendStaleWorkflowFindings records a repo-level info finding for each
+// workflow key whose file no longer exists on disk. pruned controls the
+// wording: true after the entry was dropped, false when it was only reported
+// (read-only run).
+func appendStaleWorkflowFindings(report *checks.Report, workflows []string, pruned bool) {
+	for _, wf := range workflows {
+		detail := fmt.Sprintf("lockfile records deleted workflow %s — run `gh actions-lock` to prune it", wf)
+		if pruned {
+			detail = fmt.Sprintf("pruned stale lockfile entry for deleted workflow %s", wf)
+		}
+		report.RepoFindings = append(report.RepoFindings, checks.Finding{
+			WorkflowPath: wf,
+			Category:     checks.StaleWorkflow,
+			Severity:     checks.SeverityInfo,
+			Confidence:   checks.ConfidenceHigh,
+			Detail:       detail,
+		})
 	}
 }
 

--- a/cmd/gh-actions-lock/verify.go
+++ b/cmd/gh-actions-lock/verify.go
@@ -34,7 +34,7 @@ func applyVerifyFlags(opts *checkOptions) {
 // entry — no network, no auth required.
 func runVerifyLocal(opts *checkOptions, out io.Writer, console *ui.UI) error {
 	workflowsDir := os.Getenv("GH_ACTIONS_LOCK_WORKFLOWS_DIR")
-	paths, err := discoverWorkflowPaths(opts.workflowPaths, workflowsDir)
+	paths, err := discoverWorkflowPaths(opts.workflowPaths, workflowsDir, false)
 	if err != nil {
 		return err
 	}

--- a/internal/lockfile/prune_test.go
+++ b/internal/lockfile/prune_test.go
@@ -1,0 +1,127 @@
+package lockfile
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	parserlock "github.com/github/actions-lockfile/go/pkg/lockfile"
+	"github.com/github/gh-actions-lock/internal/dep"
+)
+
+func checkoutDep() dep.Dependency {
+	return dep.Dependency{
+		NWO:      "actions/checkout",
+		Ref:      "v4.2.1",
+		Tag:      "v4.2.1",
+		SHA:      "abc123abc123abc123abc123abc123abc123abc1",
+		HashAlgo: "sha1",
+	}
+}
+
+func setupGoDep() dep.Dependency {
+	return dep.Dependency{
+		NWO:      "actions/setup-go",
+		Ref:      "v5.0.0",
+		Tag:      "v5.0.0",
+		SHA:      "def456def456def456def456def456def456def4",
+		HashAlgo: "sha1",
+	}
+}
+
+func newStoreWithWorkflows(t *testing.T, dir string) *State {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := LoadState(dir, fakeMetadataResolver{})
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	return store
+}
+
+func TestPruneWorkflows_RemovesStaleEntryAndOrphanedDeps(t *testing.T) {
+	dir := t.TempDir()
+	store := newStoreWithWorkflows(t, dir)
+
+	if err := store.Set(context.Background(), ".github/workflows/ci.yml", []dep.Dependency{checkoutDep()}, nil, nil); err != nil {
+		t.Fatalf("Set ci: %v", err)
+	}
+	if err := store.Set(context.Background(), ".github/workflows/release.yml", []dep.Dependency{setupGoDep()}, nil, nil); err != nil {
+		t.Fatalf("Set release: %v", err)
+	}
+
+	removed := store.PruneWorkflows(map[string]bool{".github/workflows/ci.yml": true})
+	if len(removed) != 1 || removed[0] != ".github/workflows/release.yml" {
+		t.Fatalf("removed = %v, want [.github/workflows/release.yml]", removed)
+	}
+
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, parserlock.Path))
+	if err != nil {
+		t.Fatalf("reading lockfile: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, "ci.yml") || !strings.Contains(got, "actions/checkout") {
+		t.Errorf("live workflow/dep missing after prune:\n%s", got)
+	}
+	if strings.Contains(got, "release.yml") {
+		t.Errorf("stale workflow still present after prune:\n%s", got)
+	}
+	if strings.Contains(got, "actions/setup-go") {
+		t.Errorf("orphaned dep not garbage-collected after prune:\n%s", got)
+	}
+}
+
+func TestPruneWorkflows_KeepsDepStillReferenced(t *testing.T) {
+	dir := t.TempDir()
+	store := newStoreWithWorkflows(t, dir)
+
+	// Both workflows use actions/checkout.
+	if err := store.Set(context.Background(), ".github/workflows/ci.yml", []dep.Dependency{checkoutDep()}, nil, nil); err != nil {
+		t.Fatalf("Set ci: %v", err)
+	}
+	if err := store.Set(context.Background(), ".github/workflows/release.yml", []dep.Dependency{checkoutDep()}, nil, nil); err != nil {
+		t.Fatalf("Set release: %v", err)
+	}
+
+	store.PruneWorkflows(map[string]bool{".github/workflows/ci.yml": true})
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, parserlock.Path))
+	if err != nil {
+		t.Fatalf("reading lockfile: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, "actions/checkout") {
+		t.Errorf("shared dep dropped even though a live workflow still uses it:\n%s", got)
+	}
+	if strings.Contains(got, "release.yml") {
+		t.Errorf("stale workflow still present after prune:\n%s", got)
+	}
+}
+
+func TestPruneWorkflows_NoStaleIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	store := newStoreWithWorkflows(t, dir)
+
+	if err := store.Set(context.Background(), ".github/workflows/ci.yml", []dep.Dependency{checkoutDep()}, nil, nil); err != nil {
+		t.Fatalf("Set ci: %v", err)
+	}
+
+	removed := store.PruneWorkflows(map[string]bool{".github/workflows/ci.yml": true})
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want none", removed)
+	}
+	if keys := store.WorkflowKeys(); len(keys) != 1 || keys[0] != ".github/workflows/ci.yml" {
+		t.Fatalf("WorkflowKeys = %v, want [.github/workflows/ci.yml]", keys)
+	}
+}

--- a/internal/lockfile/state.go
+++ b/internal/lockfile/state.go
@@ -188,6 +188,41 @@ func (s *State) HasWorkflow(workflowKey string) bool {
 	return ok
 }
 
+// WorkflowKeys returns the workflow paths currently recorded in the lockfile's
+// workflows{} map. Order is undefined. Intended for callers that need to
+// reconcile the recorded set against the workflows present on disk.
+func (s *State) WorkflowKeys() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.file.Workflows))
+	for k := range s.file.Workflows {
+		out = append(out, k)
+	}
+	return out
+}
+
+// PruneWorkflows removes every workflow entry whose key is not in keep and
+// returns the removed keys in sorted order. Dependency entries left orphaned
+// by the removal are not deleted here: Save's existing orphan GC drops any pin
+// no surviving workflow references.
+//
+// Callers must only pass a keep set derived from a full-directory scan. A
+// partial invocation (an explicit subset of workflow paths) has no authority to
+// decide a workflow is deleted and must not call this.
+func (s *State) PruneWorkflows(keep map[string]bool) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var removed []string
+	for k := range s.file.Workflows {
+		if !keep[k] {
+			removed = append(removed, k)
+			delete(s.file.Workflows, k)
+		}
+	}
+	sort.Strings(removed)
+	return removed
+}
+
 // Get returns the dependencies recorded for workflowKey (e.g.
 // ".github/workflows/ci.yml"). Returns nil when the workflow has no entry.
 func (s *State) Get(workflowKey string) ([]dep.Dependency, error) {

--- a/internal/pipeline/checks/category.go
+++ b/internal/pipeline/checks/category.go
@@ -67,6 +67,11 @@ const (
 	// workflows that reference local actions — the entire workflow is
 	// skipped.
 	LocalAction Category = "local-action"
+	// StaleWorkflow is an informational, repo-level notice: the lockfile
+	// records a workflow entry whose file no longer exists on disk. On a
+	// default (full-directory) fix run these are pruned automatically; in
+	// read-only mode they are surfaced but not removed. Non-blocking.
+	StaleWorkflow Category = "stale-workflow"
 )
 
 // IsInconclusive reports whether c represents a diagnostic that

--- a/internal/pipeline/checks/category_test.go
+++ b/internal/pipeline/checks/category_test.go
@@ -25,6 +25,7 @@ func TestCategoryStringsAreFrozen(t *testing.T) {
 		{OnboardingRequired, "onboarding-required"},
 		{VersionRef, "version-ref"},
 		{LocalAction, "local-action"},
+		{StaleWorkflow, "stale-workflow"},
 	}
 	for _, c := range cases {
 		if string(c.got) != c.want {
@@ -47,6 +48,7 @@ func TestCategoryIsInconclusive(t *testing.T) {
 		NotPinned, ShaAsRef, RefChanged, RefMoved, Stale,
 		MisleadingSHA, UnreachablePin,
 		Valid, RunOnly, OnboardingRequired, VersionRef, LocalAction,
+		StaleWorkflow,
 	}
 	for _, c := range blocking {
 		if c.IsInconclusive() {

--- a/internal/pipeline/checks/finding.go
+++ b/internal/pipeline/checks/finding.go
@@ -107,7 +107,7 @@ func (f *Finding) IsValid() bool {
 		return true
 	}
 	switch f.Category {
-	case Valid, RunOnly, LocalAction, ShaAsRef, RefMoved, VersionRef, OnboardingRequired:
+	case Valid, RunOnly, LocalAction, ShaAsRef, RefMoved, VersionRef, OnboardingRequired, StaleWorkflow:
 		return true
 	case NotPinned:
 		return f.ActionRef == nil // workflow-level is a warning

--- a/test/integration/run.rb
+++ b/test/integration/run.rb
@@ -388,6 +388,35 @@ LOCKFILE_TEMPLATES = {
       }
     )
   },
+  # pinned_checkout plus a recorded workflow (deleted.yml) that no longer
+  # exists on disk. A full-directory fix scan should prune the stale entry
+  # and GC its orphaned setup-go dep.
+  "pinned_checkout_plus_deleted" => -> {
+    build_lockfile(
+      workflows: {
+        ".github/workflows/ci.yml" => [
+          "actions/checkout@v4"
+        ],
+        ".github/workflows/deleted.yml" => [
+          "actions/setup-go@v5"
+        ]
+      },
+      dependencies: {
+        "actions/checkout@v4" => {
+          "ref" => "v4",
+          "commit" => "sha1-#{CHECKOUT_SHA}",
+          "owner_id" => 44036562,
+          "repo_id" => 197814629
+        },
+        "actions/setup-go@v5" => {
+          "ref" => "v5",
+          "commit" => "sha1-#{SETUP_GO_SHA}",
+          "owner_id" => 44036562,
+          "repo_id" => 197814629
+        }
+      }
+    )
+  },
   # Lockfile with a fully-narrowed dep key (v4.2.0) — represents a
   # workflow that was previously onboarded with default narrowing.
   "pinned_checkout_full" => -> {

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -319,6 +319,23 @@ scenarios:
       lockfile_exists: true
       lockfile_deps_cover_direct: true
 
+  - name: prune_deleted_workflow_full_scan
+    category: lockfile
+    description: "github/actions-dispatch#816 — a full-directory fix scan prunes a lockfile entry whose workflow file was deleted, and GCs its orphaned dep"
+    needs_token: true
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions: ["actions/checkout@v4"]
+      lockfile_template: pinned_checkout_plus_deleted
+    expect:
+      exit: 0
+      lockfile_deps_cover_direct: true
+      output_contains: ["Pruned 1 deleted workflow"]
+      lockfile_contains: ["'actions/checkout@v4':"]
+      lockfile_comment_excludes: "deleted\\.yml|setup-go"
+
   - name: onboarded_corrupt_recovery
     category: lockfile
     description: "Corrupt YAML lockfile — user confirms delete, lockfile rewritten from scratch"


### PR DESCRIPTION
## What

Deleted workflows were never pruned from `.github/workflows/actions.lock`. Their entries lingered forever because discovery only ever sees on-disk files, so a removed workflow was simply never revisited.

## Why

`State.Save()` garbage-collects orphaned *dependency* entries but never removes orphaned *workflow* entries. Once a workflow file is deleted, nothing rediscovers its key, so the stale entry stays in the lockfile indefinitely.

## Fix

- `internal/lockfile/state.go`: add `WorkflowKeys()` and `PruneWorkflows(keep)` — `PruneWorkflows` drops workflow keys not present on disk and relies on the existing `Save()` orphan-dep GC to clean up now-unreferenced deps.
- `cmd/gh-actions-lock/run.go`: on a **full-directory scan only** (no explicit path args), compute the set of on-disk workflows and prune the rest before commit. Partial/targeted runs never prune, so out-of-scope workflows can't be dropped.
- Read-only mode surfaces stale entries as a non-blocking `stale-workflow` info finding instead of removing them.
- `internal/pipeline/checks/category.go` / `finding.go`: add the `stale-workflow` category (additive) and map it as non-blocking in `IsValid()`.
- `pin_summary.go`: report the pruned count.

The category addition is intentionally additive-only to avoid conflicting with concurrent classification work.

## Tests

- `internal/lockfile/prune_test.go`: pruning removes stale entries + GCs orphaned deps, keeps shared deps, and no-ops when nothing is stale.
- `cmd/gh-actions-lock/prune_workflow_test.go`: full scans prune, partial runs don't, and `--no-fix` reports the stale entry as non-blocking.

Resolves github/actions-dispatch#816