### PR TITLE
Stop adding management comments to workflows

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,3 @@
-# This workflow is managed by gh actions-lock.
-
 name: dependency-review
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,3 @@
-# This workflow is managed by gh actions-lock.
-
 name: Release
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,3 @@
-# This workflow is managed by gh actions-lock.
-
 name: test
 
 on:

--- a/cmd/gh-actions-lock/selfrepository_test.go
+++ b/cmd/gh-actions-lock/selfrepository_test.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/github/gh-actions-lock/internal/workflowfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +50,6 @@ jobs:
 	gotWorkflow, err := os.ReadFile(workflowPath)
 	require.NoError(t, err)
 	assert.Equal(t, workflow, gotWorkflow)
-	assert.NotContains(t, string(gotWorkflow), workflowfile.SentinelComment)
 
 	lockPath := filepath.Join(dir, ".github", "workflows", "actions.lock")
 	if lockContent, readErr := os.ReadFile(lockPath); readErr == nil {
@@ -92,7 +90,6 @@ jobs:
 	gotWorkflow, readErr := os.ReadFile(workflowPath)
 	require.NoError(t, readErr)
 	assert.Equal(t, workflow, gotWorkflow)
-	assert.NotContains(t, string(gotWorkflow), workflowfile.SentinelComment)
 	lockPath := filepath.Join(dir, ".github", "workflows", "actions.lock")
 	_, readErr = os.Stat(lockPath)
 	assert.ErrorIs(t, readErr, os.ErrNotExist)

--- a/internal/pin/commit.go
+++ b/internal/pin/commit.go
@@ -100,7 +100,6 @@ func rewriteWorkflow(wp WorkflowPlan) error {
 		}
 	}
 
-	content = workflowfile.EnsureSentinel(content)
 	if bytes.Equal(content, wf.Content) {
 		return nil
 	}
@@ -108,8 +107,7 @@ func rewriteWorkflow(wp WorkflowPlan) error {
 }
 
 // rewriteSelfActionFiles applies each workflow's rewrites to the in-repo
