### PR TITLE
Skip branch scans for symbolic action refs

### DIFF
--- a/cmd/gh-actions-lock/command_test.go
+++ b/cmd/gh-actions-lock/command_test.go
@@ -794,15 +794,13 @@ jobs:
 // read-only switch: a bare --json run (no --no-fix) still autofixes. setup-go
 // is unpinned but fixable, so the pipeline pins it, writes the lockfile, and
 // exits 0 — while stdout carries the JSON render. The single dep uses a
-// full-semver ref (v6.0.0) so tag-narrowing skips the network; the remaining
-// stubs cover the reverse-lookup (default branch → containing branch → tag)
-// and the lockfile write (numeric owner/repo IDs).
+// full-semver ref (v6.0.0), so neither tag narrowing nor reverse lookup needs
+// the network; the remaining metadata stub covers the lockfile write.
 func TestCheck_DefaultJSON_AutofixWrites(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
 	setupGoSHA := "4a3601121dd01d1626a1e23e37211e3254c1c06c"
-	mainSHA := "1111111111111111111111111111111111111111"
 
 	// Resolve setup-go@v6.0.0 → setupGoSHA.
 	reg.Register(
@@ -813,35 +811,9 @@ func TestCheck_DefaultJSON_AutofixWrites(t *testing.T) {
 			},
 		}),
 	)
-	// Reverse lookup: default branch HEAD (main), then compare confirms the
-	// SHA is contained, then tags maps the SHA back to v6.0.0.
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/setup-go/git/ref/heads/main`),
-		httpmock.JSONResponse(map[string]any{
-			"ref":    "refs/heads/main",
-			"object": map[string]any{"sha": mainSHA, "type": "commit"},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/setup-go/compare/`),
-		httpmock.JSONResponse(map[string]any{
-			"status":            "identical",
-			"merge_base_commit": map[string]any{"sha": setupGoSHA},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/setup-go/tags`),
-		httpmock.JSONResponse([]map[string]any{
-			{"name": "v6.0.0", "commit": map[string]any{"sha": setupGoSHA}},
-		}),
-	)
-	// GetDefaultBranch (reverse lookup) and RepoIDs (lockfile write) now share
-	// a single repos/{owner}/{repo} fetch, so one stub serves both. It carries
-	// the fields either caller reads.
 	repoMeta := httpmock.JSONResponse(map[string]any{
-		"default_branch": "main",
-		"id":             2,
-		"owner":          map[string]any{"id": 1},
+		"id":    2,
+		"owner": map[string]any{"id": 1},
 	})
 	reg.Register(httpmock.REST("GET", `repos/actions/setup-go$`), repoMeta)
 

--- a/cmd/gh-actions-lock/migrate_test.go
+++ b/cmd/gh-actions-lock/migrate_test.go
@@ -126,7 +126,6 @@ func TestMigrateLocalActions_EndToEnd(t *testing.T) {
 	defer reg.Verify(t)
 
 	setupGoSHA := "4a3601121dd01d1626a1e23e37211e3254c1c06c"
-	mainSHA := "1111111111111111111111111111111111111111"
 
 	reg.Register(
 		httpmock.GraphQLForRepo("actions", "setup-go"),
@@ -134,20 +133,6 @@ func TestMigrateLocalActions_EndToEnd(t *testing.T) {
 			"data": map[string]any{
 				"a0": testRepoResponse("actions/setup-go", setupGoSHA, nodeActionYAML),
 			},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/setup-go/git/ref/heads/main`),
-		httpmock.JSONResponse(map[string]any{
-			"ref":    "refs/heads/main",
-			"object": map[string]any{"sha": mainSHA, "type": "commit"},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/setup-go/compare/`),
-		httpmock.JSONResponse(map[string]any{
-			"status":            "identical",
-			"merge_base_commit": map[string]any{"sha": setupGoSHA},
 		}),
 	)
 	reg.Register(

--- a/internal/pin/plan_test.go
+++ b/internal/pin/plan_test.go
@@ -44,23 +44,6 @@ func TestPlanWorkflow_PartialResolutionFailure(t *testing.T) {
 		}),
 	)
 
-	// Reverse lookup stubs for good/action: branch listing and tags.
-	reg.Register(
-		httpmock.REST("GET", `repos/good/action/branches`),
-		httpmock.JSONResponse([]any{
-			map[string]any{"name": "main", "commit": map[string]any{"sha": goodSHA}},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/good/action/tags`),
-		httpmock.JSONResponse([]any{
-			map[string]any{
-				"name":   "v1",
-				"commit": map[string]any{"sha": goodSHA},
-			},
-		}),
-	)
-
 	pool := pinpool.New(2, nil)
 	resolver, err := resolve.New("github.com", pool, resolve.WithTransport(reg))
 	require.NoError(t, err)
@@ -206,40 +189,6 @@ func newTransitivePlanFixture(t *testing.T, compSHA, transSHA string) (*resolve.
 			},
 		}),
 	)
