### PR TITLE
Make local-action migration default-on with a --no-migrate-local-actions opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ jobs:
 A trailing `@ref` (e.g. `$/actions/my-action@v1`) is rejected — the ref is always
 the running commit.
 
-To convert existing same-repo `./…` composite action references to `$/…`, run with
-`--migrate-local-actions`. This rewrites `./…` steps both in your workflows and in
-your in-repo composite action definitions (`action.yml`). Only `./…` paths that
-resolve to an in-repo action file are rewritten:
+Same-repo `./…` composite action references are automatically converted to `$/…`
+on fix runs. This rewrites `./…` steps both in your workflows and in your in-repo
+composite action definitions (`action.yml`). Only `./…` paths that resolve to an
+in-repo action file are rewritten. To leave `./…` refs untouched, opt out with
+`--no-migrate-local-actions`:
 
 ```bash
-gh actions-lock --migrate-local-actions
+gh actions-lock --no-migrate-local-actions
 ```
 
 ## How it works

--- a/cmd/gh-actions-lock/migrate_test.go
+++ b/cmd/gh-actions-lock/migrate_test.go
@@ -266,14 +266,16 @@ jobs:
 	t.Run("--no-fix leaves file untouched", func(t *testing.T) {
 		transport := &requestCountingTransport{}
 		wf := setup(t)
-		_, _, _ = runCommandWithHTTP(t, transport, "--no-fix", wf)
+		_, _, err := runCommandWithHTTP(t, transport, "--no-fix", wf)
+		require.NoError(t, err, "command must succeed so the assertion proves the guard, not an early failure")
 		assert.Equal(t, workflow, read(t, wf))
 	})
 
 	t.Run("--no-migrate-local-actions suppresses rewrite", func(t *testing.T) {
 		transport := &requestCountingTransport{}
 		wf := setup(t)
-		_, _, _ = runCommandWithHTTP(t, transport, "--no-migrate-local-actions", wf)
+		_, _, err := runCommandWithHTTP(t, transport, "--no-migrate-local-actions", wf)
+		require.NoError(t, err, "command must succeed so the assertion proves the opt-out, not an early failure")
 		got := read(t, wf)
 		assert.Contains(t, got, "uses: ./.github/actions/foo", "opt-out leaves the ./… ref in place")
 		assert.NotContains(t, got, "$/", "opt-out means no migration to $/")

--- a/cmd/gh-actions-lock/migrate_test.go
+++ b/cmd/gh-actions-lock/migrate_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMigrateLocalActions_CompositeActionFiles verifies that --migrate-local-actions
+// TestMigrateLocalActions_CompositeActionFiles verifies that migration
 // rewrites `./…` not just in workflow files but also inside in-repo composite
 // action definitions (action.yml), including ones nested a few directories deep.
 // A `./…` whose target does not resolve to an in-repo action file is left
@@ -111,8 +111,8 @@ func TestMigrateLocalActions_RejectsActionFileSymlinkEscape(t *testing.T) {
 	assert.Equal(t, outside, gotOutside)
 }
 
-// TestMigrateLocalActions_EndToEnd runs the real command with
-// --migrate-local-actions against a scratch repo whose local composite chain
+// TestMigrateLocalActions_EndToEnd runs the real command (migration is on by
+// default) against a scratch repo whose local composite chain
 // reaches a pinnable remote action, then asserts on BOTH sides of
 // the mutation: the rewritten workflow/action files AND the generated
 // lockfile. It proves the two behaviours compose correctly in one pass:
@@ -189,7 +189,7 @@ jobs:
 	t.Chdir(dir)
 
 	_, _, err := runCommandWithHTTP(t, reg,
-		"--migrate-local-actions", ".github/workflows/workflow.yml",
+		".github/workflows/workflow.yml",
 	)
 	require.NoError(t, err)
 
@@ -218,4 +218,64 @@ jobs:
 	assert.NotContains(t, lock, "$/", "self refs are inherently pinned; no lockfile entry")
 	assert.NotContains(t, lock, "my-action", "in-repo composite must not be pinned")
 	assert.NotContains(t, lock, "helper")
+}
+
+// TestMigrateLocalActions_DefaultOnAndOptOut proves the default-on wiring:
+// a plain fix run rewrites an in-repo `./.github/actions/foo` composite ref to
+// `$/…` with no network, --no-fix leaves the file untouched, and the
+// --no-migrate-local-actions opt-out suppresses the rewrite on a fix run.
+func TestMigrateLocalActions_DefaultOnAndOptOut(t *testing.T) {
+	const workflow = `name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/foo
+`
+	setup := func(t *testing.T) string {
+		dir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
+		wf := filepath.Join(dir, ".github", "workflows", "ci.yml")
+		require.NoError(t, os.MkdirAll(filepath.Dir(wf), 0o755))
+		require.NoError(t, os.WriteFile(wf, []byte(workflow), 0o600))
+		act := filepath.Join(dir, ".github", "actions", "foo", "action.yml")
+		require.NoError(t, os.MkdirAll(filepath.Dir(act), 0o755))
+		require.NoError(t, os.WriteFile(act,
+			[]byte("name: Foo\nruns:\n  using: composite\n  steps:\n    - run: echo hi\n      shell: bash\n"), 0o600))
+		t.Chdir(dir)
+		return wf
+	}
+	read := func(t *testing.T, path string) string {
+		b, err := os.ReadFile(path)
+		require.NoError(t, err)
+		return string(b)
+	}
+
+	t.Run("default fix run rewrites to $/", func(t *testing.T) {
+		transport := &requestCountingTransport{}
+		wf := setup(t)
+		_, _, err := runCommandWithHTTP(t, transport, wf)
+		require.NoError(t, err)
+		got := read(t, wf)
+		assert.Contains(t, got, "uses: $/.github/actions/foo")
+		assert.NotContains(t, got, "uses: ./.github/actions/foo")
+		assert.Zero(t, transport.calls.Load(), "self ref is inherently pinned; no network")
+	})
+
+	t.Run("--no-fix leaves file untouched", func(t *testing.T) {
+		transport := &requestCountingTransport{}
+		wf := setup(t)
+		_, _, _ = runCommandWithHTTP(t, transport, "--no-fix", wf)
+		assert.Equal(t, workflow, read(t, wf))
+	})
+
+	t.Run("--no-migrate-local-actions suppresses rewrite", func(t *testing.T) {
+		transport := &requestCountingTransport{}
+		wf := setup(t)
+		_, _, _ = runCommandWithHTTP(t, transport, "--no-migrate-local-actions", wf)
+		got := read(t, wf)
+		assert.Contains(t, got, "uses: ./.github/actions/foo", "opt-out leaves the ./… ref in place")
+		assert.NotContains(t, got, "$/", "opt-out means no migration to $/")
+	})
 }

--- a/cmd/gh-actions-lock/run.go
+++ b/cmd/gh-actions-lock/run.go
@@ -68,10 +68,10 @@ type checkOptions struct {
 	// in scanned workflows must have a corresponding lockfile entry.
 	// No auth, no resolution, no reachability — ideal for pre-commit hooks.
 	verifyLocal bool
-	// migrateLocalActions rewrites same-repo `./…` composite action refs to
-	// the inherently-pinned `$/…` form before scanning. Opt-in: it changes
-	// `uses:` values on disk.
-	migrateLocalActions bool
+	// noMigrateLocalActions opts out of rewriting same-repo `./…` composite
+	// action refs to the inherently-pinned `$/…` form. Migration runs by
+	// default on fix runs; set this to leave `./…` refs on disk untouched.
+	noMigrateLocalActions bool
 }
 
 // bindCheckFlags registers the run flags on the root command.
@@ -95,9 +95,9 @@ func bindCheckFlags(cmd *cobra.Command, opts *checkOptions) {
 		"Offline lockfile coverage check: verify every action ref has a lockfile entry.\n"+
 			"No network calls, no authentication required — ideal for pre-commit hooks.")
 	cmd.Flags().StringVar(&opts.profileDir, "profile", "", "Enable profiling: write trace, CPU profile, and HTTP log to `dir`")
-	cmd.Flags().BoolVar(&opts.migrateLocalActions, "migrate-local-actions", false,
-		"Rewrite same-repo `uses: ./…` actions to the inherently-pinned `uses: $/…` form.\n"+
-			"Only local paths that resolve to an in-repo action file are rewritten.")
+	cmd.Flags().BoolVar(&opts.noMigrateLocalActions, "no-migrate-local-actions", false,
+		"Do not rewrite same-repo `uses: ./…` actions to the inherently-pinned `uses: $/…` form.\n"+
+			"Migration runs by default on fix runs; this leaves `./…` refs on disk untouched.")
 }
 
 // validateOutputFlags rejects incoherent structured-output flag combinations.
