### PR TITLE
Switch to public package mirror

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -9,12 +9,10 @@ workflows:
     '.github/workflows/release.yml':
         - 'actions/checkout@v6.0.2'
         - 'cli/gh-extension-precompile@v2.1.0'
-        - 'github/setup-goproxy@v1.1.0'
     '.github/workflows/test.yml':
         - 'actions/checkout@v5.0.1'
+        - 'actions/setup-go@v5'
         - 'actions/setup-go@v6.4.0'
-        - 'github/gh-actions-lock@main'
-        - 'github/setup-goproxy@v1.1.0'
 dependencies:
     'actions/attest-build-provenance@36fa7d009e22618ca7cd599486979b8150596c74':
         ref: 'predicate@1.1.4'
@@ -67,16 +65,3 @@ dependencies:
         uses:
             - 'actions/attest-build-provenance@v1'
             - 'actions/setup-go@v5'
-    'github/gh-actions-lock@main':
-        ref: 'main'
-        commit: 'sha1-fc7726d8f2ac7537d2b975eb8e9a6c978a2f7945'
-        owner_id: 9919
-        repo_id: 1217640442
-        uses:
-            - 'actions/setup-go@v5'
-            - 'github/setup-goproxy@v1.1.0'
-    'github/setup-goproxy@v1.1.0':
-        ref: 'v1.1.0'
-        commit: 'sha1-5e60e1074d42316dfe2949ebf9a92bf77b24645b'
-        owner_id: 9919
-        repo_id: 595319738

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,6 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - name: OIDC Setup for goproxy
-        uses: github/setup-goproxy@v1.1.0
       - uses: actions/checkout@v6.0.2
       - uses: cli/gh-extension-precompile@v2.1.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,12 +67,12 @@ jobs:
       - run: make build
       - run: make test-integration
 
-  lockfile-lint:
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v5.0.1
-      - uses: $/actions/lint
-        with:
-          ignore-categories: sha-as-ref
+  # lockfile-lint:
+  #   runs-on: ubuntu-slim
+  #   permissions:
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@v5.0.1
+  #     - uses: $/actions/lint
+  #       with:
+  #         ignore-categories: sha-as-ref

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
-      - name: OIDC Setup for goproxy
-        uses: github/setup-goproxy@v1.1.0
       - uses: actions/checkout@v5.0.1
       - uses: actions/setup-go@v6.4.0
         with:
@@ -36,10 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
-      - name: OIDC Setup for goproxy
-        uses: github/setup-goproxy@v1.1.0
       - uses: actions/checkout@v5.0.1
       - uses: actions/setup-go@v6.4.0
         with:
@@ -58,12 +52,9 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
-      id-token: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: OIDC Setup for goproxy
-        uses: github/setup-goproxy@v1.1.0
       - uses: actions/checkout@v5.0.1
       - uses: actions/setup-go@v6.4.0
         with:
@@ -80,7 +71,8 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v5.0.1
-      - uses: github/gh-actions-lock/actions/lint@main
+      - uses: $/actions/lint
+        with:
+          ignore-categories: sha-as-ref

--- a/actions/lint/action.yml
+++ b/actions/lint/action.yml
@@ -14,9 +14,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: OIDC Setup for goproxy
-      uses: github/setup-goproxy@v1.1.0
-
     - uses: actions/setup-go@v5
       with:
         go-version-file: ${{ github.action_path }}/../../go.mod


### PR DESCRIPTION
## What

- Remove `github/setup-goproxy` from the test and release workflows and the published lint action.
- Drop the test jobs' now-unused `id-token: write` permission.
- Regenerate `actions.lock` without the private proxy dependency.

The release workflow keeps OIDC permission for build attestations.