### PR TITLE
Narrow remote refs inside `$/` actions, and stop transitive pins vetoing narrowing

### DIFF
--- a/cmd/gh-actions-lock/migrate_test.go
+++ b/cmd/gh-actions-lock/migrate_test.go
@@ -193,12 +193,13 @@ jobs:
 	// In-repo composite action files migrated, including the nested one.
 	assert.Contains(t, read("my-action/action.yml"), "uses: $/helper")
 	assert.Contains(t, read("helper/action.yml"), "uses: $/nested/deep")
-	assert.Contains(t, read("nested/deep/action.yml"), "uses: actions/setup-go@v6")
+	assert.Contains(t, read("nested/deep/action.yml"), "uses: actions/setup-go@v6.0.0",
+		"remote refs inside $/ actions are narrowed in their action file")
 
 	// Lockfile: pins the remote dep, records nothing for the self refs.
 	lock := readTempLockfilePins(t)
 	assert.Contains(t, lock, "actions/setup-go", "remote dep should be pinned")
-	assert.Contains(t, lock, "'actions/setup-go@v6':", "nested refs keep the author's ref instead of being narrowed as workflow source")
+	assert.Contains(t, lock, "'actions/setup-go@v6.0.0':", "narrowed ref matches the rewritten action file")
 	assert.Contains(t, lock, setupGoSHA)
 	assert.NotContains(t, lock, "$/", "self refs are inherently pinned; no lockfile entry")
 	assert.NotContains(t, lock, "my-action", "in-repo composite must not be pinned")

--- a/internal/pin/commit.go
+++ b/internal/pin/commit.go
@@ -52,6 +52,12 @@ func Commit(ctx context.Context, rec *Record, store *lockfile.State, copts *Comm
 		return err
 	}
 
+	// Action files can be shared by several workflows, so merge their
+	// rewrites and write each file once, serially.
+	if err := rewriteSelfActionFiles(rec.Workflows); err != nil {
+		return err
+	}
+
 	// Phase 2: Update lockfile entries for each pinned workflow.
 	// Only write workflows that have at least one genuinely new pin.
 	pinnedByWorkflow := groupPinnedByWorkflow(rec)
@@ -99,6 +105,43 @@ func rewriteWorkflow(wp WorkflowPlan) error {
 		return nil
 	}
 	return os.WriteFile(wp.Path, content, 0o644)