-	reg.Register(
-		httpmock.REST("GET", `repos/comp/action$`),
-		httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/comp/action/branches`),
-		httpmock.JSONResponse([]any{
-			map[string]any{"name": "main", "commit": map[string]any{"sha": compSHA}},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/comp/action/tags`),
-		httpmock.JSONResponse([]any{
-			map[string]any{"name": "v1.0.0", "commit": map[string]any{"sha": compSHA}},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/trans/dep$`),
-		httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/trans/dep/branches`),
-		httpmock.JSONResponse([]any{
-			map[string]any{"name": "main", "commit": map[string]any{"sha": transSHA}},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/trans/dep/tags`),
-		httpmock.JSONResponse([]any{
-			map[string]any{"name": "v2", "commit": map[string]any{"sha": transSHA}},
-			map[string]any{"name": "v2.3.4", "commit": map[string]any{"sha": transSHA}},
-		}),
-	)
-
 	pool := pinpool.New(2, nil)
 	resolver, err := resolve.New("github.com", pool, resolve.WithTransport(reg))
 	require.NoError(t, err)
@@ -433,10 +382,10 @@ func TestPlanWorkflow_InvalidSelfRepositoryRefDoesNotMutateWorkflow(t *testing.T
 func TestNoNarrow_BareSHA(t *testing.T) {
 	const sha = "abc1230000000000000000000000000000000000"
 
-	// newSlowPathFixtures wires up a Resolver (GraphQL resolve + ReverseLookup
-	// branch/tag listing) and a Tagger that would narrow the SHA to v4.2.1.
+	// newSlowPathFixtures wires up a Resolver and a Tagger that would narrow
+	// the SHA to v4.2.1.
 	// The report has a Finding so NeedsAttention() is true and the slow path runs.
-	newSlowPathFixtures := func(t *testing.T) (*resolve.Resolver, *tag.Lister, checks.WorkflowReport, *httpmock.Registry) {
+	newSlowPathFixtures := func(t *testing.T, reverseLookup bool) (*resolve.Resolver, *tag.Lister, checks.WorkflowReport, *httpmock.Registry) {
 		t.Helper()
 		reg := &httpmock.Registry{}
 
@@ -456,13 +405,14 @@ func TestNoNarrow_BareSHA(t *testing.T) {
 			}),
 		)
 
-		// ReverseLookup: branch + tag listing — would rewrite the SHA to v4.2.1.
-		reg.Register(
-			httpmock.REST("GET", `repos/actions/checkout/branches`),
-			httpmock.JSONResponse([]any{
-				map[string]any{"name": "main", "commit": map[string]any{"sha": sha}},
-			}),
-		)
+		if reverseLookup {
+			reg.Register(
+				httpmock.REST("GET", `repos/actions/checkout/branches`),
+				httpmock.JSONResponse([]any{
+					map[string]any{"name": "main", "commit": map[string]any{"sha": sha}},
+				}),
+			)
+		}
 		reg.Register(
 			httpmock.REST("GET", `repos/actions/checkout/tags`),
 			httpmock.JSONResponse([]any{
@@ -494,7 +444,7 @@ func TestNoNarrow_BareSHA(t *testing.T) {
 	}
 
 	t.Run("no-narrow preserves bare SHA through ReverseLookup", func(t *testing.T) {
-		resolver, tagger, wr, _ := newSlowPathFixtures(t)
+		resolver, tagger, wr, _ := newSlowPathFixtures(t, true)
 
 		opts := PlanOptions{
 			Resolver: resolver,
@@ -520,17 +470,7 @@ func TestNoNarrow_BareSHA(t *testing.T) {
 	})
 
 	t.Run("default narrows bare SHA to tag", func(t *testing.T) {
-		resolver, tagger, wr, reg := newSlowPathFixtures(t)
-
-		// ReverseLookup after narrowing resolves the new ref (v4.2.1) and
-		// lists tags again — register a second stub for that round-trip.
-		reg.Register(
-			httpmock.REST("GET", `repos/actions/checkout/tags`),
-			httpmock.JSONResponse([]any{
-				map[string]any{"name": "v4", "commit": map[string]any{"sha": sha}},
-				map[string]any{"name": "v4.2.1", "commit": map[string]any{"sha": sha}},
-			}),
-		)
+		resolver, tagger, wr, _ := newSlowPathFixtures(t, false)
 
 		opts := PlanOptions{
 			Resolver: resolver,
@@ -617,39 +557,6 @@ func TestPlanWorkflow_CrossRefTransitiveClosure(t *testing.T) {
 				},
 			},
 		}),
-	)
-
-	// Reverse lookup stubs — one set per unique NWO.
-	// org/fixtures: branches include both "updated" and "main" tips.
-	reg.Register(
-		httpmock.REST("GET", `repos/org/fixtures$`),
-		httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/org/fixtures/branches`),
-		httpmock.JSONResponse([]any{
-			map[string]any{"name": "main", "commit": map[string]any{"sha": simpleSHA}},
-			map[string]any{"name": "updated", "commit": map[string]any{"sha": nestedSHA}},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/org/fixtures/tags`),
-		httpmock.JSONResponse([]any{}),
-	)
-	// cross/dep
-	reg.Register(
-		httpmock.REST("GET", `repos/cross/dep$`),
-		httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/cross/dep/branches`),
-		httpmock.JSONResponse([]any{
-			map[string]any{"name": "main", "commit": map[string]any{"sha": crossSHA}},
-		}),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/cross/dep/tags`),
-		httpmock.JSONResponse([]any{}),
 	)
 
 	pool := pinpool.New(2, nil)

--- a/internal/resolve/discover_test.go
+++ b/internal/resolve/discover_test.go
@@ -310,16 +310,7 @@ func TestReverseLookup_PopulatesTagBranchAndRewritesSHAPins(t *testing.T) {
 }
 
 func TestReverseLookup_NoChangeWhenRefAlreadyCanonical(t *testing.T) {
-	// dep.Ref="v4", dep.SHA="abc". main HEAD=="abc" → exact match.
 	reg := &httpmock.Registry{}
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(httpmock.BranchListResponse("main", "abc")),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(httpmock.TagListResponse("v4", "abc")),
-	)
 
 	r, err := New("github.com", pinpool.New(2, nil), WithTransport(reg))
 	if err != nil {
@@ -340,8 +331,8 @@ func TestReverseLookup_NoChangeWhenRefAlreadyCanonical(t *testing.T) {
 	if deps[0].Ref != "v4" {
 		t.Errorf("ref should be unchanged, got %q", deps[0].Ref)
 	}
-	if deps[0].Tag != "v4" || deps[0].Branch != "main" {
-		t.Errorf("expected Tag=v4 Branch=main, got Tag=%q Branch=%q", deps[0].Tag, deps[0].Branch)
+	if deps[0].Tag != "v4" || deps[0].Branch != "" {
+		t.Errorf("expected Tag=v4 Branch empty, got Tag=%q Branch=%q", deps[0].Tag, deps[0].Branch)
 	}
 	reg.Verify(t)
 }
@@ -382,7 +373,11 @@ func TestReverseLookup_FailsClosedOnImpostor(t *testing.T) {
 	}
 
 	deps := []dep.Dependency{
-		{NWO: "actions/checkout", Ref: "poisoned", SHA: "dead"},
+		{
+			NWO: "actions/checkout",
+			Ref: "deaddeaddeaddeaddeaddeaddeaddeaddeaddead",
+			SHA: "deaddeaddeaddeaddeaddeaddeaddeaddeaddead",
+		},
 	}
 	_, issues, err := r.ReverseLookup(context.Background(), deps)
 	if err != nil {
@@ -403,17 +398,7 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestReverseLookup_PreservesBranchRefOverTag(t *testing.T) {
-	// User wrote @main — main HEAD=="abc" → exact match.
-	// Tag discovery finds v4 and v4.3.1 but branch ref is preserved.
 	reg := &httpmock.Registry{}
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/checkout/branches`),
-		httpmock.JSONResponse(httpmock.BranchListResponse("main", "abc", "releases/v4", "xyz")),
-	)
-	reg.Register(
-		httpmock.REST("GET", `repos/actions/checkout/tags`),
-		httpmock.JSONResponse(httpmock.TagListResponse("v4", "abc", "v4.3.1", "abc")),
-	)
 
 	r, err := New("github.com", pinpool.New(2, nil), WithTransport(reg))
 	if err != nil {
@@ -434,8 +419,8 @@ func TestReverseLookup_PreservesBranchRefOverTag(t *testing.T) {
 	if deps[0].Ref != "main" {
 		t.Errorf("expected Ref=main (preserved), got %q", deps[0].Ref)
 	}
-	if deps[0].Tag != "v4.3.1" {
-		t.Errorf("expected Tag populated (highest semver), got %q", deps[0].Tag)
+	if deps[0].Tag != "" {
+		t.Errorf("expected Tag empty, got %q", deps[0].Tag)
 	}
 	if deps[0].Branch != "main" {
 		t.Errorf("expected Branch=main, got %q", deps[0].Branch)

--- a/internal/resolve/discover_test.go
+++ b/internal/resolve/discover_test.go
@@ -331,8 +331,8 @@ func TestReverseLookup_NoChangeWhenRefAlreadyCanonical(t *testing.T) {
 	if deps[0].Ref != "v4" {
 		t.Errorf("ref should be unchanged, got %q", deps[0].Ref)
 	}
-	if deps[0].Tag != "v4" || deps[0].Branch != "" {
-		t.Errorf("expected Tag=v4 Branch empty, got Tag=%q Branch=%q", deps[0].Tag, deps[0].Branch)
+	if deps[0].Tag != "" || deps[0].Branch != "" {
+		t.Errorf("expected Tag and Branch empty, got Tag=%q Branch=%q", deps[0].Tag, deps[0].Branch)
 	}
 	reg.Verify(t)
 }
@@ -422,8 +422,8 @@ func TestReverseLookup_PreservesBranchRefOverTag(t *testing.T) {
 	if deps[0].Tag != "" {
 		t.Errorf("expected Tag empty, got %q", deps[0].Tag)
 	}
-	if deps[0].Branch != "main" {
-		t.Errorf("expected Branch=main, got %q", deps[0].Branch)
+	if deps[0].Branch != "" {
+		t.Errorf("expected Branch empty, got %q", deps[0].Branch)
 	}
 	reg.Verify(t)
 }

--- a/internal/resolve/reverse_lookup.go
+++ b/internal/resolve/reverse_lookup.go
@@ -250,9 +250,9 @@ type LookupIssue struct {
 	Message string // human-readable reason
 }
 
-// ReverseLookup classifies symbolic refs locally and reverse-lookups bare SHA
-// refs via DiscoverContaining. It populates dep.Tag and dep.Branch and computes
-// the canonical @ref. The ref priority is:
+// ReverseLookup leaves symbolic refs unchanged and reverse-lookups bare SHA
+// refs via DiscoverContaining. For bare SHAs it populates dep.Tag and dep.Branch
+// and computes the canonical @ref. The ref priority is:
 // tag (semver-ish release) > protected branch > default branch > any branch.
 // When the canonical ref differs from dep.Ref the change is recorded in
 // the returned rewrites map and dep.Ref is updated in place.

--- a/internal/resolve/reverse_lookup.go
+++ b/internal/resolve/reverse_lookup.go
@@ -250,15 +250,15 @@ type LookupIssue struct {
 	Message string // human-readable reason
 }
 
-// ReverseLookup performs a reverse lookup (SHA → containing tag/branch)
-// for every entry in deps via DiscoverContaining, populates dep.Tag and
-// dep.Branch, and computes the canonical @ref. The ref priority is:
+// ReverseLookup classifies symbolic refs locally and reverse-lookups bare SHA
+// refs via DiscoverContaining. It populates dep.Tag and dep.Branch and computes
+// the canonical @ref. The ref priority is:
 // tag (semver-ish release) > protected branch > default branch > any branch.
 // When the canonical ref differs from dep.Ref the change is recorded in
 // the returned rewrites map and dep.Ref is updated in place.
 //
-// Deps that cannot be resolved (orphaned commits, bare SHAs with no
-// containing ref) are skipped and reported in the returned issues slice.
+// Bare SHA deps with no containing ref are skipped and reported in the
+// returned issues slice.
 // Only transient/API errors are returned as err.
 func (r *Resolver) ReverseLookup(ctx context.Context, deps []dep.Dependency) (map[string]string, []LookupIssue, error) {
 	rewrites := map[string]string{}
@@ -267,6 +267,10 @@ func (r *Resolver) ReverseLookup(ctx context.Context, deps []dep.Dependency) (ma
 		d := &deps[i]
 		owner, repo := d.OwnerRepo()
 		if owner == "" || repo == "" {
+			continue
+		}
+		if !LooksLikeSHA(d.Ref) {
+			d.Tag, d.Branch = parserlock.SplitRef(d.Ref)
 			continue
 		}
 		tag, branch, err := r.DiscoverContaining(ctx, owner, repo, d.SHA, d.Ref)

--- a/internal/resolve/reverse_lookup.go
+++ b/internal/resolve/reverse_lookup.go
@@ -270,7 +270,6 @@ func (r *Resolver) ReverseLookup(ctx context.Context, deps []dep.Dependency) (ma
 			continue
 		}
 		if !LooksLikeSHA(d.Ref) {
-			d.Tag, d.Branch = parserlock.SplitRef(d.Ref)
 			continue
 		}
 		tag, branch, err := r.DiscoverContaining(ctx, owner, repo, d.SHA, d.Ref)


### PR DESCRIPTION
## What

Avoid pin-time branch discovery for symbolic action refs such as `@v4` and `@main`.

## Why

Reverse-looking up every resolved dependency caused unnecessary GitHub API requests and could burn through rate limits even when the original symbolic ref already contained all metadata needed for the lockfile.

## How

`ReverseLookup` now leaves symbolic refs unchanged. Branch and tag discovery remains limited to bare SHA refs, where a symbolic lockfile ref must actually be recovered.

Tests enforce that symbolic refs issue no reverse-lookup requests while bare SHAs retain the existing named, likely, and full-scan fallback behavior.

## Risk

Low and reversible. The change removes redundant metadata enrichment for symbolic refs; resolution and SHA verification are unchanged.

## Testing

- `go test ./...`