@@ -187,10 +187,11 @@ func runCheck(cmd *cobra.Command, opts *checkOptions, newResolver resolverFunc) 
 
 	opts.workflowPaths = paths
 
-	// --migrate-local-actions: rewrite same-repo `./…` action refs to the
-	// inherently-pinned `$/…` form before scanning, so the diagnosis sees
-	// compliant refs. Read-only runs (--no-fix) never touch disk.
-	if opts.migrateLocalActions && !opts.noFix {
+	// Rewrite same-repo `./…` action refs to the inherently-pinned `$/…` form
+	// before scanning, so the diagnosis sees compliant refs. Runs by default on
+	// fix runs; opt out with --no-migrate-local-actions. Read-only runs
+	// (--no-fix) never touch disk.
+	if !opts.noMigrateLocalActions && !opts.noFix {
 		migrated, err := migrateLocalActions(opts.workflowPaths)
 		if err != nil {
 			return err

--- a/cmd/gh-actions-lock/selfrepository_test.go
+++ b/cmd/gh-actions-lock/selfrepository_test.go
@@ -42,7 +42,10 @@ jobs:
 	t.Chdir(dir)
 
 	_, _, err := runCommandWithHTTP(t, transport, workflowPath)
-	require.ErrorIs(t, err, errSilent)
+	// Migration runs by default and validates self repository refs first, so an
+	// invalid `$/…` ref aborts the run before any dependency resolution.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid self repository reference")
 	assert.Zero(t, transport.calls.Load(), "invalid syntax should be rejected before dependency resolution")
 
 	gotWorkflow, err := os.ReadFile(workflowPath)
@@ -82,7 +85,7 @@ jobs:
 	require.NoError(t, os.WriteFile(workflowPath, workflow, 0o600))
 	t.Chdir(dir)
 
-	_, _, err := runCommandWithHTTP(t, transport, "--migrate-local-actions", workflowPath)
+	_, _, err := runCommandWithHTTP(t, transport, workflowPath)
 
 	require.Error(t, err)
 	assert.Zero(t, transport.calls.Load(), "invalid syntax should stop migration before dependency resolution")

--- a/cmd/gh-actions-lock/verify.go
+++ b/cmd/gh-actions-lock/verify.go
@@ -39,10 +39,10 @@ func runVerifyLocal(opts *checkOptions, out io.Writer, console *ui.UI) error {
 		return err
 	}
 
-	// --migrate-local-actions rewrites same-repo `./…` refs to `$/…` on disk
-	// before the coverage check sees them. Opt-in write, so it runs even in
-	// this otherwise read-only mode (but never under --no-fix).
-	if opts.migrateLocalActions && !opts.noFix {
+	// Rewrite same-repo `./…` refs to `$/…` on disk before the coverage check
+	// sees them. Runs by default on fix runs even in this otherwise read-only
+	// mode; opt out with --no-migrate-local-actions, and never under --no-fix.
+	if !opts.noMigrateLocalActions && !opts.noFix {
 		migrated, mErr := migrateLocalActions(paths)
 		if mErr != nil {
 			return mErr

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -231,7 +231,7 @@ func precheckWorkflow(pw checks.ParsedWorkflow, store *lockfile.State) (checks.W
 				Severity:     checks.SeverityError,
 				Confidence:   checks.ConfidenceHigh,
 				Detail:       "workflow uses local path actions which are not supported; remove local path actions to continue using the lockfile",
-				Remediation:  "rewrite same-repo `uses: ./…` to `uses: $/…` (run with --migrate-local-actions), or remove the `./…` steps",
+				Remediation:  "rewrite same-repo `uses: ./…` to `uses: $/…` (automatic on fix runs; disable with --no-migrate-local-actions), or remove the `./…` steps",
 			})
 		} else {
 			wr.Findings = append(wr.Findings, checks.Finding{
@@ -240,7 +240,7 @@ func precheckWorkflow(pw checks.ParsedWorkflow, store *lockfile.State) (checks.W
 				Severity:     checks.SeverityWarning,
 				Confidence:   checks.ConfidenceHigh,
 				Detail:       "workflow uses local path actions; lockfile onboarding is not supported",
-				Remediation:  "rewrite same-repo `uses: ./…` to `uses: $/…` (run with --migrate-local-actions)",
+				Remediation:  "rewrite same-repo `uses: ./…` to `uses: $/…` (automatic on fix runs; disable with --no-migrate-local-actions)",
 			})
 		}
 		hasTerminalFinding = true

--- a/test/scenarios/catalog.go
+++ b/test/scenarios/catalog.go
@@ -50,7 +50,7 @@ type Fixtures struct {
 	Lockfile         string                     `yaml:"lockfile"`
 	LockfileTemplate string                     `yaml:"lockfile_template"`
 	// Files lays down arbitrary repo-relative files before the run, e.g.
-	// in-repo composite action.yml definitions that `--migrate-local-actions`
+	// in-repo composite action.yml definitions that the default-on migration
 	// should also rewrite. Paths are relative to the repo root, not the
 	// workflows dir.
 	Files map[string]string `yaml:"files"`

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -482,10 +482,9 @@ scenarios:
 
   - name: migrate_local_actions_rewrite
     category: workflow_parsing
-    description: "--migrate-local-actions rewrites a deep in-repo ./ chain to $/, then discovers and pins the remote dependency reached only through that $/ chain; no self repository ref enters the lockfile"
+    description: "migration runs by default on fix runs: rewrites a deep in-repo ./ chain to $/, then discovers and pins the remote dependency reached only through that $/ chain; no self repository ref enters the lockfile"
     needs_stub: true
     tags: [stub]
-    flags: ["--migrate-local-actions"]
     fixtures:
       workflows:
         ci.yml:
@@ -528,6 +527,39 @@ scenarios:
         "nested/deep/action.yml": ["uses: actions/checkout@v4"]
       files_exclude:
         ".github/workflows/ci.yml": ["uses: ./my-action", "actions/checkout"]
+
+  - name: migrate_local_actions_opt_out
+    category: workflow_parsing
+    description: "--no-migrate-local-actions opts out: the same-repo ./ composite ref is left on disk untouched and never rewritten to $/"
+    needs_stub: true
+    tags: [stub]
+    flags: ["--no-migrate-local-actions"]
+    fixtures:
+      workflows:
+        ci.yml:
+          raw: |
+            name: CI
+            on: push
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: ./my-action
+      files:
+        my-action/action.yml: |
+          name: My Action
+          runs:
+            using: composite
+            steps:
+              - run: echo hi
+                shell: bash
+      delete_lockfile: true
+    expect:
+      output_contains: ["local path actions"]
+      files_contain:
+        ".github/workflows/ci.yml": ["uses: ./my-action"]
+      files_exclude:
+        ".github/workflows/ci.yml": ["$/"]
 
   - name: sub_path_action
     category: workflow_parsing

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -528,39 +528,6 @@ scenarios:
       files_exclude:
         ".github/workflows/ci.yml": ["uses: ./my-action", "actions/checkout"]
 
-  - name: migrate_local_actions_opt_out
-    category: workflow_parsing
-    description: "--no-migrate-local-actions opts out: the same-repo ./ composite ref is left on disk untouched and never rewritten to $/"
-    needs_stub: true
-    tags: [stub]
-    flags: ["--no-migrate-local-actions"]
-    fixtures:
-      workflows:
-        ci.yml:
-          raw: |
-            name: CI
-            on: push
-            jobs:
-              build:
-                runs-on: ubuntu-latest
-                steps:
-                  - uses: ./my-action
-      files:
-        my-action/action.yml: |
-          name: My Action
-          runs:
-            using: composite
-            steps:
-              - run: echo hi
-                shell: bash
-      delete_lockfile: true
-    expect:
-      output_contains: ["local path actions"]
-      files_contain:
-        ".github/workflows/ci.yml": ["uses: ./my-action"]
-      files_exclude:
-        ".github/workflows/ci.yml": ["$/"]
-
   - name: sub_path_action
     category: workflow_parsing
     description: "Sub-path action (actions/cache/restore@v4) handled"
@@ -1245,11 +1212,11 @@ scenarios:
 
   - name: self_repository_action_missing
     category: workflow_parsing
-    description: "A missing in-repo $/ action is an unfixable invalid self repository ref, not a fixable not-pinned dependency"
+    description: "A missing in-repo $/ action is an unfixable invalid self repository ref, not a fixable not-pinned dependency. --no-migrate-local-actions opts out of the default migration pass so the real binary's verify-local diagnosis is what reports it."
     needs_token: false
     needs_stub: false
     tags: [stub]
-    flags: ["--verify-local"]
+    flags: ["--verify-local", "--no-migrate-local-actions"]
     fixtures:
       workflows:
         ci.yml:
@@ -1267,11 +1234,11 @@ scenarios:
 
   - name: self_repository_ref_rejected
     category: workflow_parsing
-    description: "$/…@ref is rejected — a self repository reference always resolves to the running commit, so an explicit @ref is invalid"
+    description: "$/…@ref is rejected — a self repository reference always resolves to the running commit, so an explicit @ref is invalid. --no-migrate-local-actions opts out of the default migration pass so the real binary's verify-local diagnosis reports it."
     needs_token: false
     needs_stub: false
     tags: [stub]
-    flags: ["--verify-local"]
+    flags: ["--verify-local", "--no-migrate-local-actions"]
     fixtures:
       workflows:
         ci.yml:
@@ -1289,11 +1256,11 @@ scenarios:
 
   - name: self_repository_nested_ref_rejected
     category: workflow_parsing
-    description: "A $/…@ref nested inside an in-repo composite is rejected during local closure discovery, before any network resolution"
+    description: "A $/…@ref nested inside an in-repo composite is rejected during local closure discovery, before any network resolution. --no-migrate-local-actions opts out of the default migration pass so the real binary's verify-local diagnosis reports it."
     needs_token: false
     needs_stub: false
     tags: [stub]
-    flags: ["--verify-local"]
+    flags: ["--verify-local", "--no-migrate-local-actions"]
     fixtures:
       workflows:
         ci.yml:


### PR DESCRIPTION
## Why

Rewriting same-repo `./…` composite action refs to the inherently-pinned `$/…` form was gated behind the opt-in `--migrate-local-actions` flag, so most fix runs left non-compliant local refs in place. Since the rewrite is safe (only paths that resolve to an in-repo action file are migrated) and is what we want in the common case, this makes it the default and gives users a clean way to opt out.

## What changed

- **Default-on migration.** The gate at both entrypoints (`run.go` and `verify.go`) becomes `!opts.noMigrateLocalActions && !opts.noFix`. Migration now runs automatically on any fix run. The `!opts.noFix` guard is preserved exactly, so read-only runs still never touch disk.
- **Real named opt-out.** Replaces the opt-in flag with `--no-migrate-local-actions` (`opts.noMigrateLocalActions`, default false), mirroring the repo's existing `--no-fix` negative-flag convention rather than relying on `--flag=false`. The old `--migrate-local-actions` flag was unreleased, so no back-compat no-op alias is kept.
- **Wording.** Updates the `diagnose.go` remediation strings and the README to say migration is automatic and can be disabled with the opt-out flag.

The rewrite algorithm itself (`MigrateLocalActionsToSelfRepository`, `migrateLocalActions`) is untouched.

## Heads-up for review

One behavior change worth a conscious look: because migration now runs by default, an invalid `$/…` ref is validated during the migration pass and aborts the whole run early, where a plain run previously proceeded to diagnosis. The affected pre-existing command test was updated to assert that error; the invariants it guards (no network, file left untouched) still hold. If we'd rather soften this (downgrade a migration-validation failure to a warning and skip that file instead of aborting), that can be a follow-up.

## Tests

- New `TestMigrateLocalActions_DefaultOnAndOptOut` covers: (a) a plain fix run rewrites `./.github/actions/foo` to `$/…`, (b) `--no-fix` leaves the file untouched, (c) `--no-migrate-local-actions` suppresses the rewrite.
- Existing selfref/migrate tests updated to drop the now-default flag.
- Catalog: the rewrite scenario drops the flag and notes default-on; added a `migrate_local_actions_opt_out` scenario. Both are `[stub]`-tagged so they run in blocking CI.

Verified with gofmt, `go build ./...`, `go vet`, `go test ./...`, plus a manual smoke on a throwaway repo confirming all three behaviors.

## Out of scope

Job-level local reusable-workflow calls (`uses: ./.github/workflows/x.yml`) remain excluded. The rewrite algorithm is unchanged.