+}
+
+// rewriteSelfActionFiles applies each workflow's rewrites to the in-repo
+// action files it reaches via `$/…`. No sentinel comment: these are action
+// definitions, not managed workflows.
+func rewriteSelfActionFiles(plans []WorkflowPlan) error {
+	merged := make(map[string]map[string]string)
+	for _, wp := range plans {
+		if len(wp.Rewrites) == 0 {
+			continue
+		}
+		for _, path := range wp.SelfActionFiles {
+			if merged[path] == nil {
+				merged[path] = make(map[string]string)
+			}
+			for oldUses, newUses := range wp.Rewrites {
+				merged[path][oldUses] = newUses
+			}
+		}
+	}
+	for path, rewrites := range merged {
+		wf, err := workflowfile.Load(path)
+		if err != nil {
+			return fmt.Errorf("loading %s: %w", path, err)
+		}
+		content, changed, err := wf.RewriteActionRefs(rewrites)
+		if err != nil {
+			return fmt.Errorf("rewriting %s: %w", path, err)
+		}
+		if changed == 0 || bytes.Equal(content, wf.Content) {
+			continue
+		}
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", path, err)
+		}
+	}
+	return nil
 }
 
 func isPinOrVerified(r Resolution) bool {

--- a/internal/pin/imprecise_test.go
+++ b/internal/pin/imprecise_test.go
@@ -1,0 +1,43 @@
+package pin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/github/gh-actions-lock/internal/dep"
+	"github.com/github/gh-actions-lock/internal/lockfile"
+	"github.com/github/gh-actions-lock/internal/workflowfile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A composite's imprecise transitive pin is the composite author's choice and
+// is never narrowed, so it must not veto narrowing direct uses of that action.
+func TestPlan_impreciseTransitivePinDoesNotBlockDirectNarrowing(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755))
+	wfPath := filepath.Join(dir, ".github", "workflows", "ci.yml")
+	wfKey := workflowfile.KeyFromPath(wfPath)
+
+	store, err := lockfile.LoadState(dir, fakeMeta{})
+	require.NoError(t, err)
+
+	deps := []dep.Dependency{
+		{NWO: "github/go-linter", Ref: "v2.2.3", Tag: "v2.2.3", Branch: "main", SHA: "1111111111111111111111111111111111111111", HashAlgo: "sha1"},
+		// Transitive: pulled in by go-linter, imprecise, not a direct pin.
+		{NWO: "actions/checkout", Ref: "v6", Tag: "v6", Branch: "main", SHA: "2222222222222222222222222222222222222222", HashAlgo: "sha1"},
+		// Direct and imprecise: this one narrowing must still be allowed to fix.
+		{NWO: "actions/setup-go", Ref: "v5", Tag: "v5", Branch: "main", SHA: "3333333333333333333333333333333333333333", HashAlgo: "sha1"},
+	}
+	parents := map[string][]string{"actions/checkout@v6": {"github/go-linter@v2.2.3"}}
+	directKeys := map[string]bool{"github/go-linter@v2.2.3": true, "actions/setup-go@v5": true}
+	require.NoError(t, store.Set(context.Background(), wfKey, deps, parents, directKeys))
+	require.NoError(t, store.Save())
+
+	imprecise := impreciseDirectNWOs(store)
+
+	assert.False(t, imprecise["actions/checkout"], "transitive-only imprecise pin must not block narrowing")
+	assert.True(t, imprecise["actions/setup-go"], "a direct imprecise pin still records the user's precision choice")
+}

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -71,18 +71,14 @@ func Plan(ctx context.Context, report *checks.Report, opts PlanOptions) (*Record
 		items[i] = indexedWR{idx: i, wr: wr}
 	}
 
-	// Build set of NWOs globally recorded with a non-semver ref. Checked
-	// across all workflows (not per-WF) so two workflows referencing the
-	// same action settle on the same ref precision — avoiding duplicate
-	// dep entries in the lockfile.
+	// Build set of NWOs recorded with a non-semver ref as a *direct* pin.
+	// Checked across all workflows (not per-WF) so two workflows referencing
+	// the same action settle on the same ref precision — avoiding duplicate
+	// dep entries in the lockfile. Transitive pins are excluded: their ref is
+	// the composite author's choice, is never narrowed, and would otherwise
+	// permanently veto narrowing every direct use of the same NWO.
 	if opts.prevImpreciseNWO == nil && opts.Store != nil {
-		opts.prevImpreciseNWO = make(map[string]bool)
-		for _, d := range opts.Store.AllDeps() {
-			sv, ok := parserlock.ParseSemVer(d.Ref)
-			if ok && !sv.IsFull() {
-				opts.prevImpreciseNWO[strings.ToLower(d.NWO)] = true
-			}
-		}
+		opts.prevImpreciseNWO = impreciseDirectNWOs(opts.Store)
 	}
 
 	results := make([]planResult, len(report.Workflows))
@@ -705,4 +701,22 @@ func splitNWO(nwo string) (string, string) {
 		return "", ""
 	}
 	return parts[0], parts[1]