-// action files it reaches via `$/…`. No sentinel comment: these are action
-// definitions, not managed workflows.
+// action files it reaches via `$/…`.
 func rewriteSelfActionFiles(plans []WorkflowPlan) error {
 	merged := make(map[string]map[string]string)
 	for _, wp := range plans {

--- a/internal/pin/commit_test.go
+++ b/internal/pin/commit_test.go
@@ -113,11 +113,12 @@ func TestCommitRemovesDependenciesDroppedFromWorkflow(t *testing.T) {
 	dir := t.TempDir()
 	workflowPath := filepath.Join(".github", "workflows", "ci.yml")
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, filepath.Dir(workflowPath)), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, workflowPath), []byte(`on: push
+	workflow := []byte(`on: push
 jobs:
   lint:
     uses: owner/reusable/.github/workflows/lint.yml@main
-`), 0o644))
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, workflowPath), workflow, 0o644))
 	t.Chdir(dir)
 
 	store, err := lockfile.LoadState(dir, fakeMeta{})
@@ -143,6 +144,10 @@ jobs:
 		Workflows: []WorkflowPlan{{Path: workflowPath}},
 	}
 	require.NoError(t, Commit(context.Background(), rec, store, nil))
+
+	gotWorkflow, err := os.ReadFile(filepath.Join(dir, workflowPath))
+	require.NoError(t, err)
+	assert.Equal(t, workflow, gotWorkflow)
 
 	got, err := os.ReadFile(filepath.Join(dir, ".github", "workflows", "actions.lock"))
 	require.NoError(t, err)

--- a/internal/pin/plan.go
+++ b/internal/pin/plan.go
@@ -272,8 +272,7 @@ func planWorkflow(ctx context.Context, wr checks.WorkflowReport, opts PlanOption
 			SelfActionFiles: wr.SelfActionFiles,
 		})
 	} else if len(wplans) == 0 {
-		// No rewrites and no plan entry yet — still include the workflow
-		// so EnsureSentinel can be applied during commit.
+		// Keep the workflow in the plan so its lockfile entry is updated.
 		wplans = append(wplans, WorkflowPlan{Path: wr.Path, SelfActionFiles: wr.SelfActionFiles})
 	}
 

--- a/internal/workflowfile/rewrite.go
+++ b/internal/workflowfile/rewrite.go
@@ -1,7 +1,6 @@
 package workflowfile
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,31 +8,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
-
-// SentinelComment is prepended to workflow files managed by gh actions-lock
-// so users can tell at a glance that the file's action refs are locked.
-const SentinelComment = "# This workflow is managed by gh actions-lock."
-
-// EnsureSentinel prepends the sentinel comment to the workflow content if it
-// is not already present at the top of the file. The comment is placed before
-// any existing content with a blank line separating it from the YAML body.
-func EnsureSentinel(content []byte) []byte {
-	if bytes.HasPrefix(content, []byte(SentinelComment)) {
-		return content
-	}
-
-	var buf bytes.Buffer
-	buf.WriteString(SentinelComment)
-	buf.WriteByte('\n')
-
-	// If the file doesn't start with a comment or blank line, add a
-	// separator so the sentinel stands apart from the YAML body.
-	if len(content) > 0 && content[0] != '#' && content[0] != '\n' {
-		buf.WriteByte('\n')
-	}
-	buf.Write(content)
-	return buf.Bytes()
-}
 
 // RewriteActionRefs rewrites targeted uses: refs in the original workflow
 // content while preserving the surrounding formatting and comments.

--- a/internal/workflowfile/rewrite_test.go
+++ b/internal/workflowfile/rewrite_test.go
@@ -9,47 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnsureSentinel(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{
-			name:  "adds sentinel to plain workflow",
-			input: "name: ci\non: push\n",
-			want:  SentinelComment + "\n\nname: ci\non: push\n",
-		},
-		{
-			name:  "adds sentinel before existing comment",
-			input: "# my workflow\nname: ci\n",
-			want:  SentinelComment + "\n# my workflow\nname: ci\n",
-		},
-		{
-			name:  "idempotent when sentinel already present",
-			input: SentinelComment + "\n\nname: ci\n",
-			want:  SentinelComment + "\n\nname: ci\n",
-		},
-		{
-			name:  "empty content",
-			input: "",
-			want:  SentinelComment + "\n",
-		},
-		{
-			name:  "sentinel buried in file still prepends",
-			input: "name: ci\n# This workflow is managed by gh actions-lock.\non: push\n",
-			want:  SentinelComment + "\n\nname: ci\n# This workflow is managed by gh actions-lock.\non: push\n",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := EnsureSentinel([]byte(tt.input))
-			assert.Equal(t, tt.want, string(got))
-		})
-	}
-}
-
 func TestSubpathRewriteLookup(t *testing.T) {
 	replacements := map[string]string{
 		"actions/cache@27d5ce7": "actions/cache@v5.0.5",

--- a/test/integration/run.rb
+++ b/test/integration/run.rb
@@ -23,8 +23,6 @@ runner = ActionsPin::Integration::Runner.new
 # Minimal workflow YAML that uses a single action.
 def simple_workflow(name:, action:)
   <<~YAML
-    # This workflow is managed by gh actions-lock.
-
     name: #{name}
     on: workflow_dispatch
     jobs:
@@ -39,8 +37,6 @@ end
 def multi_action_workflow(name:, actions:)
   steps = actions.map { |a| "      - uses: #{a}" }.join("\n")
   <<~YAML
-    # This workflow is managed by gh actions-lock.
-
     name: #{name}
     on: workflow_dispatch
     jobs:


### PR DESCRIPTION
## Why

Onboarding a workflow should update its lockfile state without adding an ownership comment to the workflow file. Users have found this more annoying than helpful.

## What

- Remove the management-comment helper and commit hook
- Keep no-rewrite workflows in the plan so lockfile onboarding still works
- Remove the generated header from repository workflows and integration fixtures