### PR TITLE
Simplify failed publish recovery guidance

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,8 +29,8 @@ script/release patch --rc
 The first candidate is `vX.Y.Z-rc.1`; repeating the same bump increments
 `rc.N`. Run the bump without `--rc` to publish the stable `vX.Y.Z`.
 
-A pushed release tag is immutable. If publishing fails, fix the publisher and
-run the release script again for the next RC; do not move or reuse the failed tag.
+Release tags are immutable. If publishing fails, fix the publisher and run
+the release script again for the next RC.
 
 Use `patch` for compatible fixes, `minor` for compatible additions, and `major`
 for breaking changes.


### PR DESCRIPTION
## Summary

Clarify the immutable release-tag recovery rule without repeating the implication.