+}
+
+// impreciseDirectNWOs returns lowercased NWOs recorded with a non-full-semver
+// ref as a direct pin of some workflow.
+func impreciseDirectNWOs(store *lockfile.State) map[string]bool {
+	out := make(map[string]bool)
+	for _, wfKey := range store.WorkflowKeys() {
+		deps, err := store.Get(wfKey)
+		if err != nil {
+			continue
+		}
+		for _, d := range deps {
+			if sv, ok := parserlock.ParseSemVer(d.Ref); ok && !sv.IsFull() {
+				out[strings.ToLower(d.NWO)] = true
+			}
+		}
+	}
+	return out
 }

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -141,7 +141,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	if !wr.NeedsAttention() && !repinMoved {
 		entries = verifiedEntries(inventory, wr.Path)
 		rw := narrowVerifiedEntries(ctx, entries, opts, rewriteRefKeys)
-		wplans = append(wplans, WorkflowPlan{Path: wr.Path, Rewrites: rw})
+		wplans = append(wplans, WorkflowPlan{Path: wr.Path, Rewrites: rw, SelfActionFiles: wr.SelfActionFiles})
 		return planResult{entries: entries, wplans: wplans}, nil
 	}
 
@@ -155,7 +155,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	// --accept-moved deliberately accepts these, so it is exempt.
 	if opts.Relock && !opts.AcceptMoved && wr.CountByCategory(checks.UnreachablePin) > 0 && repinMoved {
 		entries = verifiedEntries(wr.Inventory, wr.Path)
-		wplans = append(wplans, WorkflowPlan{Path: wr.Path})
+		wplans = append(wplans, WorkflowPlan{Path: wr.Path, SelfActionFiles: wr.SelfActionFiles})
 		return planResult{entries: entries, wplans: wplans}, nil
 	}
 
@@ -175,7 +175,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 
 	if len(unrecordedRefs) == 0 {
 		rw := narrowVerifiedEntries(ctx, entries, opts, rewriteRefKeys)
-		wplans = append(wplans, WorkflowPlan{Path: wr.Path, Rewrites: rw})
+		wplans = append(wplans, WorkflowPlan{Path: wr.Path, Rewrites: rw, SelfActionFiles: wr.SelfActionFiles})
 		return planResult{entries: entries, wplans: wplans}, nil
 	}
 
@@ -185,7 +185,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	if resolveErr != nil {
 		entries = append(entries, unresolvedEntries(wr, unrecordedRefs, deps, resolveErr)...)
 		if len(deps) == 0 {
-			wplans = append(wplans, WorkflowPlan{Path: wr.Path})
+			wplans = append(wplans, WorkflowPlan{Path: wr.Path, SelfActionFiles: wr.SelfActionFiles})
 			return planResult{entries: entries, wplans: wplans}, nil
 		}
 		// Fall through with partial deps to pin what we can.
@@ -271,13 +271,14 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 	}
 	if len(rewrites) > 0 {
 		wplans = append(wplans, WorkflowPlan{
-			Path:     wr.Path,
-			Rewrites: rewrites,
+			Path:            wr.Path,
+			Rewrites:        rewrites,
+			SelfActionFiles: wr.SelfActionFiles,
 		})
 	} else if len(wplans) == 0 {
 		// No rewrites and no plan entry yet — still include the workflow
 		// so EnsureSentinel can be applied during commit.
-		wplans = append(wplans, WorkflowPlan{Path: wr.Path})
+		wplans = append(wplans, WorkflowPlan{Path: wr.Path, SelfActionFiles: wr.SelfActionFiles})
 	}
 
 	// Build entries for all pinned deps (skip any already emitted from inventory).

