### PR TITLE
Warn when workflows use mutable Docker image tags

### DIFF
--- a/internal/workflowfile/workflowfile.go
+++ b/internal/workflowfile/workflowfile.go
@@ -138,6 +138,13 @@ func (f *File) ExtractActionRefs() RefScan {
 			}
 			return
 		}
+		if strings.HasPrefix(value, "docker://") {
+			if !seen[value] {
+				seen[value] = true
+				scan.Warnings = append(scan.Warnings, fmt.Sprintf("%s is not covered by the actions lockfile; container image tags are mutable", value))
+			}
+			return
+		}
 		actionRef := parserlock.ParseActionRef(value)
 		if actionRef != nil {
 			dedupKey := actionRef.FullName() + "@" + actionRef.Ref

--- a/internal/workflowfile/workflowfile.go
+++ b/internal/workflowfile/workflowfile.go
@@ -76,6 +76,22 @@ func usesExpressionErr(values []string) error {
 	return fmt.Errorf("`uses:` can't contain an expression: %s", strings.Join(values, ", "))
 }
 
+func appendDockerWarning(warnings *[]string, seen map[string]bool, value string) bool {
+	if !strings.HasPrefix(value, "docker://") {
+		return false
+	}
+	if seen[value] {
+		return true
+	}
+	seen[value] = true
+	detail := "container image tags are mutable"
+	if strings.Contains(strings.TrimPrefix(value, "docker://"), "@") {
+		detail = "container image digests must be maintained separately"
+	}
+	*warnings = append(*warnings, fmt.Sprintf("%s is not covered by the actions lockfile; %s", value, detail))
+	return true
+}
+
 // RefScan is the classified result of walking a workflow's `uses:` values.
 type RefScan struct {
 	// Refs are remote repository action references (owner/repo[/path]@ref).
@@ -103,6 +119,7 @@ func (f *File) ExtractActionRefs() RefScan {
 	seenLocal := make(map[string]bool)
 	seenSelf := make(map[string]bool)
 	seenSelfAction := make(map[string]bool)
+	seenDocker := make(map[string]bool)
 
 	walkUses(&f.root, func(value string, stepLevel bool) {
 		value = strings.TrimSpace(value)
@@ -138,11 +155,7 @@ func (f *File) ExtractActionRefs() RefScan {
 			}
 			return
 		}
-		if strings.HasPrefix(value, "docker://") {
-			if !seen[value] {
-				seen[value] = true
-				scan.Warnings = append(scan.Warnings, fmt.Sprintf("%s is not covered by the actions lockfile; container image tags are mutable", value))
-			}
+		if appendDockerWarning(&scan.Warnings, seenDocker, value) {
 			return
 		}
 		actionRef := parserlock.ParseActionRef(value)
@@ -202,6 +215,7 @@ func ScanSelfRepositoryActions(workflowPath string, actionRefs []string) SelfRep
 	seenSelf := make(map[string]bool)
 	seenInvalid := make(map[string]bool)
 	seenLocal := make(map[string]bool)
+	seenDocker := make(map[string]bool)
 
 	for len(pending) > 0 {
 		current := pending[0]
@@ -255,6 +269,7 @@ func ScanSelfRepositoryActions(workflowPath string, actionRefs []string) SelfRep
 					seenLocal[use] = true
 					scan.LocalPaths = append(scan.LocalPaths, use)
 				}
+			case appendDockerWarning(&scan.Warnings, seenDocker, use):
 			default:
 				actionRef := parserlock.ParseActionRef(use)
 				if actionRef == nil {

--- a/internal/workflowfile/workflowfile.go
+++ b/internal/workflowfile/workflowfile.go
@@ -84,11 +84,10 @@ func appendDockerWarning(warnings *[]string, seen map[string]bool, value string)
 		return true
 	}
 	seen[value] = true
-	detail := "container image tags are mutable"
 	if strings.Contains(strings.TrimPrefix(value, "docker://"), "@") {
-		detail = "container image digests must be maintained separately"
+		return true
 	}
-	*warnings = append(*warnings, fmt.Sprintf("%s is not covered by the actions lockfile; %s", value, detail))
+	*warnings = append(*warnings, fmt.Sprintf("%s is not covered by the actions lockfile; container image tags are mutable", value))
 	return true
 }
 

--- a/internal/workflowfile/workflowfile_test.go
+++ b/internal/workflowfile/workflowfile_test.go
@@ -41,7 +41,9 @@ func TestExtractActionRefsMixed(t *testing.T) {
 
 	assert.Len(t, localPaths, 1)
 	assert.Equal(t, "./local-action", localPaths[0])
-	assert.Empty(t, warnings)
+	assert.Equal(t, []string{
+		"docker://alpine:3.18 is not covered by the actions lockfile; container image tags are mutable",
+	}, warnings)
 }
 
 func TestParseRejectsUsesExpression(t *testing.T) {

--- a/internal/workflowfile/workflowfile_test.go
+++ b/internal/workflowfile/workflowfile_test.go
@@ -46,6 +46,25 @@ func TestExtractActionRefsMixed(t *testing.T) {
 	}, warnings)
 }
 
+func TestExtractActionRefs_DockerWarnings(t *testing.T) {
+	f, err := Parse("ci.yml", []byte(`
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://alpine:3.18
+      - uses: docker://alpine:3.18
+      - uses: docker://alpine@sha256:0123456789abcdef
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"docker://alpine:3.18 is not covered by the actions lockfile; container image tags are mutable",
+		"docker://alpine@sha256:0123456789abcdef is not covered by the actions lockfile; container image digests must be maintained separately",
+	}, f.ExtractActionRefs().Warnings)
+}
+
 func TestParseRejectsUsesExpression(t *testing.T) {
 	for name, content := range map[string]string{
 		"step level": `
@@ -262,6 +281,9 @@ func TestScanSelfRepositoryActions_RecursiveClosure(t *testing.T) {
     - uses: $/actions/root
     - uses: actions/checkout@v4
     - uses: ./workspace-relative
+    - uses: docker://alpine:3.18
+    - uses: docker://alpine:3.18
+    - uses: docker://alpine@sha256:0123456789abcdef
     - uses: $/actions/bad@v2
     - uses: "$/actions/expression@${{ matrix.ref }}"
 `)
@@ -276,7 +298,10 @@ func TestScanSelfRepositoryActions_RecursiveClosure(t *testing.T) {
 	)
 	assert.Equal(t, []string{"./workspace-relative"}, scan.LocalPaths)
 	assert.Empty(t, scan.Errors)
-	assert.Empty(t, scan.Warnings)
+	assert.Equal(t, []string{
+		"docker://alpine:3.18 is not covered by the actions lockfile; container image tags are mutable",
+		"docker://alpine@sha256:0123456789abcdef is not covered by the actions lockfile; container image digests must be maintained separately",
+	}, scan.Warnings)
 }
 
 func TestScanSelfRepositoryActions_NoRepoRoot(t *testing.T) {

--- a/internal/workflowfile/workflowfile_test.go
+++ b/internal/workflowfile/workflowfile_test.go
@@ -61,7 +61,6 @@ jobs:
 
 	assert.Equal(t, []string{
 		"docker://alpine:3.18 is not covered by the actions lockfile; container image tags are mutable",
-		"docker://alpine@sha256:0123456789abcdef is not covered by the actions lockfile; container image digests must be maintained separately",
 	}, f.ExtractActionRefs().Warnings)
 }
 
@@ -300,7 +299,6 @@ func TestScanSelfRepositoryActions_RecursiveClosure(t *testing.T) {
 	assert.Empty(t, scan.Errors)
 	assert.Equal(t, []string{
 		"docker://alpine:3.18 is not covered by the actions lockfile; container image tags are mutable",
-		"docker://alpine@sha256:0123456789abcdef is not covered by the actions lockfile; container image digests must be maintained separately",
 	}, scan.Warnings)
 }
 

--- a/test/scenarios/catalog.yml
+++ b/test/scenarios/catalog.yml
@@ -433,6 +433,21 @@ scenarios:
       exit: 2
       output_contains: ["can't contain an expression"]
 
+  - name: docker_uses_warns
+    category: workflow_parsing
+    description: "Real binary warns that docker:// image tags are mutable and outside lockfile coverage"
+    needs_stub: true
+    tags: [stub]
+    fixtures:
+      workflows:
+        ci.yml:
+          name: CI
+          actions: ["docker://alpine:3.18"]
+    expect:
+      exit: 0
+      output_contains:
+        - "docker://alpine:3.18 is not covered by the actions lockfile; container image tags are mutable"
+
   - name: local_action_skipped
     category: workflow_parsing
     description: "Local action (./path) — entire workflow skipped"


### PR DESCRIPTION
`docker://` references currently bypass lockfile coverage without telling users, even though their image tags remain mutable.

This adds a non-blocking parser warning through the existing `RefScan.Warnings` path and deduplicates repeated image references. A stub-backed catalog scenario exercises the compiled binary and verifies the exact warning while preserving a successful exit.

## Testing

- `go test ./...`
- `ruby test/integration/run.rb docker_uses_warns`