### PR TITLE
Support hosted Dependabot through REST-only GitHub API access

### DIFF
--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -47,13 +47,13 @@ func (c *Client) SSOFallbackEligible(ctx context.Context, owner string) bool {
 	return eligible
 }
 
-func (c *Client) publicRepoFallbackEligible(ctx context.Context, owner, repo string, err error) bool {
+func (c *Client) repoFallbackEligible(ctx context.Context, owner, repo string, err error) bool {
 	code, _ := StatusCode(err)
 	if !IsSAMLEnforcement(err) && code != http.StatusUnauthorized {
 		return false
 	}
-	meta, metaErr := c.repoMetadata(ctx, owner, repo)
-	return metaErr == nil && meta.Visibility == "public"
+	_, metaErr := c.repoMetadata(ctx, owner, repo)
+	return metaErr == nil
 }
 
 // IsSAMLEnforcement reports whether err represents a SAML/SSO enforcement

--- a/internal/ghapi/anon_fallback.go
+++ b/internal/ghapi/anon_fallback.go
@@ -47,6 +47,15 @@ func (c *Client) SSOFallbackEligible(ctx context.Context, owner string) bool {
 	return eligible
 }
 
+func (c *Client) publicRepoFallbackEligible(ctx context.Context, owner, repo string, err error) bool {
+	code, _ := StatusCode(err)
+	if !IsSAMLEnforcement(err) && code != http.StatusUnauthorized {
+		return false
+	}
+	meta, metaErr := c.repoMetadata(ctx, owner, repo)
+	return metaErr == nil && meta.Visibility == "public"
+}
+
 // IsSAMLEnforcement reports whether err represents a SAML/SSO enforcement
 // block. It matches both REST 403s (api.HTTPError) and plain errors whose
 // message indicates SAML enforcement (e.g. from the GraphQL resolution path).

--- a/internal/ghapi/anon_fallback_test.go
+++ b/internal/ghapi/anon_fallback_test.go
@@ -112,7 +112,7 @@ func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
 
 	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method == http.MethodGet {
-			return jsonHTTP(map[string]any{"visibility": "private"})
+			return statusResponse(req, http.StatusUnauthorized)
 		}
 		return jsonHTTP(map[string]any{
 			"data": map[string]any{"a0": nil},
@@ -148,7 +148,7 @@ func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
 	}
 }
 
-func TestResolveActionFiles_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
+func TestResolveActionFiles_BadCredentialsUsesRESTFallbackForPrivateRepo(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("fallback request method = %s, want GET", r.Method)
@@ -167,7 +167,7 @@ func TestResolveActionFiles_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
 	var graphqlCalls int
 	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method == http.MethodGet {
-			return jsonHTTP(map[string]any{"visibility": "public"})
+			return jsonHTTP(map[string]any{"visibility": "private"})
 		}
 		graphqlCalls++
 		return badCredentialsResponse(req)
@@ -202,10 +202,10 @@ func TestResolveActionFiles_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
 func TestResolveActionFiles_BadCredentialsFallbackFailsClosed(t *testing.T) {
 	tests := []struct {
 		name       string
-		visibility string
+		repoStatus int
 	}{
-		{name: "private repository", visibility: "private"},
-		{name: "unreachable ref", visibility: "public"},
+		{name: "inaccessible repository", repoStatus: http.StatusNotFound},
+		{name: "unreachable ref", repoStatus: http.StatusOK},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -218,7 +218,10 @@ func TestResolveActionFiles_BadCredentialsFallbackFailsClosed(t *testing.T) {
 
 			tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 				if req.Method == http.MethodGet {
-					return jsonHTTP(map[string]any{"visibility": tt.visibility})
+					if tt.repoStatus != http.StatusOK {
+						return statusResponse(req, tt.repoStatus)
+					}
+					return jsonHTTP(map[string]any{"visibility": "private"})
 				}
 				return badCredentialsResponse(req)
 			})
@@ -234,11 +237,11 @@ func TestResolveActionFiles_BadCredentialsFallbackFailsClosed(t *testing.T) {
 			if results[0].Err == nil {
 				t.Fatal("expected resolution error")
 			}
-			if tt.visibility == "private" && fallbackCalls != 0 {
-				t.Fatalf("private repository made %d fallback requests", fallbackCalls)
+			if tt.repoStatus != http.StatusOK && fallbackCalls != 0 {
+				t.Fatalf("inaccessible repository made %d fallback requests", fallbackCalls)
 			}
-			if tt.visibility == "public" && fallbackCalls == 0 {
-				t.Fatal("unreachable public ref was not attempted over REST")
+			if tt.repoStatus == http.StatusOK && fallbackCalls == 0 {
+				t.Fatal("unreachable ref was not attempted over REST")
 			}
 		})
 	}
@@ -311,9 +314,13 @@ func TestBatchBranchContains_BadCredentialsUsesPublicRESTFallback(t *testing.T) 
 }
 
 func badCredentialsResponse(req *http.Request) (*http.Response, error) {
-	resp, err := jsonHTTP(map[string]string{"message": "Bad credentials"})
-	resp.StatusCode = http.StatusUnauthorized
-	resp.Status = "401 Unauthorized"
+	return statusResponse(req, http.StatusUnauthorized)
+}
+
+func statusResponse(req *http.Request, status int) (*http.Response, error) {
+	resp, err := jsonHTTP(map[string]string{"message": http.StatusText(status)})
+	resp.StatusCode = status
+	resp.Status = fmt.Sprintf("%d %s", status, http.StatusText(status))
 	resp.Request = req
 	return resp, err
 }

--- a/internal/ghapi/anon_fallback_test.go
+++ b/internal/ghapi/anon_fallback_test.go
@@ -3,6 +3,7 @@ package ghapi
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -57,6 +58,9 @@ func TestResolveActionFiles_SSOFallbackForActionsOrg(t *testing.T) {
 
 	// GraphQL transport returns SAML error for actions/checkout.
 	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet {
+			return jsonHTTP(map[string]any{"visibility": "public"})
+		}
 		return jsonHTTP(map[string]any{
 			"data": map[string]any{"a0": nil},
 			"errors": []map[string]any{
@@ -107,6 +111,9 @@ func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
 	defer srv.Close()
 
 	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet {
+			return jsonHTTP(map[string]any{"visibility": "private"})
+		}
 		return jsonHTTP(map[string]any{
 			"data": map[string]any{"a0": nil},
 			"errors": []map[string]any{
@@ -139,4 +146,174 @@ func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
 	if !strings.Contains(results[0].Err.Error(), "SSO authorization required") {
 		t.Fatalf("expected SSO error, got: %v", results[0].Err)
 	}
+}
+
+func TestResolveActionFiles_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("fallback request method = %s, want GET", r.Method)
+		}
+		switch {
+		case strings.Contains(r.URL.Path, "/commits/"):
+			json.NewEncoder(w).Encode(map[string]string{"sha": "abc123def456abc123def456abc123def456abc1"})
+		case strings.Contains(r.URL.Path, "/contents/"):
+			fmt.Fprint(w, "name: public action")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var graphqlCalls int
+	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet {
+			return jsonHTTP(map[string]any{"visibility": "public"})
+		}
+		graphqlCalls++
+		return badCredentialsResponse(req)
+	})
+	c, err := New("github.com", WithClientTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.anonBaseURL = srv.URL
+
+	results := c.ResolveActionFiles(context.Background(), []ActionFileRequest{
+		{Owner: "actions", Repo: "checkout", Ref: "v4"},
+		{Owner: "actions", Repo: "setup-go", Path: "cache", Ref: "v5"},
+	})
+	for _, result := range results {
+		nwo := result.Owner + "/" + result.Repo
+		if result.Err != nil {
+			t.Fatalf("%s: %v", nwo, result.Err)
+		}
+		if result.CommitOID != "abc123def456abc123def456abc123def456abc1" {
+			t.Fatalf("%s: commit = %q", nwo, result.CommitOID)
+		}
+		if result.ActionYML != "name: public action" {
+			t.Fatalf("%s: action.yml = %q", nwo, result.ActionYML)
+		}
+	}
+	if graphqlCalls != 1 {
+		t.Fatalf("GraphQL calls = %d, want 1", graphqlCalls)
+	}
+}
+
+func TestResolveActionFiles_BadCredentialsFallbackFailsClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		visibility string
+	}{
+		{name: "private repository", visibility: "private"},
+		{name: "unreachable ref", visibility: "public"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fallbackCalls int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fallbackCalls++
+				http.NotFound(w, r)
+			}))
+			defer srv.Close()
+
+			tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method == http.MethodGet {
+					return jsonHTTP(map[string]any{"visibility": tt.visibility})
+				}
+				return badCredentialsResponse(req)
+			})
+			c, err := New("github.com", WithClientTransport(tr))
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.anonBaseURL = srv.URL
+
+			results := c.ResolveActionFiles(context.Background(), []ActionFileRequest{
+				{Owner: "example", Repo: "action", Ref: "v1"},
+			})
+			if results[0].Err == nil {
+				t.Fatal("expected resolution error")
+			}
+			if tt.visibility == "private" && fallbackCalls != 0 {
+				t.Fatalf("private repository made %d fallback requests", fallbackCalls)
+			}
+			if tt.visibility == "public" && fallbackCalls == 0 {
+				t.Fatal("unreachable public ref was not attempted over REST")
+			}
+		})
+	}
+}
+
+func TestPeelTagObject_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("fallback request method = %s, want GET", r.Method)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"object": map[string]string{"type": "commit", "sha": "commitabc"},
+		})
+	}))
+	defer srv.Close()
+
+	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet {
+			return jsonHTTP(map[string]any{"visibility": "public"})
+		}
+		return badCredentialsResponse(req)
+	})
+	c, err := New("github.com", WithClientTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.anonBaseURL = srv.URL
+
+	result, err := c.PeelTagObject(context.Background(), "actions", "checkout", "tagsha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Typename != "Tag" || result.CommitOID != "commitabc" {
+		t.Fatalf("unexpected peel result: %+v", result)
+	}
+}
+
+func TestBatchBranchContains_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("fallback request method = %s, want GET", r.Method)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"merge_base_commit": map[string]string{"sha": "targetsha"},
+		})
+	}))
+	defer srv.Close()
+
+	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet {
+			return jsonHTTP(map[string]any{"visibility": "public"})
+		}
+		return badCredentialsResponse(req)
+	})
+	c, err := New("github.com", WithClientTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.anonBaseURL = srv.URL
+
+	matched, checked, err := c.BatchBranchContains(context.Background(), "actions", "checkout", "targetsha", []BranchHead{
+		{Name: "main", SHA: "headsha"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !checked || matched != "main" {
+		t.Fatalf("matched = %q, checked = %v", matched, checked)
+	}
+}
+
+func badCredentialsResponse(req *http.Request) (*http.Response, error) {
+	resp, err := jsonHTTP(map[string]string{"message": "Bad credentials"})
+	resp.StatusCode = http.StatusUnauthorized
+	resp.Status = "401 Unauthorized"
+	resp.Request = req
+	return resp, err
 }

--- a/internal/ghapi/client.go
+++ b/internal/ghapi/client.go
@@ -28,6 +28,7 @@ type Client struct {
 	graphql  *api.GraphQLClient
 	rest     *api.RESTClient
 	Hostname string
+	restOnly bool
 
 	// anonBaseURL overrides the base URL for anonymous REST fallback calls.
 	// Empty uses the default "https://api.<Hostname>". Set in tests.
@@ -91,7 +92,10 @@ func New(hostname string, opts ...ClientOption) (*Client, error) {
 		o(&cfg)
 	}
 
-	c := &Client{Hostname: hostname}
+	c := &Client{
+		Hostname: hostname,
+		restOnly: os.Getenv("GH_TOKEN") == "x-access-token",
+	}
 
 	apiOpts := api.ClientOptions{Host: hostname}
 

--- a/internal/ghapi/client.go
+++ b/internal/ghapi/client.go
@@ -94,7 +94,7 @@ func New(hostname string, opts ...ClientOption) (*Client, error) {
 
 	c := &Client{
 		Hostname: hostname,
-		restOnly: os.Getenv("GH_TOKEN") == "x-access-token",
+		restOnly: os.Getenv("GH_ACTIONS_LOCK_DEPENDABOT_PROXY") == "1",
 	}
 
 	apiOpts := api.ClientOptions{Host: hostname}

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -68,6 +68,13 @@ func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileReques
 	if len(refs) == 0 {
 		return nil
 	}
+	if c.restOnly {
+		results := make([]ActionFileResult, len(refs))
+		for i, ref := range refs {
+			results[i] = c.resolveAnonymous(ctx, ref)
+		}
+		return results
+	}
 	results, batchErr := c.resolveActionFilesOnce(ctx, refs)
 	code, _ := StatusCode(batchErr)
 	if batchErr == nil || len(refs) == 1 || ctx.Err() != nil || code == http.StatusUnauthorized {

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
@@ -68,8 +69,9 @@ func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileReques
 		return nil
 	}
 	results, batchErr := c.resolveActionFilesOnce(ctx, refs)
-	if batchErr == nil || len(refs) == 1 || ctx.Err() != nil {
-		return c.retrySSOWithAnonymous(ctx, refs, results)
+	code, _ := StatusCode(batchErr)
+	if batchErr == nil || len(refs) == 1 || ctx.Err() != nil || code == http.StatusUnauthorized {
+		return c.retryWithAnonymous(ctx, refs, results)
 	}
 	mid := len(refs) / 2
 	left := c.ResolveActionFiles(ctx, refs[:mid])
@@ -90,17 +92,14 @@ func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileReques
 	return append(left, right...)
 }
 
-// retrySSOWithAnonymous retries refs that failed with SSO errors for
-// fallback-eligible orgs (e.g. actions/*) using unauthenticated REST.
-func (c *Client) retrySSOWithAnonymous(ctx context.Context, refs []ActionFileRequest, results []ActionFileResult) []ActionFileResult {
+// retryWithAnonymous retries public refs that GraphQL could not authenticate
+// using REST GETs.
+func (c *Client) retryWithAnonymous(ctx context.Context, refs []ActionFileRequest, results []ActionFileResult) []ActionFileResult {
 	for i, r := range results {
 		if r.Err == nil || ctx.Err() != nil {
 			continue
 		}
-		if !c.SSOFallbackEligible(ctx, refs[i].Owner) {
-			continue
-		}
-		if !IsSAMLEnforcement(r.Err) {
+		if !c.publicRepoFallbackEligible(ctx, refs[i].Owner, refs[i].Repo, r.Err) {
 			continue
 		}
 		results[i] = c.resolveAnonymous(ctx, refs[i])

--- a/internal/ghapi/graphql_action_files.go
+++ b/internal/ghapi/graphql_action_files.go
@@ -92,14 +92,14 @@ func (c *Client) ResolveActionFiles(ctx context.Context, refs []ActionFileReques
 	return append(left, right...)
 }
 
-// retryWithAnonymous retries public refs that GraphQL could not authenticate
-// using REST GETs.
+// retryWithAnonymous retries refs that GraphQL could not authenticate using
+// REST GETs when the repository is accessible through REST.
 func (c *Client) retryWithAnonymous(ctx context.Context, refs []ActionFileRequest, results []ActionFileResult) []ActionFileResult {
 	for i, r := range results {
 		if r.Err == nil || ctx.Err() != nil {
 			continue
 		}
-		if !c.publicRepoFallbackEligible(ctx, refs[i].Owner, refs[i].Repo, r.Err) {
+		if !c.repoFallbackEligible(ctx, refs[i].Owner, refs[i].Repo, r.Err) {
 			continue
 		}
 		results[i] = c.resolveAnonymous(ctx, refs[i])

--- a/internal/ghapi/graphql_peel.go
+++ b/internal/ghapi/graphql_peel.go
@@ -50,7 +50,7 @@ func (c *Client) PeelTagObject(ctx context.Context, owner, repo, sha string) (Pe
 		"expr":  sha + "^{commit}",
 	}
 	if err := c.graphql.DoWithContext(profile.WithGraphQLLabel(ctx, "peel"), tagObjectPeelQuery, vars, &resp); err != nil {
-		if c.publicRepoFallbackEligible(ctx, owner, repo, err) {
+		if c.repoFallbackEligible(ctx, owner, repo, err) {
 			return c.anonPeelTagObject(ctx, owner, repo, sha)
 		}
 		return PeelTagObjectResult{}, err

--- a/internal/ghapi/graphql_peel.go
+++ b/internal/ghapi/graphql_peel.go
@@ -33,6 +33,9 @@ type PeelTagObjectResult struct {
 // (not an error) when the OID or repo is not accessible — callers decide
 // how to interpret the negative.
 func (c *Client) PeelTagObject(ctx context.Context, owner, repo, sha string) (PeelTagObjectResult, error) {
+	if c.restOnly {
+		return c.anonPeelTagObject(ctx, owner, repo, sha)
+	}
 	var resp struct {
 		Repository *struct {
 			Head *struct {

--- a/internal/ghapi/graphql_peel.go
+++ b/internal/ghapi/graphql_peel.go
@@ -50,8 +50,7 @@ func (c *Client) PeelTagObject(ctx context.Context, owner, repo, sha string) (Pe
 		"expr":  sha + "^{commit}",
 	}
 	if err := c.graphql.DoWithContext(profile.WithGraphQLLabel(ctx, "peel"), tagObjectPeelQuery, vars, &resp); err != nil {
-		// SAML-blocked: fall back to anonymous REST peel.
-		if IsSAMLEnforcement(err) && c.SSOFallbackEligible(ctx, owner) {
+		if c.publicRepoFallbackEligible(ctx, owner, repo, err) {
 			return c.anonPeelTagObject(ctx, owner, repo, sha)
 		}
 		return PeelTagObjectResult{}, err

--- a/internal/ghapi/graphql_reachability.go
+++ b/internal/ghapi/graphql_reachability.go
@@ -57,8 +57,7 @@ func (c *Client) batchBranchContainsChunk(ctx context.Context, owner, repo, sha 
 	if gqlErr != nil {
 		var httpErr *api.HTTPError
 		if errors.As(gqlErr, &httpErr) {
-			// SAML-blocked GraphQL → fall back to REST compare for eligible orgs.
-			if IsSAMLEnforcement(gqlErr) && c.SSOFallbackEligible(ctx, owner) {
+			if c.publicRepoFallbackEligible(ctx, owner, repo, gqlErr) {
 				return c.anonBatchBranchContains(ctx, owner, repo, sha, branches)
 			}
 			return "", false, gqlErr

--- a/internal/ghapi/graphql_reachability.go
+++ b/internal/ghapi/graphql_reachability.go
@@ -27,6 +27,9 @@ func (c *Client) BatchBranchContains(ctx context.Context, owner, repo, sha strin
 	if len(branches) == 0 {
 		return "", false, nil
 	}
+	if c.restOnly {
+		return c.anonBatchBranchContains(ctx, owner, repo, sha, branches)
+	}
 
 	for start := 0; start < len(branches); start += batchReachabilitySize {
 		end := start + batchReachabilitySize

--- a/internal/ghapi/graphql_reachability.go
+++ b/internal/ghapi/graphql_reachability.go
@@ -57,7 +57,7 @@ func (c *Client) batchBranchContainsChunk(ctx context.Context, owner, repo, sha 
 	if gqlErr != nil {
 		var httpErr *api.HTTPError
 		if errors.As(gqlErr, &httpErr) {
-			if c.publicRepoFallbackEligible(ctx, owner, repo, gqlErr) {
+			if c.repoFallbackEligible(ctx, owner, repo, gqlErr) {
 				return c.anonBatchBranchContains(ctx, owner, repo, sha, branches)
 			}
 			return "", false, gqlErr

--- a/internal/ghapi/rest_fallback.go
+++ b/internal/ghapi/rest_fallback.go
@@ -171,7 +171,7 @@ func (c *Client) anonListTags(ctx context.Context, owner, repo string) ([]TagEnt
 // anonPeelTagObject determines whether sha is an annotated tag and, if so,
 // peels it to the underlying commit using unauthenticated REST.
 func (c *Client) anonPeelTagObject(ctx context.Context, owner, repo, sha string) (PeelTagObjectResult, error) {
-	const maxDepth = 100
+	const maxDepth = 16 // ponytail: cap pathological REST walks; raise only for a real tag chain.
 	current := sha
 	seen := make(map[string]struct{})
 	result := PeelTagObjectResult{}

--- a/internal/ghapi/rest_fallback.go
+++ b/internal/ghapi/rest_fallback.go
@@ -171,23 +171,47 @@ func (c *Client) anonListTags(ctx context.Context, owner, repo string) ([]TagEnt
 // anonPeelTagObject determines whether sha is an annotated tag and, if so,
 // peels it to the underlying commit using unauthenticated REST.
 func (c *Client) anonPeelTagObject(ctx context.Context, owner, repo, sha string) (PeelTagObjectResult, error) {
-	// First, determine the object type via GET /repos/{owner}/{repo}/git/tags/{sha}.
-	// If it's not a tag (404), try the commit endpoint to confirm it's a commit.
-	tagPath := fmt.Sprintf("repos/%s/%s/git/tags/%s",
-		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(sha))
-	var tagResp struct {
-		Object struct {
-			Type string `json:"type"`
-			SHA  string `json:"sha"`
-		} `json:"object"`
-	}
-	if err := c.anonGet(ctx, tagPath, &tagResp); err == nil {
-		// It's an annotated tag — peel to the commit it points to.
-		result := PeelTagObjectResult{Typename: "Tag"}
-		if tagResp.Object.Type == "commit" {
-			result.CommitOID = tagResp.Object.SHA
+	const maxDepth = 100
+	current := sha
+	seen := make(map[string]struct{})
+	result := PeelTagObjectResult{}
+	for depth := 0; depth < maxDepth; depth++ {
+		if _, ok := seen[current]; ok {
+			return result, fmt.Errorf("annotated tag cycle at %s", current)
 		}
-		return result, nil
+		seen[current] = struct{}{}
+
+		tagPath := fmt.Sprintf("repos/%s/%s/git/tags/%s",
+			url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(current))
+		var tagResp struct {
+			Object struct {
+				Type string `json:"type"`
+				SHA  string `json:"sha"`
+			} `json:"object"`
+		}
+		if err := c.anonGet(ctx, tagPath, &tagResp); err != nil {
+			if depth > 0 {
+				return result, fmt.Errorf("peeling annotated tag %s: %w", current, err)
+			}
+			break
+		}
+
+		result.Typename = "Tag"
+		switch tagResp.Object.Type {
+		case "commit":
+			result.CommitOID = tagResp.Object.SHA
+			return result, nil
+		case "tag":
+			if tagResp.Object.SHA == "" {
+				return result, fmt.Errorf("annotated tag %s points to an empty tag SHA", current)
+			}
+			current = tagResp.Object.SHA
+		default:
+			return result, nil
+		}
+	}
+	if result.Typename == "Tag" {
+		return result, fmt.Errorf("annotated tag peel exceeded %d objects", maxDepth)
 	}
 
 	// Not a tag object — check if it's a commit directly.

--- a/internal/ghapi/rest_fallback.go
+++ b/internal/ghapi/rest_fallback.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 )
 
-// anonProbeCache caches per-owner results of anonymous access probes.
+// anonProbeCache caches per-owner results of unauthenticated access probes.
 // true = anonymous access confirmed working, false = not accessible.
 var anonProbeCache sync.Map // map[string]bool
 

--- a/internal/ghapi/rest_fallback_test.go
+++ b/internal/ghapi/rest_fallback_test.go
@@ -37,6 +37,28 @@ func TestSSOFallbackEligible(t *testing.T) {
 	}
 }
 
+func TestNew_RESTOnlyForDependabotToken(t *testing.T) {
+	tests := []struct {
+		token string
+		want  bool
+	}{
+		{token: "x-access-token", want: true},
+		{token: "real-token", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.token, func(t *testing.T) {
+			t.Setenv("GH_TOKEN", tt.token)
+			c, err := New("github.com", WithClientTransport(roundTripFunc(nil)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c.restOnly != tt.want {
+				t.Fatalf("restOnly = %v, want %v", c.restOnly, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveActionFiles_SSOFallbackForActionsOrg(t *testing.T) {
 	anonProbeCache = sync.Map{} // reset cache
 
@@ -148,7 +170,8 @@ func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
 	}
 }
 
-func TestResolveActionFiles_BadCredentialsUsesRESTFallbackForPrivateRepo(t *testing.T) {
+func TestResolveActionFiles_RESTOnlyUsesPrivateRepo(t *testing.T) {
+	t.Setenv("GH_TOKEN", "x-access-token")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("fallback request method = %s, want GET", r.Method)
@@ -164,13 +187,9 @@ func TestResolveActionFiles_BadCredentialsUsesRESTFallbackForPrivateRepo(t *test
 	}))
 	defer srv.Close()
 
-	var graphqlCalls int
 	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method == http.MethodGet {
-			return jsonHTTP(map[string]any{"visibility": "private"})
-		}
-		graphqlCalls++
-		return badCredentialsResponse(req)
+		t.Fatalf("REST-only mode used authenticated transport: %s %s", req.Method, req.URL)
+		return nil, nil
 	})
 	c, err := New("github.com", WithClientTransport(tr))
 	if err != nil {
@@ -193,9 +212,6 @@ func TestResolveActionFiles_BadCredentialsUsesRESTFallbackForPrivateRepo(t *test
 		if result.ActionYML != "name: public action" {
 			t.Fatalf("%s: action.yml = %q", nwo, result.ActionYML)
 		}
-	}
-	if graphqlCalls != 1 {
-		t.Fatalf("GraphQL calls = %d, want 1", graphqlCalls)
 	}
 }
 
@@ -247,7 +263,8 @@ func TestResolveActionFiles_BadCredentialsFallbackFailsClosed(t *testing.T) {
 	}
 }
 
-func TestPeelTagObject_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
+func TestPeelTagObject_RESTOnlyUsesRESTFallback(t *testing.T) {
+	t.Setenv("GH_TOKEN", "x-access-token")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("fallback request method = %s, want GET", r.Method)
@@ -259,10 +276,8 @@ func TestPeelTagObject_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
 	defer srv.Close()
 
 	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method == http.MethodGet {
-			return jsonHTTP(map[string]any{"visibility": "public"})
-		}
-		return badCredentialsResponse(req)
+		t.Fatalf("REST-only mode used authenticated transport: %s %s", req.Method, req.URL)
+		return nil, nil
 	})
 	c, err := New("github.com", WithClientTransport(tr))
 	if err != nil {
@@ -279,7 +294,8 @@ func TestPeelTagObject_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
 	}
 }
 
-func TestBatchBranchContains_BadCredentialsUsesPublicRESTFallback(t *testing.T) {
+func TestBatchBranchContains_RESTOnlyUsesRESTFallback(t *testing.T) {
+	t.Setenv("GH_TOKEN", "x-access-token")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("fallback request method = %s, want GET", r.Method)
@@ -291,10 +307,8 @@ func TestBatchBranchContains_BadCredentialsUsesPublicRESTFallback(t *testing.T) 
 	defer srv.Close()
 
 	tr := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method == http.MethodGet {
-			return jsonHTTP(map[string]any{"visibility": "public"})
-		}
-		return badCredentialsResponse(req)
+		t.Fatalf("REST-only mode used authenticated transport: %s %s", req.Method, req.URL)
+		return nil, nil
 	})
 	c, err := New("github.com", WithClientTransport(tr))
 	if err != nil {

--- a/internal/ghapi/rest_fallback_test.go
+++ b/internal/ghapi/rest_fallback_test.go
@@ -269,9 +269,18 @@ func TestPeelTagObject_RESTOnlyUsesRESTFallback(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("fallback request method = %s, want GET", r.Method)
 		}
-		json.NewEncoder(w).Encode(map[string]any{
-			"object": map[string]string{"type": "commit", "sha": "commitabc"},
-		})
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/tagsha"):
+			json.NewEncoder(w).Encode(map[string]any{
+				"object": map[string]string{"type": "tag", "sha": "innertag"},
+			})
+		case strings.HasSuffix(r.URL.Path, "/innertag"):
+			json.NewEncoder(w).Encode(map[string]any{
+				"object": map[string]string{"type": "commit", "sha": "commitabc"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	defer srv.Close()
 

--- a/internal/ghapi/rest_fallback_test.go
+++ b/internal/ghapi/rest_fallback_test.go
@@ -37,17 +37,17 @@ func TestSSOFallbackEligible(t *testing.T) {
 	}
 }
 
-func TestNew_RESTOnlyForDependabotToken(t *testing.T) {
+func TestNew_RESTOnlyForDependabotProxy(t *testing.T) {
 	tests := []struct {
-		token string
+		value string
 		want  bool
 	}{
-		{token: "x-access-token", want: true},
-		{token: "real-token", want: false},
+		{value: "1", want: true},
+		{value: "", want: false},
 	}
 	for _, tt := range tests {
-		t.Run(tt.token, func(t *testing.T) {
-			t.Setenv("GH_TOKEN", tt.token)
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv("GH_ACTIONS_LOCK_DEPENDABOT_PROXY", tt.value)
 			c, err := New("github.com", WithClientTransport(roundTripFunc(nil)))
 			if err != nil {
 				t.Fatal(err)
@@ -171,7 +171,7 @@ func TestResolveActionFiles_SSONoFallbackForNonActionsOrg(t *testing.T) {
 }
 
 func TestResolveActionFiles_RESTOnlyUsesPrivateRepo(t *testing.T) {
-	t.Setenv("GH_TOKEN", "x-access-token")
+	t.Setenv("GH_ACTIONS_LOCK_DEPENDABOT_PROXY", "1")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("fallback request method = %s, want GET", r.Method)
@@ -264,7 +264,7 @@ func TestResolveActionFiles_BadCredentialsFallbackFailsClosed(t *testing.T) {
 }
 
 func TestPeelTagObject_RESTOnlyUsesRESTFallback(t *testing.T) {
-	t.Setenv("GH_TOKEN", "x-access-token")
+	t.Setenv("GH_ACTIONS_LOCK_DEPENDABOT_PROXY", "1")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("fallback request method = %s, want GET", r.Method)
@@ -295,7 +295,7 @@ func TestPeelTagObject_RESTOnlyUsesRESTFallback(t *testing.T) {
 }
 
 func TestBatchBranchContains_RESTOnlyUsesRESTFallback(t *testing.T) {
-	t.Setenv("GH_TOKEN", "x-access-token")
+	t.Setenv("GH_ACTIONS_LOCK_DEPENDABOT_PROXY", "1")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("fallback request method = %s, want GET", r.Method)

--- a/test/integration/run.rb
+++ b/test/integration/run.rb
@@ -623,27 +623,12 @@ STUB_WIRING = {
   sso_auth_failure: ->(s) {
     s.stub_server { |srv| sso_403_all(srv) }
   },
-  sso_anon_fallback: ->(s) {
-    # Authenticated requests (with Authorization header) get SAML 403.
-    # Anonymous requests (no Authorization) succeed — simulating public repo.
+  dependabot_proxy_rest_only: ->(s) {
     fake_sha = "a" * 40
     s.stub_server do |srv|
-      # GraphQL always uses auth → return SAML error.
-      srv.on(:POST, /.*/) do |req|
-        [403, { "Content-Type" => "application/json", "X-GitHub-SSO" => SSO_HEADER_VALUE },
-         JSON.generate(SSO_ERROR_BODY)]
-      end
-
-      # GET: if Authorization present → SAML 403; otherwise → anon success.
+      # No POST handler: any GraphQL request fails the scenario.
       srv.on(:GET, /.*/) do |req|
-        if req["Authorization"] && !req["Authorization"].empty?
-          [403, { "Content-Type" => "application/json", "X-GitHub-SSO" => SSO_HEADER_VALUE },
-           JSON.generate(SSO_ERROR_BODY)]
-        elsif req.path.include?("/orgs/")
-          # Probe: org is publicly visible.
-          [200, { "Content-Type" => "application/json" },
-           JSON.generate({ login: "actions", id: 44036562 })]
-        elsif req.path.include?("/commits/")
+        if req.path.include?("/commits/")
           [200, { "Content-Type" => "application/json" },
            JSON.generate({ sha: fake_sha })]
         elsif req.path.include?("/contents/")
@@ -657,7 +642,7 @@ STUB_WIRING = {
            JSON.generate([{ name: "v4", commit: { sha: fake_sha } }])]
         elsif req.path.match?(%r{/repos/actions/checkout$})
           [200, { "Content-Type" => "application/json" },
-           JSON.generate({ default_branch: "main", visibility: "public", pushed_at: "2024-01-01T00:00:00Z", id: 1, owner: { id: 44036562 } })]
+           JSON.generate({ default_branch: "main", visibility: "private", pushed_at: "2024-01-01T00:00:00Z", id: 1, owner: { id: 44036562 } })]
         elsif req.path.include?("/compare/")
           [200, { "Content-Type" => "application/json" },
            JSON.generate({ status: "behind", merge_base_commit: { sha: fake_sha } })]
@@ -668,17 +653,8 @@ STUB_WIRING = {
           [404, { "Content-Type" => "application/json" }, JSON.generate({ message: "Not Found" })]
         end
       end
-
-      # HEAD for the probe.
-      srv.on(:HEAD, /.*/) do |req|
-        if req["Authorization"] && !req["Authorization"].empty?
-          [403, { "Content-Type" => "application/json" }, ""]
-        else
-          [200, { "Content-Type" => "application/json" }, ""]
-        end
-      end
     end
-    s.env("GH_TOKEN" => "gho_fake_sso_fallback_token")
+    s.env("GH_TOKEN" => "gho_fake_dependabot_proxy_token")
   },
   sso_dedup: ->(s) {
     s.stub_server { |srv| sso_403_all(srv) }

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -148,11 +148,13 @@ scenarios:
       output_excludes:
         - "resolution failed:"
 
-  - name: sso_anon_fallback
+  - name: dependabot_proxy_rest_only
     category: sso_auth
-    description: "SSO-blocked public org falls back to anonymous access and resolves"
+    description: "Dependabot proxy context resolves private actions with REST GETs and no GraphQL POST"
     needs_stub: true
     tags: [stub]
+    env:
+      GH_ACTIONS_LOCK_DEPENDABOT_PROXY: "1"
     fixtures:
       workflows:
         ci.yml:
@@ -164,8 +166,7 @@ scenarios:
       output_contains:
         - "actions/checkout"
       output_excludes:
-        - "SAML enforcement"
-        - "SSO authorization required"
+        - "Bad credentials"
 
   - name: sso_dedup
     category: sso_auth


### PR DESCRIPTION
## Why

Hosted Dependabot supplies a dummy GitHub token, while its proxy injects the real token only for `GET` and `HEAD` requests. `gh-actions-lock` used GraphQL `POST` requests during relock, so action resolution failed with `401 Bad credentials`.

## How

- Use the private integration context `GH_ACTIONS_LOCK_DEPENDABOT_PROXY=1` to select REST-only mode at client startup. This avoids coupling behavior to the dummy token value without adding a CLI flag or documented user-facing feature.
- Resolve action files, peel annotated tags, and check branch reachability with REST `GET` requests without first attempting GraphQL.
- Reuse the existing REST fallback for public and proxy-authenticated private repositories.
- Preserve GraphQL batching and authentication-failure fallback for normal execution.

The fallback remains fail-closed: inaccessible repositories and unreachable refs still return errors. This does not require allowing authenticated `POST` requests through the Dependabot proxy.

## Testing

- `go test -race -count=1 ./...`
- `go vet ./...`
- `make fmt-check`
- `make build && /opt/homebrew/opt/ruby/bin/ruby test/integration/run.rb dependabot_proxy_rest_only`

The integration scenario runs the compiled binary against a private-repository stub with REST responses only. Any GraphQL `POST` has no matching handler and fails the scenario.

> A new `gh-actions-lock` release is required, and the Dependabot caller must set the private execution-context variable.