--- a/internal/pin/record.go
+++ b/internal/pin/record.go
@@ -50,6 +50,9 @@ type Entry struct {
 type WorkflowPlan struct {
 	Path     string
 	Rewrites map[string]string
+	// SelfActionFiles are in-repo action definition files reached from this
+	// workflow through `$/…`. The same rewrites apply to their `uses:` lines.
+	SelfActionFiles []string
 }
 
 // Record is the complete output of Plan — everything Commit needs to

--- a/internal/pipeline/checks/finding.go
+++ b/internal/pipeline/checks/finding.go
@@ -66,8 +66,11 @@ type WorkflowReport struct {
 	// ActionRefs are all remote dependency roots attributed to the workflow,
 	// including refs found inside in-repo `$/…` actions.
 	ActionRefs []parserlock.ActionRef
-	// RewriteRefs are the workflow-YAML refs eligible for source rewriting.
+	// RewriteRefs are the refs eligible for source rewriting: workflow YAML
+	// plus the in-repo `$/…` action files listed in SelfActionFiles.
 	RewriteRefs []parserlock.ActionRef
+	// SelfActionFiles are in-repo action definition files reached via `$/…`.
+	SelfActionFiles []string
 	// Deps are the existing pinned dependencies (nil if not pinned).
 	Deps []dep.Dependency
 	// Inventory lists all dependencies with direct/transitive classification.

--- a/internal/pipeline/checks/parsed.go
+++ b/internal/pipeline/checks/parsed.go
@@ -15,10 +15,12 @@ type ParsedWorkflow struct {
 	// Refs are all remote dependency roots attributed to the workflow. This
 	// includes refs found inside in-repo `$/…` actions.
 	Refs []parserlock.ActionRef
-	// RewriteRefs are workflow-YAML refs that pinning may rewrite. A ref also
-	// used inside a `$/…` action is excluded because rewriting only the workflow
-	// occurrence would leave the action file and lockfile out of sync.
-	RewriteRefs        []parserlock.ActionRef
+	// RewriteRefs are the refs that pinning may rewrite in source: the
+	// workflow YAML plus the in-repo `$/…` action files it reaches.
+	RewriteRefs []parserlock.ActionRef
+	// SelfActionFiles are the in-repo action definition files reached through
+	// step-level `$/…` refs. They are rewritten alongside the workflow.
+	SelfActionFiles    []string
 	LocalPaths         []string
 	SelfRepositoryRefs []string
 	// SelfRepositoryRefErrs holds malformed `$/…@ref` values (the invalid form).

--- a/internal/pipeline/diagnose.go
+++ b/internal/pipeline/diagnose.go
@@ -195,6 +195,7 @@ func precheckWorkflow(pw checks.ParsedWorkflow, store *lockfile.State) (checks.W
 	if wr.RewriteRefs == nil {
 		wr.RewriteRefs = pw.Refs
 	}
+	wr.SelfActionFiles = pw.SelfActionFiles
 	wr.ParseWarnings = pw.ParseWarnings
 
 	hasTerminalFinding := false

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -47,8 +47,11 @@ func ParseAll(paths []string, store *lockfile.State) []checks.ParsedWorkflow {
 		scan := wf.ExtractActionRefs()
 		selfScan := workflowfile.ScanSelfRepositoryActions(path, scan.SelfRepositoryActionRefs)
 
-		pw.RewriteRefs = excludeActionRefs(scan.Refs, selfScan.Refs)
 		pw.Refs = mergeActionRefs(scan.Refs, selfScan.Refs)
+		// Refs inside `$/…` actions are rewritable too: their action file is
+		// rewritten alongside the workflow, so narrowing stays in sync.
+		pw.RewriteRefs = pw.Refs
+		pw.SelfActionFiles = selfScan.ActionFiles
 		pw.LocalPaths = mergeStrings(scan.LocalPaths, selfScan.LocalPaths)
 		pw.SelfRepositoryRefs = mergeStrings(scan.SelfRepositoryRefs, selfScan.SelfRepositoryRefs)
 		pw.SelfRepositoryRefErrs = mergeStrings(scan.SelfRepositoryRefErrs, selfScan.SelfRepositoryRefErrs)
@@ -82,24 +85,6 @@ func mergeActionRefs(groups ...[]parserlock.ActionRef) []parserlock.ActionRef {
 		}
 	}
 	return refs
-}
-
-func excludeActionRefs(refs, excluded []parserlock.ActionRef) []parserlock.ActionRef {
-	excludedKeys := make(map[string]bool, len(excluded))
-	for _, ref := range excluded {
-		excludedKeys[actionRefLockKey(ref)] = true
-	}
-	out := make([]parserlock.ActionRef, 0, len(refs))
-	for _, ref := range refs {
-		if !excludedKeys[actionRefLockKey(ref)] {
-			out = append(out, ref)
-		}
-	}
-	return out
-}
-
-func actionRefLockKey(ref parserlock.ActionRef) string {
-	return strings.ToLower(ref.Owner+"/"+ref.Repo) + "@" + ref.Ref
 }
 
 func mergeStrings(groups ...[]string) []string {

--- a/internal/pipeline/parse_test.go
+++ b/internal/pipeline/parse_test.go
@@ -41,8 +41,8 @@ jobs:
 	require.Len(t, pw.Refs, 1)
 	assert.Equal(t, "actions/checkout", pw.Refs[0].NWO())
 	assert.Equal(t, "v4", pw.Refs[0].Ref)
-	assert.NotNil(t, pw.RewriteRefs)
-	assert.Empty(t, pw.RewriteRefs, "a ref shared with a self repository action must not be rewritten in only the workflow")
+	assert.NotEmpty(t, pw.RewriteRefs, "refs inside a self repository action are rewritable in their action file")
+	assert.Equal(t, []string{actionPath}, pw.SelfActionFiles)
 	assert.ElementsMatch(t, []string{"$/actions/root", "$/.github/workflows/reusable.yml"}, pw.SelfRepositoryRefs)
 	assert.Empty(t, pw.SelfRepositoryResolutionErrs)
 }

--- a/internal/pipeline/verify_local.go
+++ b/internal/pipeline/verify_local.go
@@ -28,7 +28,8 @@ func VerifyLocalCoverage(parsed []checks.ParsedWorkflow, store *lockfile.State) 
 				}
 				return pw.Refs
 			}(),
-			Deps: pw.ExistingDeps,
+			SelfActionFiles: pw.SelfActionFiles,
+			Deps:            pw.ExistingDeps,
 		}
 
 		if pw.LoadErr != nil {

--- a/internal/workflowfile/workflowfile.go
+++ b/internal/workflowfile/workflowfile.go
@@ -158,8 +158,11 @@ type SelfRepositoryActionScan struct {
 	SelfRepositoryRefs    []string
 	SelfRepositoryRefErrs []string
 	LocalPaths            []string
-	Errors                []string
-	Warnings              []string
+	// ActionFiles are the in-repo action definition files visited, in visit
+	// order. Refs in these files are rewritable source, unlike `$/…` itself.
+	ActionFiles []string
+	Errors      []string
+	Warnings    []string
 }
 
 // ScanSelfRepositoryActions recursively reads in-repo actions reached through
@@ -220,11 +223,12 @@ func ScanSelfRepositoryActions(workflowPath string, actionRefs []string) SelfRep
 			continue
 		}
 
-		uses, err := readActionUses(repoRoot, actionDir)
+		uses, actionPath, err := readActionUses(repoRoot, actionDir)
 		if err != nil {
 			scan.Errors = append(scan.Errors, fmt.Sprintf("can't inspect self repository action %s: %v", current.ref, err))
 			continue
 		}
+		scan.ActionFiles = append(scan.ActionFiles, actionPath)
 		for _, rawUse := range uses {
 			use := strings.TrimSpace(rawUse)
 			switch {
@@ -596,13 +600,15 @@ func parseActionYAMLForUses(content []byte) ([]string, error) {
 	return uses, nil
 }
 
-func readActionUses(repoRoot, actionDir string) ([]string, error) {
+// readActionUses returns the `uses:` values of an in-repo action definition
+// along with the file they were read from, so callers can rewrite that file.
+func readActionUses(repoRoot, actionDir string) ([]string, string, error) {
 	var lastErr error
 	for _, name := range []string{"action.yml", "action.yaml"} {
 		actionPath := filepath.Join(actionDir, name)
 		if err := ValidatePathWithinRoot(repoRoot, actionPath); err != nil {
 			if errors.Is(err, errPathOutsideRoot) {
-				return nil, err
+				return nil, "", err
 			}
 			lastErr = err
 			continue
@@ -614,11 +620,11 @@ func readActionUses(repoRoot, actionDir string) ([]string, error) {
 		}
 		uses, err := parseActionYAMLForUses(content)
 		if err != nil {
-			return nil, fmt.Errorf("parsing %s: %w", name, err)
+			return nil, "", fmt.Errorf("parsing %s: %w", name, err)
 		}
-		return uses, nil
+		return uses, actionPath, nil
 	}
-	return nil, fmt.Errorf("reading action.yml or action.yaml: %w", lastErr)
+	return nil, "", fmt.Errorf("reading action.yml or action.yaml: %w", lastErr)
 }
 
 // KeyFromPath converts a workflow path discovered on disk (relative to the

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -501,7 +501,7 @@ scenarios:
 
   - name: migrate_local_actions_rewrite
     category: workflow_parsing
-    description: "migration runs by default on fix runs: rewrites a deep in-repo ./ chain to $/, then discovers and pins the remote dependency reached only through that $/ chain; no self repository ref enters the lockfile"
+    description: "migration runs by default on fix runs: rewrites a deep in-repo ./ chain to $/, then discovers, narrows and pins the remote dependency reached only through that $/ chain; no self repository ref enters the lockfile"
     needs_stub: true
     tags: [stub]
     fixtures:
@@ -537,13 +537,13 @@ scenarios:
       delete_lockfile: true
     expect:
       exit: 0
-      lockfile_contains: ["'actions/checkout@v4':"]
+      lockfile_contains: ["'actions/checkout@v4.2.2':"]
       lockfile_excludes: ["$/"]
       files_contain:
         ".github/workflows/ci.yml": ["uses: $/my-action"]
         "my-action/action.yml": ["uses: $/helper"]
         "helper/action.yml": ["uses: $/nested/deep"]
-        "nested/deep/action.yml": ["uses: actions/checkout@v4"]
+        "nested/deep/action.yml": ["uses: actions/checkout@v4.2.2"]
       files_exclude:
         ".github/workflows/ci.yml": ["uses: ./my-action", "actions/checkout"]
 
@@ -1304,7 +1304,7 @@ scenarios:
 
   - name: self_repository_shared_dependency
     category: workflow_parsing
-    description: "The real binary keeps a remote ref shared by workflow YAML and a local $/ action at its authored ref, so source and lockfile coverage converge in one pass"
+    description: "The real binary narrows a remote ref shared by workflow YAML and a local $/ action in both files, so source and lockfile stay in sync"
     needs_stub: true
     tags: [stub]
     fixtures:
@@ -1329,13 +1329,11 @@ scenarios:
       delete_lockfile: true
     expect:
       exit: 0
-      lockfile_contains: ["'actions/checkout@v4':"]
-      lockfile_excludes: ["actions/checkout@v4.2.2", "$/"]
+      lockfile_contains: ["'actions/checkout@v4.2.2':"]
+      lockfile_excludes: ["'actions/checkout@v4':", "$/"]
       files_contain:
-        ".github/workflows/ci.yml": ["uses: $/actions/shared", "uses: actions/checkout@v4"]
-        "actions/shared/action.yml": ["uses: actions/checkout@v4"]
-      files_exclude:
-        ".github/workflows/ci.yml": ["actions/checkout@v4.2.2"]
+        ".github/workflows/ci.yml": ["uses: $/actions/shared", "uses: actions/checkout@v4.2.2"]
+        "actions/shared/action.yml": ["uses: actions/checkout@v4.2.2"]
 
   - name: fresh_no_narrow_keeps_major
     category: narrowing


### PR DESCRIPTION
Two narrowing bugs.

**Refs inside `$/` actions never narrowed.** Commit only wrote workflow files, so a `uses:` in an in-repo `action.yml` stayed at `@v6` while the same ref in a workflow became `@v6.0.0`. Commit now writes the reached `action.yml` files too, so those refs narrow with the rest.

**A transitive imprecise pin blocked narrowing repo-wide.** `prevImpreciseNWO` was built from `Store.AllDeps()`, which includes transitive pins. Those are never narrowed by design, so one composite pulling in `actions/checkout@v6` permanently vetoed narrowing every direct `actions/checkout` in the repo. Now built from each workflow's direct pin list.
